### PR TITLE
feat: add .NET and Python support to make-ai-teammate skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ This plugin instruments and configures A365 agents. It contains five skills:
 | `add-workiq-tools` | `/agent365:add-workiq-tools` | "add workiq tools", "add mcp tools to this agent" |
 | `test-local` | `/agent365:test-local` | "test this agent locally", "open agentsplayground" |
 
+**Supported languages for `make-ai-teammate`:** Node.js (LangChain · OpenAI Agents SDK · Claude SDK) · .NET AgentFramework · Python AgentFramework
+
 The skills are designed to be **non-destructive**, **idempotent**, and **additive**.
 They read before writing, ask before doing anything risky, and leave the codebase
 in a better state than they found it.
@@ -33,8 +35,10 @@ plugins/agent365/
 │   ├── make-ai-teammate/
 │   │   ├── SKILL.md              # Full AI Teammate transformation (hosting, observability, notifications, WorkIQ)
 │   │   └── references/
-│   │       ├── nodejs-ai-teammate.md     # Complete hosting + agent + client patterns (all 3 frameworks)
-│   │       └── nodejs-notifications.md  # Notification + lifecycle event patterns
+│   │       ├── nodejs-ai-teammate.md     # Complete hosting + agent + client patterns (Node.js LangChain/OpenAI/Claude)
+│   │       ├── nodejs-notifications.md  # Notification + lifecycle event patterns (Node.js)
+│   │       ├── dotnet-ai-teammate.md    # Complete patterns for .NET AgentFramework
+│   │       └── python-ai-teammate.md   # Complete patterns for Python AgentFramework
 │   ├── a365-setup/
 │   │   └── SKILL.md              # Full A365 CLI lifecycle
 │   ├── instrument-observability/

--- a/README.md
+++ b/README.md
@@ -2,25 +2,38 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Agent skills and MCP configuration for [Microsoft Agent 365](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/) — works with Claude Code and GitHub Copilot. These skills teach AI agents how to register Agent 365 blueprints, wire WorkIQ MCP tools, and instrument observability using natural language.
+Agent skills and MCP configuration for [Microsoft Agent 365](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/) — works with Claude Code and GitHub Copilot. These skills transform Node.js, .NET, and Python agents into production-ready Microsoft Agent 365 AI Teammates: registering blueprints, wiring WorkIQ MCP tools, instrumenting observability, and handling Teams messages and email notifications.
 
 Browse the [`plugins/agent365/skills/`](https://github.com/microsoft/agent365-skills/blob/main/plugins/agent365/skills) folder for the full catalog.
+
+---
+
+## What is an AI Teammate?
+
+An **AI Teammate** is an agent registered with Microsoft Agent 365 that can receive direct messages in Microsoft Teams, respond to email notifications, and access Microsoft 365 data (mail, calendar, Teams, SharePoint) through WorkIQ tools — all authenticated through your tenant's Entra ID.
+
+**Before these skills:** Your agent is a standalone script or HTTP server. It has no Teams presence, no M365 data access, and no observability.
+
+**After these skills:** Your agent is a live AI Teammate in Microsoft Teams — users can chat with it directly, it can read and respond to emails, and every LLM call is traced in Microsoft Defender.
 
 ---
 
 ## Prerequisites
 
 - **Microsoft Agent 365** tenant with developer access
-- **Node.js 18+** and **.NET 8.0+**
+- **Node.js 18+**, **.NET 8.0+**, or **Python 3.11+** (depending on your agent)
 - **a365 CLI** — `dotnet tool install -g Microsoft.Agents.A365.DevTools.Cli --prerelease`
 - **Azure CLI** — `winget install Microsoft.AzureCLI` (Windows) or `brew install azure-cli` (macOS)
 
 **Supported frameworks:**
 
-| Framework | Package | Language |
+| Framework | Packages | Language |
 |-----------|---------|---------|
-| .NET AgentFramework | `Microsoft.Agents.A365` / `AgentApplication` | C# |
+| .NET AgentFramework | `Microsoft.Agents.A365.*` / `AgentApplication` | C# |
+| Python AgentFramework | `agent-framework-azure-ai` + `microsoft_agents_a365_*` | Python |
 | Node.js LangChain | `@langchain/core` + `@microsoft/agents-hosting` | TypeScript |
+| Node.js OpenAI Agents SDK | `@openai/agents` + `@microsoft/agents-hosting` | TypeScript |
+| Node.js Claude SDK | `@anthropic-ai/sdk` + `@microsoft/agents-hosting` | TypeScript |
 
 ---
 
@@ -42,78 +55,140 @@ copilot plugin install agent365@agent365-skills
 
 ---
 
-## What's Included
+## AI Teammate — End-to-End Flow
 
-- **5 skills** covering full AI Teammate transformation, blueprint setup, WorkIQ MCP tools, observability instrumentation, and local testing with AgentsPlayground
-- **Automatic agent detection** — skills detect your agent stack, programming language, and Custom Engine Agent status, then ask validation questions before any code runs
-- **Smart capability selection** — based on your agent type, you get tailored options: Discoverability, Observability, WorkIQ tools, or AI Teammate registration
-- **WorkIQ MCP tools** — pre-built M365 integrations for Mail, Calendar, Teams, SharePoint, OneDrive, Word, User profiles, Copilot, and Dataverse/Dynamics 365
+The fastest path from a plain agent to a live AI Teammate in Teams:
+
+### Step 1 — Transform the code
+
+```
+"Make this agent an AI Teammate"
+```
+
+Runs the `make-ai-teammate` skill. Detects your language and LLM framework,
+confirms with you, then wraps your existing code with the full AI Teammate layer:
+
+**Node.js:**
+
+| File | What's added |
+|------|-------------|
+| `src/index.ts` | Express + `CloudAdapter` + JWT auth + `/api/health` + `/api/messages` |
+| `src/agent.ts` | `AgentApplication` subclass — message routing, typing indicator loop, email notifications, install/uninstall lifecycle |
+| `src/client.ts` | `ObservabilityManager` init, `McpToolRegistrationService` singleton, `InferenceScope` wrapping your LLM call |
+| `src/token-cache.ts` | Agentic token resolver + in-memory cache |
+| `ToolingManifest.json` | Empty MCP server manifest (populated in step 3) |
+| `.env` / `tsconfig.json` | All A365 env vars added, `module: "node16"` ensured |
+
+**.NET:**
+
+| File | What's added |
+|------|-------------|
+| `Program.cs` | `AddAgenticTracingExporter` + `AddA365Tracing` + `IMcpToolRegistrationService` + `/api/messages` + `/api/health` |
+| `Agent/MyAgent.cs` | `AgentApplication` subclass — dual agentic/OBO activity handlers, typing indicators, MCP tool loading |
+| `ToolingManifest.json` | Empty MCP server manifest |
+| `appsettings.json` | A365 auth, token validation, and connection sections |
+
+**Python:**
+
+| File | What's added |
+|------|-------------|
+| `host_agent_server.py` | `CloudAdapterAiohttp` server + `/api/messages` + `/api/health` + notification handler |
+| `agent.py` | `AgentInterface` implementation — MCP tooling, notification handling, token resolver |
+| `token_cache.py` | `cache_agentic_token` / `get_cached_agentic_token` helpers |
+| `agent_interface.py` | Abstract base class |
+| `ToolingManifest.json` | Empty MCP server manifest |
+| `.env` / `pyproject.toml` | All A365 env vars and dependencies added |
+
+Your existing LLM logic, prompts, and tools are preserved. Nothing is deleted.
+
+### Step 2 — Register the Blueprint
+
+```
+"Run a365 setup"
+```
+
+Runs the `a365-setup` skill (AI Teammate path). Collects three inputs from you:
+
+- **Agent Name** — unique display name (`contoso-hr-agent`)
+- **Manager Email** — M365 account from your tenant
+- **Messaging Endpoint** — devtunnel URL for local dev, or your production HTTPS endpoint
+
+Then provisions everything automatically:
+
+```
+a365 config init        →  creates a365.config.json
+a365 setup all          →  Blueprint + Entra identity + permissions + endpoint registration
+a365 publish            →  publishes manifest to M365 Admin Center
+```
+
+### Step 3 — Add WorkIQ tools (optional)
+
+```
+"Add Work IQ Mail and Work IQ Calendar"
+```
+
+Runs the `add-workiq-tools` skill. Shows the full M365 tool catalog, adds the servers you choose
+to `ToolingManifest.json` via the CLI, and tells you (or your Global Administrator) what
+permissions command to run.
+
+Available tools: Mail · Calendar · Teams · SharePoint · OneDrive · Word · User · Copilot · Dataverse
+
+### Step 4 — Test locally
+
+```
+"Test this agent locally"
+```
+
+Runs the `test-local` skill. Builds the agent, starts it on port 3978, and opens
+AgentsPlayground — no Bot Framework auth required in dev.
+
+### Step 5 — Deploy and activate
+
+Deploy to any hosting provider (Azure App Service, Container Apps, AWS, GCP, on-prem).
+Set production env vars:
+
+```dotenv
+ENABLE_A365_OBSERVABILITY_EXPORTER=true
+NODE_ENV=production                    # Node.js
+ASPNETCORE_ENVIRONMENT=Production      # .NET
+PYTHON_ENVIRONMENT=production          # Python
+```
+
+Then in your browser:
+1. [Teams Developer Portal](https://dev.teams.microsoft.com) → your blueprint → set **Agent Type = API Based**
+2. Teams → Apps → find your agent → **Request Instance**
+3. Admin approves in [Microsoft Admin Center → Agents](https://admin.cloud.microsoft/#/agents/all/requested)
+4. Search your agent in Teams and start chatting
+
+> **Note:** Agent user creation is asynchronous — it can take minutes to hours before the agent is searchable in Teams.
+
+### What you get
+
+Once live, your AI Teammate can:
+- **Receive Teams messages** directly in 1:1 chat
+- **Handle email notifications** — reads the email via Work IQ Mail, processes it with your LLM, replies via the notifications API
+- **Send typing indicators** while the LLM is thinking
+- **Access M365 data** via WorkIQ tools (mail, calendar, Teams, SharePoint, etc.)
+- **Trace every LLM call** in Microsoft Defender via A365 Observability
 
 ---
 
 ## Skills
 
-### `a365-setup` — Register, Configure & Publish
+### `make-ai-teammate` — Transform Any Agent into an AI Teammate
 
-Full A365 CLI lifecycle. Detects your agent stack (Agent Framework, LangChain, OpenAI), programming language (DotNet, NodeJS, Python), and Custom Engine Agent status automatically. Asks validation questions, then guides you through capability selection and follows the right path:
+The full-stack transformation skill. Takes any agent using LangChain, OpenAI Agents SDK, Claude SDK (.NET, Node.js, or Python), or .NET/.Python AgentFramework and makes it a production-ready Microsoft Agent 365 AI Teammate — wrapping your existing LLM code without replacing it.
 
-| Agent Type | Available Capabilities |
-|------------|----------------------|
-| **Custom Engine Agent** | • **Observability** — OTel tracing + Defender integration (self-hosted)<br>• **Observability + WorkIQ** — Adds M365 tools: Mail, Calendar, Teams, SharePoint (self-hosted)<br>• **AI Teammate** — Blueprint registration, permissions, and messaging endpoint registration; you provide hosting |
-| **Standard Agent** | • **Discoverability** — M365 catalog registration (self-hosted)<br>• **Discoverability + Observability** — Registration + telemetry (self-hosted)<br>• **AI Teammate** — Blueprint registration, permissions, and messaging endpoint registration; you provide hosting |
+Adds the complete hosting and integration layer in one pass:
 
-**AI Teammate path** — validates prerequisites, creates `a365.config.json`, runs `a365 setup all` (creates the Blueprint, grants permissions, and registers your messaging endpoint), then reviews and publishes the agent manifest. You host the agent on your own infrastructure — any cloud or on-premises deployment is supported.
+- **Hosting layer** — Express/CloudAdapter (Node.js) · ASP.NET Core/IAgentHttpAdapter (.NET) · aiohttp/CloudAdapterAiohttp (Python) — with `/api/health` and `/api/messages`
+- **`AgentApplication` subclass** — message routing, typing indicator loop, observability token preloading, email notification dispatch, install/uninstall lifecycle events
+- **Observability** — `ObservabilityManager`/`AddAgenticTracingExporter` initialized before any spans, context propagation, `InferenceScope`/`UseOpenTelemetry` wrapping every LLM call with token counts and finish reasons
+- **`McpToolRegistrationService`** — module-level singleton (Node.js), DI-injected singleton (.NET), or per-turn (Python) wired into the per-turn client factory
+- **Token cache** — per-language token caching with agentic resolver support
+- **`ToolingManifest.json`**, all A365 packages, env vars, and tsconfig/pyproject settings
 
-**Discoverability path** — registers the Blueprint and configures permissions. The agent appears in the M365 catalog but requires self-hosting; no messaging endpoint is provisioned.
-
-**Observability path** — instruments OpenTelemetry tracing, BaggageBuilder context, and A365 exporter with agentic token resolver for Microsoft Defender integration.
-
-**Trigger phrases:**
-```
-"Run a365 setup"         "Create blueprint"
-"Register agent"         "Onboard agent"
-"Provision agent"        "Publish agent"
-```
-
-### `add-workiq-tools` — Add WorkIQ MCP Tools
-
-Adds pre-built Microsoft 365 integration tools to your agent. Runs `a365 develop list-available` to show the MCP server catalog, adds selected servers via `a365 develop add-mcp-servers`, wires `GetMcpToolsAsync` in the agent code, and guides the permissions handoff.
-
-**What WorkIQ provides:** Instead of writing custom Microsoft Graph API integrations, you get ready-to-use MCP tool servers maintained by Microsoft that handle authentication, permissions, and API calls automatically.
-
-**Trigger phrases:**
-```
-"Add workiq tools"                   "Add Work IQ Mail"
-"Add work intelligence tools"        "Add MCP tools to this agent"
-```
-
-### `instrument-observability` — Add A365 Observability
-
-Instruments OpenTelemetry-based tracing, BaggageBuilder context propagation, and the A365 exporter with agentic token resolver into your agent entry point and message handler.
-
-**Trigger phrases:**
-```
-"Instrument observability"     "Add A365 observability"
-"Enable tracing"               "Add OTel"
-"Instrument for Defender"      "Add telemetry"
-```
-
-### `make-ai-teammate` — Transform Any Node.js Agent into an AI Teammate
-
-The full-stack transformation skill. Takes any Node.js agent using LangChain, OpenAI Agents SDK,
-or Claude SDK and makes it a production-ready Microsoft Agent 365 AI Teammate — wrapping your
-existing LLM code without replacing it.
-
-**What it adds:**
-- **Hosting layer** — Express server with `CloudAdapter`, JWT auth, `/api/health`, `/api/messages`
-- **Agent routing** — `AgentApplication` subclass with message handling and typing indicator loop
-- **Observability** — `ObservabilityManager`, `BaggageBuilder`, `InferenceScope`, token cache
-- **Notifications** — email notification handler using `createEmailResponseActivity`, install/uninstall lifecycle events
-- **WorkIQ tools** — `McpToolRegistrationService` wired into the client factory, `ToolingManifest.json`
-- **All packages and env vars** — installs every required `@microsoft/agents-*` package
-
-Supports **LangChain**, **OpenAI Agents SDK**, and **Claude SDK**. Idempotent — re-runnable on
-agents that are partially configured.
+Supports **LangChain**, **OpenAI Agents SDK**, and **Claude SDK** (Node.js), **AgentFramework** (.NET and Python). Idempotent — re-running on a partially-configured agent only adds what is missing.
 
 **Trigger phrases:**
 ```
@@ -122,9 +197,84 @@ agents that are partially configured.
 "Convert agent to Teams agent"        "Add CloudAdapter to this agent"
 ```
 
+---
+
+### `a365-setup` — Register, Configure & Publish
+
+Full A365 CLI lifecycle. Detects your agent stack and Custom Engine Agent status automatically,
+then asks two questions — agent type and desired capabilities — and follows the right path:
+
+| Agent Type | Available Capabilities |
+|------------|----------------------|
+| **Custom Engine Agent** | • **Observability** — OTel tracing + Defender integration<br>• **Observability + WorkIQ** — Adds M365 tools: Mail, Calendar, Teams, SharePoint<br>• **AI Teammate** — Blueprint, permissions, and messaging endpoint registration |
+| **Standard Agent** | • **Discoverability** — M365 catalog registration<br>• **Discoverability + Observability** — Registration + telemetry<br>• **AI Teammate** — Blueprint, permissions, and messaging endpoint registration |
+
+**AI Teammate path** — collects Agent Name, Manager Email, and Messaging Endpoint (devtunnel or custom HTTPS). Creates `a365.config.json`, runs `a365 setup all` (Blueprint + permissions + endpoint), and publishes the manifest to M365 Admin Center. You host the agent on your own infrastructure.
+
+**Discoverability path** — Blueprint + permissions only. Agent appears in the M365 catalog but has no messaging endpoint.
+
+**Observability path** — instruments OTel tracing, BaggageBuilder context, and the A365 exporter with agentic token resolver for Microsoft Defender.
+
+**Trigger phrases:**
+```
+"Run a365 setup"         "Create blueprint"
+"Register agent"         "Onboard agent"
+"Provision agent"        "Publish agent"
+```
+
+---
+
+### `add-workiq-tools` — Add WorkIQ MCP Tools
+
+Adds pre-built Microsoft 365 integration tools to your agent. Runs `a365 develop list-available`
+to show the MCP server catalog, adds selected servers via `a365 develop add-mcp-servers`
+(which writes `ToolingManifest.json`), wires `McpToolRegistrationService` in the agent code,
+and guides the permissions handoff to your Global Administrator.
+
+**What WorkIQ provides:** Ready-to-use MCP tool servers maintained by Microsoft — no custom Graph API integrations needed. Authentication, permissions, and API calls are handled automatically.
+
+| Tool | What it does |
+|------|-------------|
+| Work IQ Mail | Read, send, and manage email |
+| Work IQ Calendar | Read/create events, check availability |
+| Work IQ Teams | Read channel messages, list teams and members |
+| Work IQ SharePoint | Search documents, read files, list sites |
+| Work IQ OneDrive | Manage OneDrive files |
+| Work IQ Word | Read and write Word documents |
+| Work IQ User | Get user profile and presence |
+| Work IQ Copilot | Chat with Microsoft 365 Copilot |
+| Dataverse & Dynamics 365 | CRUD and domain actions |
+
+**Trigger phrases:**
+```
+"Add workiq tools"                   "Add Work IQ Mail"
+"Add work intelligence tools"        "Add MCP tools to this agent"
+```
+
+---
+
+### `instrument-observability` — Add A365 Observability
+
+Instruments OpenTelemetry-based tracing, BaggageBuilder context propagation, and the A365
+exporter with agentic token resolver into an existing agent entry point and message handler.
+Use `make-ai-teammate` for new agents — use this skill to add observability incrementally to
+an agent that already has a hosting layer.
+
+**Trigger phrases:**
+```
+"Instrument observability"     "Add A365 observability"
+"Enable tracing"               "Add OTel"
+"Instrument for Defender"      "Add telemetry"
+```
+
+---
+
 ### `test-local` — Local Testing with AgentsPlayground
 
-Tests your agent locally without deploying to Azure or Teams. Checks prerequisites (`agentsplayground` CLI, build tools), builds the agent, starts it in the background, and opens AgentsPlayground pointed at your local endpoint — no Bot Framework auth required.
+Tests your agent locally without deploying to Azure or Teams. Checks prerequisites
+(`agentsplayground` CLI, build tools), builds the agent, starts it in the background on
+port 3978, and opens AgentsPlayground pointed at your local endpoint — no Bot Framework
+auth required.
 
 **Trigger phrases:**
 ```
@@ -137,18 +287,36 @@ Tests your agent locally without deploying to Azure or Teams. Checks prerequisit
 
 ## Starter Prompts
 
-**Transform an existing Node.js agent into a full AI Teammate:**
+**Transform a plain Node.js agent into a full AI Teammate (all-in-one):**
 ```
-I have a Node.js LangChain agent that runs as a plain script. Transform it into
-a Microsoft Agent 365 AI Teammate with hosting, observability, email notifications,
-and WorkIQ tools.
+I have a Node.js LangChain agent that runs as a plain script. Transform it into a
+Microsoft Agent 365 AI Teammate with Teams hosting, observability, email notifications,
+and WorkIQ Mail and Calendar tools.
 ```
 
-**Register a new agent as an AI Teammate:**
+**Transform a .NET AgentFramework agent:**
 ```
-This agent has never been registered with Agent 365. Walk me through blueprint setup,
-adding WorkIQ SharePoint and Teams tools, and instrumentation with observability.
-Register it as an AI Teammate.
+I have a .NET AgentFramework agent. Transform it into a Microsoft Agent 365 AI Teammate
+with full hosting, observability, WorkIQ tools, and email notification handling.
+```
+
+**Transform a Python agent:**
+```
+I have a Python agent using agent-framework-azure-ai. Make it a Microsoft Agent 365
+AI Teammate with Teams hosting, MCP tooling, and email notification handling.
+```
+
+**Register a transformed agent (after make-ai-teammate):**
+```
+The code is ready. Register this agent as an AI Teammate with Agent 365 — create the
+blueprint, grant permissions, and register my messaging endpoint.
+```
+
+**Full flow in one prompt:**
+```
+This agent has never been registered with Agent 365. Walk me through the full AI
+Teammate setup: transform the code, register a blueprint, add WorkIQ Mail and
+Teams tools, and test it locally.
 ```
 
 **Register for Discoverability only (self-hosted):**
@@ -157,23 +325,10 @@ I want to register this agent so it shows up in the M365 catalog,
 but I'll handle hosting and deployment myself. Set up Discoverability.
 ```
 
-**Add Discoverability + Observability (self-hosted with telemetry):**
-```
-Register this agent in the M365 catalog and add observability instrumentation
-for Microsoft Defender integration. I'll host it on my own infrastructure.
-```
-
 **Custom Engine Agent — add observability and WorkIQ:**
 ```
 This is a Custom Engine Agent available in Microsoft Teams and Copilot.
 Add A365 observability and WorkIQ Mail, Calendar, and Teams tools.
-```
-
-**Register a new agent with specific WorkIQ tools:**
-```
-I have a new .NET AgentFramework agent. Register it with Agent 365 as an AI Teammate
-and add Work IQ Mail, Calendar, and SharePoint tools.
-I'll host the agent myself.
 ```
 
 **Add specific WorkIQ tools to an existing agent:**
@@ -191,6 +346,16 @@ Test my agent locally without deploying to Teams.
 ```
 Check which Agent 365 skills have already been applied to this agent and tell me what's missing.
 ```
+
+---
+
+## What's Included
+
+- **5 skills** covering full AI Teammate transformation, blueprint setup, WorkIQ MCP tools, observability instrumentation, and local testing with AgentsPlayground
+- **Multi-language support** — Node.js (LangChain, OpenAI Agents SDK, Claude SDK), .NET AgentFramework, and Python AgentFramework
+- **Automatic agent detection** — skills detect your LLM framework, programming language, and Custom Engine Agent status, then ask validation questions before any code runs
+- **Non-destructive and idempotent** — skills wrap existing code without deleting anything; re-running skips what is already configured
+- **WorkIQ MCP tools** — pre-built M365 integrations for Mail, Calendar, Teams, SharePoint, OneDrive, Word, User profiles, Copilot, and Dataverse/Dynamics 365
 
 ---
 
@@ -212,7 +377,7 @@ cd my-agent-project
 claude --plugin-dir "/path/to/agent365-skills/plugins/agent365"
 
 # 3. Start with a trigger phrase, e.g.:
-#    "Add workiq tools to this agent"
+#    "Make this agent an AI Teammate"
 ```
 
 The `--plugin-dir` path must be in double quotes if it contains spaces. Use the absolute path.
@@ -252,8 +417,11 @@ The plugin is designed around a least-privilege model — it cannot exceed the p
 - [A365 CLI Develop Commands](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/reference/cli/develop)
 - [A365 Observability](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/observability)
 - [AI-Guided Setup](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/ai-guided-setup)
-- [.NET Sample Agent](https://github.com/microsoft/Agent365-Samples/tree/main/dotnet/agent-framework/sample-agent)
-- [Node.js Sample Agent](https://github.com/microsoft/Agent365-Samples/tree/main/nodejs/langchain)
+- [Node.js LangChain Sample](https://github.com/microsoft/Agent365-Samples/tree/main/nodejs/langchain/sample-agent)
+- [Node.js OpenAI Sample](https://github.com/microsoft/Agent365-Samples/tree/main/nodejs/openai/sample-agent)
+- [Node.js Claude Sample](https://github.com/microsoft/Agent365-Samples/tree/main/nodejs/claude/sample-agent)
+- [.NET AgentFramework Sample](https://github.com/microsoft/Agent365-Samples/tree/main/dotnet/agent-framework/sample-agent)
+- [Python AgentFramework Sample](https://github.com/microsoft/Agent365-Samples/tree/main/python/agent-framework/sample-agent)
 
 ---
 

--- a/evals/agent365/make-ai-teammate/evals.json
+++ b/evals/agent365/make-ai-teammate/evals.json
@@ -1,14 +1,16 @@
 {
   "skill_name": "make-ai-teammate",
-  "eval_instructions": "Test against Node.js agents that are NOT yet M365-integrated — plain LangChain scripts, standalone OpenAI apps, Claude SDK demos. The skill must WRAP existing LLM code, not replace it. Verify: (1) index.ts has CloudAdapter + authorizeJWT + /api/health + /api/messages, (2) agent.ts has AgentApplication with message/notification/InstallationUpdate handlers, (3) client.ts has ObservabilityManager.configure().start() and McpToolRegistrationService at module level, (4) token-cache.ts exists, (5) ToolingManifest.json exists, (6) all @microsoft/agents-* packages in package.json, (7) tsconfig has module: node16. The skill must be idempotent — re-running on a partially-configured agent should only add what is missing.",
+  "eval_instructions": "Test against agents that are NOT yet M365-integrated across three languages: Node.js (LangChain/OpenAI/Claude), .NET AgentFramework, and Python AgentFramework. The skill must WRAP existing LLM code, not replace it. For Node.js verify: (1) index.ts has CloudAdapter + authorizeJWT + /api/health + /api/messages, (2) agent.ts has AgentApplication with message/notification/InstallationUpdate handlers, (3) client.ts has ObservabilityManager.configure().start() and McpToolRegistrationService at module level, (4) token-cache.ts exists, (5) ToolingManifest.json exists, (6) all @microsoft/agents-* packages in package.json, (7) tsconfig has module: node16. For .NET verify: (1) Program.cs has AddAgenticTracingExporter + AddA365Tracing + AddAgent<T> + /api/messages + /api/health, (2) agent class extends AgentApplication with dual isAgenticOnly registrations, (3) .csproj has all Microsoft.Agents.A365.* packages, (4) appsettings.json has AgentApplication + TokenValidation + Connections. For Python verify: (1) host_agent_server.py has CloudAdapterAiohttp + /api/messages + /api/health + on_agent_notification, (2) agent.py implements AgentInterface with process_user_message and setup_mcp_servers, (3) token_cache.py exists, (4) pyproject.toml has all microsoft_agents_a365_* packages. The skill must be idempotent across all languages.",
   "evals": [
     {
       "id": 1,
       "prompt": "Make this agent an AI Teammate",
       "description": "Full transformation of a plain Node.js LangChain script with no M365 integration",
+      "language": "nodejs",
       "expected_output": "The skill detects LangChain, confirms with the user, installs all required @microsoft/agents-* packages, writes src/index.ts with Express + CloudAdapter + JWT auth + health + messages endpoints, writes src/agent.ts with AgentApplication subclass and all handlers, writes src/client.ts wrapping existing LangChain invocation with ObservabilityManager and McpToolRegistrationService, writes src/token-cache.ts, creates ToolingManifest.json with empty mcpServers array, updates .env.example with A365 variables, updates tsconfig.json to node16, validates the build, and tells the user to run a365 setup next.",
       "files": [],
       "expectations": [
+        "Phase 0A: language detected as NodeJS from package.json",
         "Phase 0A: LangChain is detected from package.json",
         "Phase 0B: Detection summary shown to user with all 5 'already present' flags as ❌",
         "Phase 0B: User is asked to confirm before any files are written",
@@ -41,10 +43,12 @@
     {
       "id": 2,
       "prompt": "Transform agent to AI Teammate",
-      "description": "OpenAI Agents SDK project — partial integration (hosting already present, no observability or notifications)",
+      "description": "Node.js OpenAI Agents SDK project — partial integration (hosting already present, no observability or notifications)",
+      "language": "nodejs",
       "expected_output": "The skill detects OpenAI Agents SDK and that hosting is already present (CloudAdapter found). It skips Phase 4 (index.ts), adds the AgentApplication class, wires observability and McpToolRegistrationService into client.ts, adds notification handlers to agent.ts, and validates the build. Existing routes and middleware are preserved.",
       "files": [],
       "expectations": [
+        "Phase 0A: language detected as NodeJS",
         "Phase 0A: OpenAI Agents SDK detected from package.json (@openai/agents)",
         "Phase 0A: hasHosting is detected as ✅ (CloudAdapter already present)",
         "Phase 0A: hasObservability is detected as ❌, hasNotifications as ❌",
@@ -62,10 +66,12 @@
     {
       "id": 3,
       "prompt": "Add AI Teammate hosting to this Claude agent",
-      "description": "Claude SDK project — no existing M365 integration",
+      "description": "Node.js Claude SDK project — no existing M365 integration",
+      "language": "nodejs",
       "expected_output": "The skill detects Claude SDK (@anthropic-ai/sdk), installs Claude-specific packages (@microsoft/agents-a365-tooling-extensions-claude, @microsoft/agents-a365-observability-extensions-claude), and follows the same full transformation using Claude variants. The Anthropic API key env var is preserved.",
       "files": [],
       "expectations": [
+        "Phase 0A: language detected as NodeJS",
         "Phase 0A: Claude SDK detected from @anthropic-ai/sdk in package.json",
         "Phase 1: npm install uses @microsoft/agents-a365-tooling-extensions-claude and @microsoft/agents-a365-observability-extensions-claude",
         "Phase 6: client.ts uses Claude-specific MCP service (agents-a365-tooling-extensions-claude)",
@@ -76,10 +82,12 @@
     {
       "id": 4,
       "prompt": "Make this agent an AI Teammate",
-      "description": "Idempotency — fully configured agent, all components already present",
+      "description": "Node.js idempotency — fully configured agent, all components already present",
+      "language": "nodejs",
       "expected_output": "The skill detects all components are already present, skips all creation phases, runs the build, and reports that the agent is already a complete AI Teammate.",
       "files": [],
       "expectations": [
+        "Phase 0A: language detected as NodeJS",
         "Phase 0A: All 5 'already present' flags detected as ✅",
         "Phase 0B: User is shown all-green detection summary",
         "All creation phases (3–8) are skipped",
@@ -90,10 +98,12 @@
     {
       "id": 5,
       "prompt": "Wire up M365 hosting",
-      "description": "Agent with existing Express server (non-CloudAdapter) — migration path",
+      "description": "Node.js agent with existing Express server (non-CloudAdapter) — migration path",
+      "language": "nodejs",
       "expected_output": "The skill finds the existing Express server in index.ts. Instead of overwriting, it migrates it: adds configDotenv() as first line, adds CloudAdapter and authorizeJWT, adds /api/health before auth, adds /api/messages, and preserves any existing routes.",
       "files": [],
       "expectations": [
+        "Phase 0A: language detected as NodeJS",
         "Phase 0A: hasHosting detected as ❌ (Express present but no CloudAdapter)",
         "Phase 4: Existing index.ts is migrated — not overwritten from scratch",
         "Phase 4: configDotenv() is added as first line if missing",
@@ -106,16 +116,113 @@
     {
       "id": 6,
       "prompt": "Convert this agent to a Teams agent",
-      "description": "Unknown/unsupported LLM framework (not LangChain, OpenAI, or Claude)",
+      "description": "Node.js unknown/unsupported LLM framework — stub path",
+      "language": "nodejs",
       "expected_output": "The skill detects an unrecognized LLM framework and tells the user. It still adds the hosting layer, agent class, token cache, ToolingManifest.json, and observability init. It stubs out the client factory with a placeholder and tells the user exactly where to integrate their LLM calls.",
       "files": [],
       "expectations": [
+        "Phase 0A: language detected as NodeJS",
         "Phase 0B: User is told the framework is not auto-detected",
         "Phase 0B: User is asked to confirm or provide the framework name",
         "Hosting layer (index.ts), agent class (agent.ts), token-cache.ts are still created",
         "client.ts is created with ObservabilityManager + McpToolRegistrationService + stub invokeInferenceScope",
         "User is clearly told where in client.ts to integrate their LLM calls",
         "Build is attempted — any LLM-specific errors are reported but do not block the skill"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Make this agent an AI Teammate",
+      "description": ".NET AgentFramework project — no existing A365 integration. Has Program.cs with basic ASP.NET Core setup and an agent class using Azure OpenAI IChatClient.",
+      "language": "dotnet",
+      "expected_output": "The skill detects a .NET project with AgentFramework. It adds Microsoft.Agents.A365.* NuGet packages, updates Program.cs with A365 service registrations (AddAgenticTracingExporter, AddA365Tracing, IMcpToolRegistrationService), adds /api/messages and /api/health endpoints, creates or updates the agent class with dual isAgenticOnly activity handlers, creates ToolingManifest.json, updates appsettings.json with A365 auth and connection config, and validates the build with dotnet build.",
+      "files": [],
+      "expectations": [
+        "Phase 0A: language detected as DotNet from .csproj",
+        "Phase 0A: agentStack detected as AgentFramework",
+        "Phase 0B: Detection summary shown to user",
+        "Phase 1: dotnet add package runs for Microsoft.Agents.A365.Notifications, Microsoft.Agents.A365.Tooling.Extensions.AgentFramework, Microsoft.Agents.A365.Observability.Extensions.AgentFramework (all --prerelease)",
+        "Phase 4: Program.cs gains builder.Services.AddAgenticTracingExporter(clusterCategory: 'production')",
+        "Phase 4: Program.cs gains builder.AddA365Tracing(config => config.WithAgentFramework())",
+        "Phase 4: Program.cs gains AddSingleton<IMcpToolRegistrationService, McpToolRegistrationService>",
+        "Phase 4: Program.cs gains AddSingleton<IMcpToolServerConfigurationService, McpToolServerConfigurationService>",
+        "Phase 4: Program.cs has app.MapPost('/api/messages', ...) using adapter.ProcessAsync()",
+        "Phase 4: Program.cs has app.MapGet('/api/health', ...) with no auth",
+        "Phase 5: Agent class extends AgentApplication",
+        "Phase 5: Agent class has OnActivity(ActivityTypes.InstallationUpdate, ..., isAgenticOnly: true) and isAgenticOnly: false",
+        "Phase 5: Agent class has OnActivity(ActivityTypes.Message, ..., isAgenticOnly: true) and isAgenticOnly: false",
+        "Phase 5: Agent class has typing indicator loop (4 second interval) in OnMessageAsync",
+        "Phase 5: GetAgentInstructions() sanitizes Activity.From.Name (strips control chars, caps at 64 chars)",
+        "Phase 5: GetClientAgent() calls toolService.GetMcpToolsAsync()",
+        "Phase 7: ToolingManifest.json created with empty mcpServers array",
+        "Phase 8: appsettings.json has AgentApplication.AgenticAuthHandlerName, TokenValidation, Connections, ConnectionsMap sections",
+        "Phase 9: dotnet build succeeds",
+        "Phase 10: .NET-specific next steps shown (set appsettings.json values, dotnet run)"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "Transform agent to AI Teammate",
+      "description": ".NET AgentFramework — partial integration (Program.cs already has /api/messages but no A365 observability or tooling)",
+      "language": "dotnet",
+      "expected_output": "The skill detects that hosting is present (/api/messages found) but observability and WorkIQ tooling are missing. It skips Program.cs rewrite but adds the A365 service registrations. It adds the missing activity handlers to the agent class and validates the build.",
+      "files": [],
+      "expectations": [
+        "Phase 0A: hasHosting detected as ✅ (/api/messages already in Program.cs)",
+        "Phase 0A: hasObservability detected as ❌ (AddAgenticTracingExporter not found)",
+        "Phase 0A: hasWorkIQ detected as ❌ (IMcpToolRegistrationService not found)",
+        "Phase 4: Program.cs is NOT rewritten — only A365 service registrations are added",
+        "Phase 4: Existing routes and middleware are preserved",
+        "Phase 5: Missing activity handlers added to existing agent class",
+        "Phase 9: dotnet build succeeds"
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "Make this agent an AI Teammate",
+      "description": "Python AgentFramework project — plain agent.py with AzureOpenAI, no hosting or A365 integration",
+      "language": "python",
+      "expected_output": "The skill detects a Python project with AgentFramework. It adds microsoft_agents_a365_* dependencies to pyproject.toml, creates token_cache.py and agent_interface.py, writes host_agent_server.py with CloudAdapterAiohttp server and all A365 handlers, updates agent.py to implement AgentInterface with MCP tooling and notification handling (preserving the existing LLM client setup), creates ToolingManifest.json, updates .env with A365 variables, and validates with uv sync.",
+      "files": [],
+      "expectations": [
+        "Phase 0A: language detected as Python from pyproject.toml",
+        "Phase 0A: agentStack detected as AgentFramework",
+        "Phase 0B: Detection summary shown to user with all 5 'already present' flags as ❌",
+        "Phase 1: uv add runs with all microsoft_agents_a365_* packages",
+        "Phase 3: token_cache.py created with cache_agentic_token and get_cached_agentic_token",
+        "Phase 4: agent_interface.py created with AgentInterface ABC",
+        "Phase 4: host_agent_server.py created with CloudAdapterAiohttp, /api/messages, /api/health",
+        "Phase 4: host_agent_server.py has on_agent_notification handler",
+        "Phase 4: host_agent_server.py has typing indicator loop (4 second interval)",
+        "Phase 4: load_dotenv() is called at top of host_agent_server.py before other imports",
+        "Phase 5: agent.py implements AgentInterface (process_user_message, initialize, cleanup)",
+        "Phase 5: agent.py has _sanitize_display_name() to prevent prompt injection",
+        "Phase 5: agent.py has setup_mcp_servers() calling McpToolRegistrationService.add_tool_servers_to_agent()",
+        "Phase 5: agent.py has handle_agent_notification_activity() handling EMAIL_NOTIFICATION",
+        "Phase 5: agent.py has token_resolver() using get_cached_agentic_token()",
+        "Phase 5: Existing LLM client configuration (AZURE_OPENAI_* env vars) is preserved",
+        "Phase 7: ToolingManifest.json created with empty mcpServers array",
+        "Phase 8: .env / .env.template gains AUTH_HANDLER_NAME, CONNECTIONS__* vars, USE_AGENTIC_AUTH, OBSERVABILITY_* vars",
+        "Phase 9: uv sync succeeds",
+        "Phase 10: Python-specific next steps shown (python host_agent_server.py)"
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "Add AI Teammate hosting",
+      "description": "Python — idempotency: agent.py already implements AgentInterface, host_agent_server.py exists, only ToolingManifest.json and env vars are missing",
+      "language": "python",
+      "expected_output": "The skill detects that hosting and agent class are already present, skips those phases, creates the missing ToolingManifest.json and adds missing env vars, and validates the setup.",
+      "files": [],
+      "expectations": [
+        "Phase 0A: language detected as Python",
+        "Phase 0A: hasHosting detected as ✅ (CloudAdapterAiohttp found)",
+        "Phase 0A: hasAgentApp detected as ✅ (AgentInterface found)",
+        "Phase 0A: hasManifest detected as ❌",
+        "Phases 4 and 5 are skipped entirely",
+        "Phase 7: ToolingManifest.json is created",
+        "Phase 8: Missing env vars are appended to .env",
+        "Phase 9: uv sync succeeds"
       ]
     }
   ]

--- a/plugins/agent365/scripts/validate-make-ai-teammate.js
+++ b/plugins/agent365/scripts/validate-make-ai-teammate.js
@@ -3,7 +3,8 @@
  * validate-make-ai-teammate.js
  *
  * Stop hook validator for the make-ai-teammate skill.
- * Checks that the full AI Teammate hosting layer was added to a Node.js agent.
+ * Detects the project language (Node.js / .NET / Python) and validates
+ * that the full AI Teammate hosting layer was added.
  *
  * Exit codes:
  *   0  → ok: true  (session may end)
@@ -21,7 +22,7 @@ function findFiles(dir, extensions, maxDepth = 5) {
     try { entries = fs.readdirSync(current, { withFileTypes: true }); } catch { return; }
     for (const entry of entries) {
       if (entry.isDirectory() && entry.name.startsWith('.')) continue;
-      if (['node_modules', 'dist', 'bin', 'obj'].includes(entry.name)) continue;
+      if (['node_modules', 'dist', 'bin', 'obj', '.git', '__pycache__', '.venv'].includes(entry.name)) continue;
       const full = path.join(current, entry.name);
       if (entry.isDirectory()) walk(full, depth + 1);
       else if (extensions.some(e => entry.name.endsWith(e))) results.push(full);
@@ -45,84 +46,22 @@ function anyFileContains(files, ...patterns) {
 const cwd    = process.cwd();
 const issues = [];
 
-const tsFiles   = findFiles(cwd, ['.ts']).filter(f => !f.includes('node_modules'));
-const jsonFiles = findFiles(cwd, ['package.json']).filter(f => !f.includes('node_modules'));
+// ── Detect language ─────────────────────────────────────────────────────────
 
-// ── Check 1: Hosting layer — index.ts ───────────────────────────────────────
+const hasCsproj     = findFiles(cwd, ['.csproj']).length > 0;
+const hasPyproject  = fs.existsSync(path.join(cwd, 'pyproject.toml'));
+const hasPackageJson = fs.existsSync(path.join(cwd, 'package.json'));
 
-const indexFile = path.join(cwd, 'src', 'index.ts');
-if (fs.existsSync(indexFile)) {
-  if (!fileContains(indexFile, 'CloudAdapter')) {
-    issues.push('src/index.ts exists but does not use CloudAdapter — hosting layer incomplete');
-  }
-  if (!fileContains(indexFile, '/api/messages')) {
-    issues.push('src/index.ts is missing the /api/messages endpoint');
-  }
-  if (!fileContains(indexFile, '/api/health')) {
-    issues.push('src/index.ts is missing the /api/health endpoint');
-  }
-  if (!fileContains(indexFile, 'authorizeJWT')) {
-    issues.push('src/index.ts is missing authorizeJWT middleware');
-  }
-  if (!fileContains(indexFile, 'configDotenv') && !fileContains(indexFile, 'dotenv')) {
-    issues.push('src/index.ts does not load .env — configDotenv() must be first line');
-  }
-} else {
-  issues.push('src/index.ts not found — hosting layer was not added');
+let language = 'nodejs'; // default
+if (hasCsproj) {
+  language = 'dotnet';
+} else if (hasPyproject) {
+  language = 'python';
+} else if (hasPackageJson) {
+  language = 'nodejs';
 }
 
-// ── Check 2: Agent class ────────────────────────────────────────────────────
-
-const agentHasApp = anyFileContains(tsFiles, 'AgentApplication');
-if (!agentHasApp) {
-  issues.push('No TypeScript file extends AgentApplication — agent class not added');
-}
-
-const agentHasNotification = anyFileContains(tsFiles, 'onAgentNotification');
-if (!agentHasNotification) {
-  issues.push('onAgentNotification handler not found — notification routing not wired');
-}
-
-const agentHasInstall = anyFileContains(tsFiles, 'InstallationUpdate');
-if (!agentHasInstall) {
-  issues.push('InstallationUpdate handler not found — lifecycle events not wired');
-}
-
-const agentHasNotifImport = anyFileContains(tsFiles, "agents-a365-notifications");
-if (!agentHasNotifImport) {
-  issues.push("import '@microsoft/agents-a365-notifications' not found — notification deserialization will break");
-}
-
-// ── Check 3: Client factory + observability ─────────────────────────────────
-
-const clientHasObservability = anyFileContains(tsFiles, 'ObservabilityManager');
-if (!clientHasObservability) {
-  issues.push('ObservabilityManager not found — observability not initialized');
-}
-
-const clientHasToolService = anyFileContains(tsFiles,
-  'McpToolRegistrationService', 'addToolServersToAgent');
-if (!clientHasToolService) {
-  issues.push('McpToolRegistrationService / addToolServersToAgent not found — WorkIQ tools not wired');
-}
-
-const clientHasInferenceScope = anyFileContains(tsFiles, 'InferenceScope');
-if (!clientHasInferenceScope) {
-  issues.push('InferenceScope not found in client — LLM calls are not wrapped with telemetry');
-}
-
-// ── Check 4: Token cache ────────────────────────────────────────────────────
-
-const tokenCacheFile = path.join(cwd, 'src', 'token-cache.ts');
-if (!fs.existsSync(tokenCacheFile)) {
-  issues.push('src/token-cache.ts not found');
-} else {
-  if (!fileContains(tokenCacheFile, 'createAgenticTokenCacheKey')) {
-    issues.push('src/token-cache.ts is missing createAgenticTokenCacheKey export');
-  }
-}
-
-// ── Check 5: ToolingManifest.json ───────────────────────────────────────────
+// ── Validate: ToolingManifest.json (all languages) ──────────────────────────
 
 const manifestFile = path.join(cwd, 'ToolingManifest.json');
 if (!fs.existsSync(manifestFile)) {
@@ -134,46 +73,254 @@ if (!fs.existsSync(manifestFile)) {
       issues.push('ToolingManifest.json is missing mcpServers array');
     }
   } catch {
-    issues.push('ToolingManifest.json exists but cannot be parsed');
+    issues.push('ToolingManifest.json exists but cannot be parsed as JSON');
   }
 }
 
-// ── Check 6: Required packages in package.json ──────────────────────────────
+// ── Node.js validations ─────────────────────────────────────────────────────
 
-const pkgFile = jsonFiles.find(f => path.basename(f) === 'package.json' && !f.includes('/src/'));
-if (pkgFile) {
-  const required = [
-    '@microsoft/agents-hosting',
-    '@microsoft/agents-a365-observability',
-    '@microsoft/agents-a365-notifications',
-  ];
-  for (const pkg of required) {
-    if (!fileContains(pkgFile, pkg)) {
-      issues.push(`${pkg} not found in package.json dependencies`);
+if (language === 'nodejs') {
+  const tsFiles   = findFiles(cwd, ['.ts']).filter(f => !f.includes('node_modules'));
+  const jsonFiles = findFiles(cwd, ['package.json']).filter(f => !f.includes('node_modules'));
+
+  // Check 1: Hosting layer — index.ts
+  const indexFile = path.join(cwd, 'src', 'index.ts');
+  if (fs.existsSync(indexFile)) {
+    if (!fileContains(indexFile, 'CloudAdapter')) {
+      issues.push('src/index.ts exists but does not use CloudAdapter — hosting layer incomplete');
+    }
+    if (!fileContains(indexFile, '/api/messages')) {
+      issues.push('src/index.ts is missing the /api/messages endpoint');
+    }
+    if (!fileContains(indexFile, '/api/health')) {
+      issues.push('src/index.ts is missing the /api/health endpoint');
+    }
+    if (!fileContains(indexFile, 'authorizeJWT')) {
+      issues.push('src/index.ts is missing authorizeJWT middleware');
+    }
+    if (!fileContains(indexFile, 'configDotenv') && !fileContains(indexFile, 'dotenv')) {
+      issues.push('src/index.ts does not load .env — configDotenv() must be first line');
+    }
+  } else {
+    issues.push('src/index.ts not found — hosting layer was not added');
+  }
+
+  // Check 2: Agent class
+  if (!anyFileContains(tsFiles, 'AgentApplication')) {
+    issues.push('No TypeScript file extends AgentApplication — agent class not added');
+  }
+  if (!anyFileContains(tsFiles, 'onAgentNotification')) {
+    issues.push('onAgentNotification handler not found — notification routing not wired');
+  }
+  if (!anyFileContains(tsFiles, 'InstallationUpdate')) {
+    issues.push('InstallationUpdate handler not found — lifecycle events not wired');
+  }
+  if (!anyFileContains(tsFiles, "agents-a365-notifications")) {
+    issues.push("import '@microsoft/agents-a365-notifications' not found — notification deserialization will break");
+  }
+
+  // Check 3: Client factory + observability
+  if (!anyFileContains(tsFiles, 'ObservabilityManager')) {
+    issues.push('ObservabilityManager not found — observability not initialized');
+  }
+  if (!anyFileContains(tsFiles, 'McpToolRegistrationService', 'addToolServersToAgent')) {
+    issues.push('McpToolRegistrationService / addToolServersToAgent not found — WorkIQ tools not wired');
+  }
+  if (!anyFileContains(tsFiles, 'InferenceScope')) {
+    issues.push('InferenceScope not found in client — LLM calls are not wrapped with telemetry');
+  }
+
+  // Check 4: Token cache
+  const tokenCacheFile = path.join(cwd, 'src', 'token-cache.ts');
+  if (!fs.existsSync(tokenCacheFile)) {
+    issues.push('src/token-cache.ts not found');
+  } else {
+    if (!fileContains(tokenCacheFile, 'createAgenticTokenCacheKey')) {
+      issues.push('src/token-cache.ts is missing createAgenticTokenCacheKey export');
     }
   }
-} else {
-  issues.push('package.json not found');
+
+  // Check 5: Required packages in package.json
+  const pkgFile = jsonFiles.find(f => path.basename(f) === 'package.json' && !f.includes('/src/'));
+  if (pkgFile) {
+    const required = [
+      '@microsoft/agents-hosting',
+      '@microsoft/agents-a365-observability',
+      '@microsoft/agents-a365-notifications',
+    ];
+    for (const pkg of required) {
+      if (!fileContains(pkgFile, pkg)) {
+        issues.push(`${pkg} not found in package.json dependencies`);
+      }
+    }
+  } else {
+    issues.push('package.json not found');
+  }
+
+  // Check 6: tsconfig.json module resolution
+  const tsconfigFile = path.join(cwd, 'tsconfig.json');
+  if (fs.existsSync(tsconfigFile)) {
+    try {
+      const tsconfig = JSON.parse(fs.readFileSync(tsconfigFile, 'utf8'));
+      const opts = tsconfig.compilerOptions ?? {};
+      if (opts.module !== 'node16' && opts.module !== 'Node16') {
+        issues.push('tsconfig.json: "module" is not "node16" — this will break @microsoft/agents-* imports');
+      }
+      if (opts.moduleResolution !== 'node16' && opts.moduleResolution !== 'Node16') {
+        issues.push('tsconfig.json: "moduleResolution" is not "node16"');
+      }
+    } catch {
+      issues.push('tsconfig.json exists but cannot be parsed');
+    }
+  } else {
+    issues.push('tsconfig.json not found');
+  }
 }
 
-// ── Check 7: tsconfig.json module resolution ────────────────────────────────
+// ── .NET validations ────────────────────────────────────────────────────────
 
-const tsconfigFile = path.join(cwd, 'tsconfig.json');
-if (fs.existsSync(tsconfigFile)) {
-  try {
-    const tsconfig = JSON.parse(fs.readFileSync(tsconfigFile, 'utf8'));
-    const opts = tsconfig.compilerOptions ?? {};
-    if (opts.module !== 'node16' && opts.module !== 'Node16') {
-      issues.push('tsconfig.json: "module" is not "node16" — this will break @microsoft/agents-* imports');
+if (language === 'dotnet') {
+  const csFiles = findFiles(cwd, ['.cs']);
+
+  // Check 1: Program.cs — hosting layer
+  const programFile = path.join(cwd, 'Program.cs');
+  if (fs.existsSync(programFile)) {
+    if (!fileContains(programFile, 'AddAgenticTracingExporter')) {
+      issues.push('Program.cs is missing AddAgenticTracingExporter — A365 observability exporter not configured');
     }
-    if (opts.moduleResolution !== 'node16' && opts.moduleResolution !== 'Node16') {
-      issues.push('tsconfig.json: "moduleResolution" is not "node16"');
+    if (!fileContains(programFile, 'AddA365Tracing')) {
+      issues.push('Program.cs is missing AddA365Tracing — A365 tracing provider not configured');
     }
-  } catch {
-    issues.push('tsconfig.json exists but cannot be parsed');
+    if (!fileContains(programFile, 'AddAgent<')) {
+      issues.push('Program.cs is missing AddAgent<T>() — agent not registered with DI container');
+    }
+    if (!fileContains(programFile, '/api/messages')) {
+      issues.push('Program.cs is missing /api/messages endpoint');
+    }
+    if (!fileContains(programFile, '/api/health')) {
+      issues.push('Program.cs is missing /api/health endpoint');
+    }
+    if (!fileContains(programFile, 'IMcpToolRegistrationService') &&
+        !fileContains(programFile, 'McpToolRegistrationService')) {
+      issues.push('Program.cs is missing IMcpToolRegistrationService registration — WorkIQ tools not wired');
+    }
+  } else {
+    issues.push('Program.cs not found — hosting layer was not added');
   }
-} else {
-  issues.push('tsconfig.json not found');
+
+  // Check 2: Agent class
+  if (!anyFileContains(csFiles, 'AgentApplication')) {
+    issues.push('No .cs file extends AgentApplication — agent class not added');
+  }
+  if (!anyFileContains(csFiles, 'ActivityTypes.InstallationUpdate')) {
+    issues.push('InstallationUpdate handler not found in agent class — lifecycle events not wired');
+  }
+  if (!anyFileContains(csFiles, 'ActivityTypes.Message')) {
+    issues.push('Message handler not found in agent class');
+  }
+  if (!anyFileContains(csFiles, 'isAgenticOnly')) {
+    issues.push('isAgenticOnly parameter not found — dual auth registration (agentic + OBO) not configured');
+  }
+
+  // Check 3: Required NuGet packages in .csproj
+  const csprojFiles = findFiles(cwd, ['.csproj']);
+  if (csprojFiles.length > 0) {
+    const required = [
+      'Microsoft.Agents.A365.Notifications',
+      'Microsoft.Agents.A365.Tooling.Extensions.AgentFramework',
+      'Microsoft.Agents.A365.Observability.Extensions.AgentFramework',
+    ];
+    for (const pkg of required) {
+      if (!anyFileContains(csprojFiles, pkg)) {
+        issues.push(`${pkg} not found in .csproj — add with: dotnet add package ${pkg} --prerelease`);
+      }
+    }
+  } else {
+    issues.push('.csproj file not found');
+  }
+
+  // Check 4: appsettings.json
+  const appsettingsFile = path.join(cwd, 'appsettings.json');
+  if (fs.existsSync(appsettingsFile)) {
+    if (!fileContains(appsettingsFile, 'AgentApplication')) {
+      issues.push('appsettings.json is missing AgentApplication section');
+    }
+    if (!fileContains(appsettingsFile, 'TokenValidation')) {
+      issues.push('appsettings.json is missing TokenValidation section');
+    }
+  } else {
+    issues.push('appsettings.json not found — A365 auth configuration is required');
+  }
+}
+
+// ── Python validations ──────────────────────────────────────────────────────
+
+if (language === 'python') {
+  const pyFiles = findFiles(cwd, ['.py']);
+
+  // Check 1: host_agent_server.py — hosting layer
+  const hostFile = path.join(cwd, 'host_agent_server.py');
+  if (fs.existsSync(hostFile)) {
+    if (!fileContains(hostFile, 'CloudAdapterAiohttp')) {
+      issues.push('host_agent_server.py is missing CloudAdapterAiohttp — hosting layer incomplete');
+    }
+    if (!fileContains(hostFile, '/api/messages')) {
+      issues.push('host_agent_server.py is missing /api/messages route');
+    }
+    if (!fileContains(hostFile, '/api/health')) {
+      issues.push('host_agent_server.py is missing /api/health route');
+    }
+    if (!fileContains(hostFile, 'on_agent_notification') && !anyFileContains(pyFiles, 'on_agent_notification')) {
+      issues.push('on_agent_notification handler not found — notification routing not wired');
+    }
+  } else {
+    issues.push('host_agent_server.py not found — hosting layer was not added');
+  }
+
+  // Check 2: agent.py — agent interface implementation
+  const agentFile = path.join(cwd, 'agent.py');
+  if (fs.existsSync(agentFile)) {
+    if (!fileContains(agentFile, 'AgentInterface') && !fileContains(agentFile, 'process_user_message')) {
+      issues.push('agent.py does not implement AgentInterface / process_user_message — agent class incomplete');
+    }
+    if (!fileContains(agentFile, 'McpToolRegistrationService') &&
+        !anyFileContains(pyFiles, 'McpToolRegistrationService')) {
+      issues.push('McpToolRegistrationService not found — WorkIQ tools not wired');
+    }
+  } else {
+    issues.push('agent.py not found — agent implementation was not added');
+  }
+
+  // Check 3: token_cache.py
+  const tokenCacheFile = path.join(cwd, 'token_cache.py');
+  if (!fs.existsSync(tokenCacheFile)) {
+    issues.push('token_cache.py not found');
+  } else {
+    if (!fileContains(tokenCacheFile, 'cache_agentic_token')) {
+      issues.push('token_cache.py is missing cache_agentic_token function');
+    }
+  }
+
+  // Check 4: agent_interface.py
+  const interfaceFile = path.join(cwd, 'agent_interface.py');
+  if (!fs.existsSync(interfaceFile)) {
+    issues.push('agent_interface.py not found — AgentInterface ABC is required');
+  }
+
+  // Check 5: Required packages in pyproject.toml
+  if (fs.existsSync(hasPyproject)) {
+    const required = [
+      'microsoft_agents_a365_tooling',
+      'microsoft_agents_a365_notifications',
+      'microsoft_agents_a365_observability',
+      'microsoft-agents-hosting-aiohttp',
+    ];
+    for (const pkg of required) {
+      if (!fileContains(path.join(cwd, 'pyproject.toml'), pkg)) {
+        issues.push(`${pkg} not found in pyproject.toml dependencies`);
+      }
+    }
+  }
 }
 
 // ── Result ──────────────────────────────────────────────────────────────────

--- a/plugins/agent365/skills/make-ai-teammate/SKILL.md
+++ b/plugins/agent365/skills/make-ai-teammate/SKILL.md
@@ -1,16 +1,17 @@
 ---
 name: make-ai-teammate
 description: >
-  Transforms a non-M365 Node.js agent (LangChain, OpenAI Agents SDK, or Claude SDK) into a
-  fully-featured Microsoft Agent 365 AI Teammate. Adds the Express/CloudAdapter hosting layer,
-  AgentApplication class with message routing and typing indicators, client factory pattern,
-  token cache, A365 observability, email notifications, WorkIQ MCP tools, and all required
-  packages and env vars. Wraps existing LLM code — does not replace it.
+  Transforms a non-M365 agent (Node.js LangChain/OpenAI/Claude, .NET AgentFramework, or Python
+  AgentFramework) into a fully-featured Microsoft Agent 365 AI Teammate. Adds the hosting layer
+  (Express/CloudAdapter for Node.js, ASP.NET Core for .NET, aiohttp for Python), AgentApplication
+  class with message routing and typing indicators, token cache, A365 observability, email
+  notifications, WorkIQ MCP tools, and all required packages and env vars.
+  Wraps existing LLM code — does not replace it.
 compatibility:
   - claude-code
   - vscode-copilot
 user-invocable: true
-argument-hint: "Optional: LLM framework override (langchain | openai | claude)"
+argument-hint: "Optional: language/framework override (langchain | openai | claude | dotnet | python)"
 allowed-tools: Read, Write, Edit, Grep, Glob, Bash, AskUserQuestion, TaskCreate, TaskUpdate, TaskList
 model: sonnet
 hooks:
@@ -20,7 +21,9 @@ hooks:
       timeout: 15000
     - type: prompt
       prompt: |
-        Before ending, verify ALL of the following:
+        Before ending, verify based on the detected language:
+
+        Node.js:
         1. src/index.ts has Express + CloudAdapter + /api/health + /api/messages pattern.
         2. src/agent.ts has AgentApplication subclass with message, notification, InstallationUpdate handlers.
         3. src/client.ts has ObservabilityManager.configure().start() and McpToolRegistrationService.
@@ -30,6 +33,24 @@ hooks:
         7. tsconfig.json has module: "node16" and moduleResolution: "node16".
         8. All required @microsoft/agents-* packages are in package.json.
         9. Build succeeds (npm run build or tsc --noEmit).
+
+        .NET:
+        1. Program.cs has AddAgenticTracingExporter, AddA365Tracing, AddAgent<T>, /api/messages, /api/health.
+        2. Agent class (MyAgent.cs or equivalent) extends AgentApplication with message, InstallationUpdate handlers.
+        3. .csproj has Microsoft.Agents.A365.Notifications, Microsoft.Agents.A365.Tooling.Extensions.AgentFramework, Microsoft.Agents.A365.Observability.Extensions.AgentFramework.
+        4. ToolingManifest.json exists.
+        5. appsettings.json has AgentApplication, TokenValidation, Connections sections.
+        6. Build succeeds (dotnet build).
+
+        Python:
+        1. host_agent_server.py has CloudAdapterAiohttp, /api/messages, /api/health, on_notification.
+        2. agent.py implements AgentInterface with process_user_message, setup_mcp_servers.
+        3. token_cache.py exists with cache_agentic_token and get_cached_agentic_token.
+        4. agent_interface.py exists with AgentInterface ABC.
+        5. pyproject.toml has all microsoft_agents_a365_* dependencies.
+        6. ToolingManifest.json exists.
+        7. .env / .env.template has all required A365 variables.
+
         If any item failed or was skipped, return {"ok": false, "reason": "<specific item>"}.
         If all items completed successfully, return {"ok": true}.
       timeout: 45000
@@ -51,6 +72,8 @@ hooks:
 > AI Teammate layer — hosting, routing, observability, notifications, and WorkIQ tools. Your
 > existing LLM code (models, prompts, tools, business logic) is preserved and integrated into
 > the new structure. Nothing is deleted.
+>
+> **Supported languages:** Node.js (LangChain, OpenAI Agents SDK, Claude SDK) · .NET AgentFramework · Python AgentFramework
 
 ---
 
@@ -61,27 +84,66 @@ If `detectedAt` is within the last 60 minutes, load cached values and skip to Ph
 
 Run all detection steps **in parallel**:
 
-**Step 1: Detect LLM Framework** → Store as `agentStack`
+**Step 1: Detect Programming Language** → Store as `language`
+- `package.json` exists (and no `.csproj`, no `pyproject.toml`) → `NodeJS`
+- `*.csproj` file exists → `DotNet`
+- `pyproject.toml` exists → `Python`
+- Multiple markers found → prefer the most specific (`.csproj` > `pyproject.toml` > `package.json`)
+- None found → ask the user
+
+**Step 2: Detect LLM Framework** → Store as `agentStack`
+
+*NodeJS:*
 - `package.json` contains `@langchain` or `langchain` → `LangChain`
 - `package.json` contains `@openai/agents` → `OpenAI`
 - `package.json` contains `@anthropic-ai/sdk` → `Claude`
-- None found → ask the user (see Phase 0B)
+- None found → ask the user
 
-**Step 2: Detect Programming Language** → `NodeJS` if `package.json` exists, else stop.
+*DotNet:*
+- `*.csproj` contains `Microsoft.Agents.AI` or `Microsoft.Extensions.AI` → `AgentFramework`
+- `*.csproj` contains `Microsoft.SemanticKernel` → `SemanticKernel`
+- Default → `AgentFramework`
+
+*Python:*
+- `pyproject.toml` contains `agent-framework-azure-ai` → `AgentFramework`
+- `pyproject.toml` contains `openai` → `OpenAI`
+- `pyproject.toml` contains `anthropic` → `Claude`
+- Default → `AgentFramework`
 
 **Step 3: Find existing LLM entry point**
-- **Glob** `src/**/*.ts` and **Grep** for: LLM model instantiation (`ChatOpenAI`, `AzureChatOpenAI`,
-  `OpenAI`, `Anthropic`), chain/agent creation (`createAgent`, `createReactAgent`, `new OpenAI`),
-  or existing HTTP server (`express()`, `http.createServer`).
-- Store the main source file(s) as `existingFiles`.
+
+*NodeJS:* **Glob** `src/**/*.ts` and **Grep** for LLM instantiation (`ChatOpenAI`, `AzureChatOpenAI`, `OpenAI`, `Anthropic`), chain/agent creation, or existing HTTP server.
+
+*DotNet:* **Glob** `**/*.cs` and **Grep** for `AddAgent<`, `AgentApplication`, `IChatClient`, or `WebApplication.CreateBuilder`. Store `Program.cs` and agent `.cs` files.
+
+*Python:* **Glob** `**/*.py` and **Grep** for `ChatAgent`, `AzureOpenAIChatClient`, `CloudAdapterAiohttp`, or `AgentInterface`.
+
+Store the main source file(s) as `existingFiles`.
 
 **Step 4: Check what's already present**
-Run these **Grep** checks in parallel:
+
+*NodeJS — Grep in parallel:*
 - `AgentApplication` in `src/**/*.ts` → `hasAgentApp`
 - `CloudAdapter` in `src/**/*.ts` → `hasHosting`
 - `ObservabilityManager` in `src/**/*.ts` → `hasObservability`
 - `onAgentNotification` in `src/**/*.ts` → `hasNotifications`
 - `McpToolRegistrationService` in `src/**/*.ts` → `hasWorkIQ`
+- `ToolingManifest.json` exists → `hasManifest`
+
+*DotNet — Grep in parallel:*
+- `AgentApplication` in `**/*.cs` → `hasAgentApp`
+- `adapter.ProcessAsync` or `IAgentHttpAdapter` in `**/*.cs` → `hasHosting`
+- `AddAgenticTracingExporter` in `**/*.cs` → `hasObservability`
+- `OnConversationUpdate` or `InstallationUpdate` in `**/*.cs` → `hasNotifications`
+- `IMcpToolRegistrationService` in `**/*.cs` → `hasWorkIQ`
+- `ToolingManifest.json` exists → `hasManifest`
+
+*Python — Grep in parallel:*
+- `AgentInterface` or `AgentFrameworkAgent` in `**/*.py` → `hasAgentApp`
+- `CloudAdapterAiohttp` in `**/*.py` → `hasHosting`
+- `configure_observability` or `microsoft_agents_a365_observability` in `**/*.py` → `hasObservability`
+- `on_agent_notification` in `**/*.py` → `hasNotifications`
+- `McpToolRegistrationService` in `**/*.py` → `hasWorkIQ`
 - `ToolingManifest.json` exists → `hasManifest`
 
 ---
@@ -92,8 +154,8 @@ Present all detections in one message:
 
 ```
 Here's what we detected:
+  • Language:           {language}
   • LLM Framework:      {agentStack ?? "not detected"}
-  • Language:           NodeJS
   • Existing LLM code:  {existingFiles.join(', ') || "not found"}
 
 Already present:
@@ -103,27 +165,26 @@ Already present:
   • Notifications:      {hasNotifications ? "✅" : "❌"}
   • WorkIQ tools:       {hasWorkIQ ? "✅" : "❌"}
 
-Reply **yes** to confirm, or describe corrections (e.g. "it's OpenAI not LangChain").
+Reply **yes** to confirm, or describe corrections (e.g. "it's Python not .NET").
 ```
 
 After confirmation, write `.a365-workspace-detection.json`.
 
 If `agentStack` is still unknown, ask:
-> "Which LLM framework does this agent use? (LangChain / OpenAI Agents SDK / Claude SDK / Other)"
+> "Which LLM framework does this agent use?"
 
-If `agentStack` is `Other`, tell the user:
-> "This skill supports LangChain, OpenAI Agents SDK, and Claude SDK. For other frameworks,
-> I'll add the hosting layer and agent class, but you'll need to integrate your LLM calls
-> manually into `client.ts`."
+If `agentStack` is unrecognized, tell the user:
+> "This skill supports LangChain/OpenAI/Claude (Node.js), AgentFramework (Node.js/.NET/Python),
+> and SemanticKernel (.NET). For other frameworks, I'll add the hosting layer and agent class,
+> but you'll need to integrate your LLM calls manually."
 
 ---
 
 ## Phase 0C — Create Task List
 
-Create tasks only for items not already present (from `hasHosting`, `hasAgentApp`, etc.):
-
+**NodeJS tasks (only create if not already present):**
 ```
-TaskCreate: "Install required @microsoft/agents-* packages"
+TaskCreate: "Install required @microsoft/agents-* npm packages"
 TaskCreate: "Configure tsconfig.json for node16 module resolution"  [skip if already correct]
 TaskCreate: "Add src/token-cache.ts"                               [skip if exists]
 TaskCreate: "Add src/index.ts — Express + CloudAdapter hosting"    [skip if hasHosting]
@@ -131,75 +192,173 @@ TaskCreate: "Add src/agent.ts — AgentApplication class"            [skip if ha
 TaskCreate: "Add src/client.ts — client factory with observability" [skip if hasObservability]
 TaskCreate: "Add ToolingManifest.json"                             [skip if hasManifest]
 TaskCreate: "Update .env / .env.example with A365 variables"
-TaskCreate: "Validate build"
+TaskCreate: "Validate build (npm run build)"
 ```
 
-Always include install, env update, and build tasks — they are safe to re-run.
+**.NET tasks (only create if not already present):**
+```
+TaskCreate: "Add Microsoft.Agents.A365.* NuGet packages"
+TaskCreate: "Update Program.cs — A365 services + /api/messages + /api/health" [skip if hasHosting]
+TaskCreate: "Add Agent/MyAgent.cs — AgentApplication subclass"                 [skip if hasAgentApp]
+TaskCreate: "Update appsettings.json with A365 auth and connection config"
+TaskCreate: "Add ToolingManifest.json"                                          [skip if hasManifest]
+TaskCreate: "Validate build (dotnet build)"
+```
+
+**Python tasks (only create if not already present):**
+```
+TaskCreate: "Add microsoft_agents_a365_* to pyproject.toml"
+TaskCreate: "Add token_cache.py"                                    [skip if exists]
+TaskCreate: "Add agent_interface.py"                                [skip if exists]
+TaskCreate: "Add host_agent_server.py — aiohttp server + A365 routing" [skip if hasHosting]
+TaskCreate: "Update agent.py — AgentInterface implementation with MCP and notifications" [skip if hasAgentApp]
+TaskCreate: "Add ToolingManifest.json"                             [skip if hasManifest]
+TaskCreate: "Update .env / .env.template with A365 variables"
+TaskCreate: "Validate setup (uv sync or pip install)"
+```
+
+Always include install, env update, and build/sync tasks — they are safe to re-run.
 
 ---
 
 ## Phase 1 — Install Required Packages
 
-**Mark task in progress: "Install required @microsoft/agents-* packages"**
+**Mark task in progress.**
+
+### NodeJS
 
 **Read** `${CLAUDE_PLUGIN_ROOT}/skills/make-ai-teammate/references/nodejs-ai-teammate.md`
 for the package list for `{agentStack}`.
 
-**Grep** `package.json` for `@microsoft/agents-hosting`. If already present, check each
-required package individually and install only the missing ones.
+**Grep** `package.json` for `@microsoft/agents-hosting`. Install only missing packages:
 
 ```bash
-# Install all required packages for the detected framework in one command
-npm install <packages from reference doc>
+npm install @microsoft/agents-hosting @microsoft/agents-a365-observability \
+  @microsoft/agents-a365-observability-hosting @microsoft/agents-a365-notifications \
+  @microsoft/agents-a365-tooling-extensions-langchain  # (or -openai / -claude)
 ```
 
-Also install dev dependencies if missing (`typescript`, `ts-node`, `nodemon`, `@types/express`, `@types/node`).
+Also install dev dependencies if missing: `typescript`, `ts-node`, `@types/express`, `@types/node`.
+
+### .NET
+
+**Read** `${CLAUDE_PLUGIN_ROOT}/skills/make-ai-teammate/references/dotnet-ai-teammate.md`
+for the full package list.
+
+**Read** the `.csproj` file. Add only missing packages:
+
+```bash
+dotnet add package Microsoft.Agents.A365.Notifications --prerelease
+dotnet add package Microsoft.Agents.A365.Tooling.Extensions.AgentFramework --prerelease
+dotnet add package Microsoft.Agents.A365.Observability.Extensions.AgentFramework --prerelease
+dotnet add package Microsoft.Agents.AI --prerelease
+dotnet add package Microsoft.Agents.Authentication.Msal
+dotnet add package Microsoft.Agents.Hosting.AspNetCore
+dotnet add package Microsoft.Extensions.AI.OpenAI --prerelease
+dotnet add package Azure.AI.OpenAI --prerelease
+dotnet add package Azure.Identity
+dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
+dotnet add package OpenTelemetry.Extensions.Hosting
+dotnet add package OpenTelemetry.Instrumentation.AspNetCore
+dotnet add package OpenTelemetry.Instrumentation.Http
+dotnet add package OpenTelemetry.Instrumentation.Runtime
+```
+
+### Python
+
+**Read** `${CLAUDE_PLUGIN_ROOT}/skills/make-ai-teammate/references/python-ai-teammate.md`
+for the full dependency list.
+
+**Read** `pyproject.toml`. Add only missing `microsoft_agents_a365_*` dependencies, then sync:
+
+```bash
+uv add microsoft_agents_a365_tooling microsoft_agents_a365_tooling_extensions_agentframework \
+  microsoft_agents_a365_observability_core microsoft_agents_a365_observability_extensions_agent_framework \
+  microsoft_agents_a365_runtime microsoft_agents_a365_notifications \
+  microsoft-agents-hosting-aiohttp microsoft-agents-hosting-core \
+  microsoft-agents-authentication-msal python-dotenv aiohttp azure-identity
+uv sync
+# or: pip install -e .
+```
 
 **Mark task complete.**
 
 ---
 
-## Phase 2 — Configure tsconfig.json
+## Phase 2 — Language Setup
 
-**Mark task in progress: "Configure tsconfig.json for node16 module resolution"**
+**Mark task in progress.**
 
-**Read** `tsconfig.json` if it exists.
+### NodeJS — Configure tsconfig.json
 
-Check: `"module": "node16"` and `"moduleResolution": "node16"` are both present.
+**Read** `tsconfig.json` if it exists. Check `"module": "node16"` and `"moduleResolution": "node16"` are both present.
 
-If missing or wrong, **Edit** (or **Write** if not present) `tsconfig.json` using the exact
-config from the reference doc. Do NOT change `rootDir`/`outDir` if the user has customized them —
-only update the module resolution fields if they are wrong.
+If missing or wrong, **Edit** (or **Write** if not present) `tsconfig.json`:
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}
+```
+Do NOT change `rootDir`/`outDir` if the user has customized them — only update `module`/`moduleResolution`.
+
+### .NET — Skip
+
+No tsconfig equivalent needed. Proceed to Phase 3.
+
+### Python — Skip
+
+No tsconfig equivalent needed. Proceed to Phase 3.
 
 **Mark task complete.**
 
 ---
 
-## Phase 3 — Add src/token-cache.ts
+## Phase 3 — Token Cache
 
-**Mark task in progress: "Add src/token-cache.ts"**
+**Mark task in progress.**
 
-**Glob** `src/token-cache.ts`. If it exists, **Read** it — check that `createAgenticTokenCacheKey`,
-`tokenResolver`, and the default export are all present. Add anything missing.
+### NodeJS — Add src/token-cache.ts
 
-If it does not exist, **Write** `src/token-cache.ts` using the exact pattern from the reference doc.
+**Glob** `src/token-cache.ts`. If it exists, **Read** it and check for `createAgenticTokenCacheKey`,
+`tokenResolver`, and the default export. Add anything missing.
+
+If it does not exist, **Write** `src/token-cache.ts` using the pattern from `nodejs-ai-teammate.md`.
+
+### .NET — Skip
+
+Token cache is handled by `IExporterTokenCache<AgenticTokenStruct>` injected by the A365 SDK. No file to create.
+
+### Python — Add token_cache.py
+
+**Glob** `token_cache.py`. If it exists, check for `cache_agentic_token` and `get_cached_agentic_token`.
+
+If it does not exist, **Write** `token_cache.py` using the exact pattern from `python-ai-teammate.md`.
 
 **Mark task complete.**
 
 ---
 
-## Phase 4 — Add src/index.ts — Hosting Layer
+## Phase 4 — Hosting Layer
 
-**Mark task in progress: "Add src/index.ts — Express + CloudAdapter hosting"**
+**Mark task in progress.**
+
+### NodeJS — Add src/index.ts
 
 **Read** `src/index.ts` if it exists.
 
-### If index.ts does NOT exist or has no CloudAdapter:
+**If index.ts does NOT exist or has no CloudAdapter:**
+**Write** `src/index.ts` using the pattern from `nodejs-ai-teammate.md`.
 
-**Write** `src/index.ts` using the pattern from the reference doc.
-
-### If index.ts already has an HTTP server (Express or other):
-
+**If index.ts already has an HTTP server (Express or other):**
 Migrate it to the CloudAdapter pattern:
 1. Add `configDotenv()` as the very first line (before existing imports).
 2. Replace or augment the existing server with `CloudAdapter`, `authorizeJWT`, and `loadAuthConfigFromEnv`.
@@ -210,50 +369,113 @@ Migrate it to the CloudAdapter pattern:
 
 > **Non-destructive rule:** Never delete existing routes. Add the A365 routes alongside them.
 
+### .NET — Update Program.cs
+
+**Read** `Program.cs` if it exists.
+
+**If Program.cs does NOT exist:**
+**Write** `Program.cs` using the pattern from `dotnet-ai-teammate.md`.
+
+**If Program.cs exists but is missing A365 services:**
+**Edit** `Program.cs` to add:
+1. `builder.Services.AddAgenticTracingExporter(clusterCategory: "production")` — A365 exporter
+2. `builder.AddA365Tracing(config => config.WithAgentFramework())` — tracing provider
+3. `builder.Services.AddSingleton<IMcpToolRegistrationService, McpToolRegistrationService>()` — WorkIQ tooling
+4. `builder.Services.AddSingleton<IMcpToolServerConfigurationService, McpToolServerConfigurationService>()` — manifest reader
+5. `app.MapPost("/api/messages", ...)` using `adapter.ProcessAsync()`
+6. `app.MapGet("/api/health", () => Results.Ok(...))` — health check endpoint, NO auth required
+
+> **Non-destructive rule:** Preserve existing services and middleware. Add A365 registrations after existing ones.
+
+### Python — Add host_agent_server.py
+
+**Glob** `host_agent_server.py`. If it exists, check for `CloudAdapterAiohttp`, `/api/messages`, `/api/health`, and `on_agent_notification`.
+
+If it does not exist, **Write** `host_agent_server.py` using the pattern from `python-ai-teammate.md`.
+Also create `agent_interface.py` using the pattern from `python-ai-teammate.md` if it does not exist.
+
 **Mark task complete.**
 
 ---
 
-## Phase 5 — Add src/agent.ts — Agent Class
+## Phase 5 — Agent Class
 
-**Mark task in progress: "Add src/agent.ts — AgentApplication class"**
+**Mark task in progress.**
+
+### NodeJS — Add src/agent.ts
 
 **Read** `src/agent.ts` if it exists. **Grep** `AgentApplication` in `src/**/*.ts`.
 
-### If agent.ts does NOT exist:
+**If agent.ts does NOT exist:**
+**Write** `src/agent.ts` using the full pattern from `nodejs-ai-teammate.md`.
+- Replace `MyAgent` class name with a name derived from the project.
+- Replace placeholder session description with what the agent does.
 
-**Write** `src/agent.ts` using the full pattern from the reference doc.
-- Replace `MyAgent` class name with a name derived from the project (e.g., from `package.json` `name` field).
-- Replace `'user turn'` in `sessionDescription` with a brief description of what the agent does.
+**If an AgentApplication subclass already exists:**
+Check each handler and add only what is missing:
+- `onAgentNotification('agents:*', ...)` with priority `1` and `[authHandlerName]`
+- `onActivity(ActivityTypes.Message, ...)` with `[authHandlerName]`
+- `onActivity(ActivityTypes.InstallationUpdate, ...)`
+- `preloadObservabilityToken()`
+- `handleAgentNotificationActivity()` dispatching on `NotificationType.EmailNotification`
+- `handleEmailNotification()` using `createEmailResponseActivity`
+- `handleInstallationUpdateActivity()`
+- Typing indicator loop (setInterval every 4000ms) in message handler
 
-### If an AgentApplication subclass already exists:
+> **Critical import:** `import '@microsoft/agents-a365-notifications'` (side-effect form) must be present.
+> Without it, notification routing silently breaks at runtime.
 
-Read the existing class and check each handler:
-- `onAgentNotification('agents:*', ...)` with priority `1` and `[authHandlerName]` — add if missing
-- `onActivity(ActivityTypes.Message, ...)` with `[authHandlerName]` — add auth restriction if missing
-- `onActivity(ActivityTypes.InstallationUpdate, ...)` — add if missing
-- `preloadObservabilityToken()` — add if missing
-- `handleAgentNotificationActivity()` dispatching on `NotificationType.EmailNotification` — add if missing
-- `handleEmailNotification()` using `createEmailResponseActivity` — add if missing
-- `handleInstallationUpdateActivity()` — add if missing
-- Typing indicator loop pattern in message handler — add if missing
+### .NET — Add Agent/MyAgent.cs
 
-Add only what is missing. Do not restructure existing code.
+**Glob** `**/*.cs` and **Grep** for `AgentApplication`.
 
-> **Critical import:** Ensure `import '@microsoft/agents-a365-notifications'` (side-effect form)
-> is present in this file. Without it, notification routing silently breaks.
+**If no AgentApplication subclass exists:**
+Create `Agent/MyAgent.cs` using the full pattern from `dotnet-ai-teammate.md`.
+- Rename `MyAgent` to match the project name (from `.csproj`).
+- Register agent in `Program.cs`: `builder.AddAgent<MyAgent>();`
+
+**If an AgentApplication subclass already exists:**
+Check each registration and add only what is missing:
+- `OnConversationUpdate(ConversationUpdateEvents.MembersAdded, WelcomeMessageAsync)`
+- `OnActivity(ActivityTypes.InstallationUpdate, OnInstallationUpdateAsync, isAgenticOnly: true, autoSignInHandlers: agenticHandlers)`
+- `OnActivity(ActivityTypes.InstallationUpdate, OnInstallationUpdateAsync, isAgenticOnly: false)`
+- `OnActivity(ActivityTypes.Message, OnMessageAsync, isAgenticOnly: true, autoSignInHandlers: agenticHandlers)`
+- `OnActivity(ActivityTypes.Message, OnMessageAsync, isAgenticOnly: false, autoSignInHandlers: oboHandlers)`
+- Typing indicator loop (4 second interval) in `OnMessageAsync`
+- `GetClientAgent()` calling `toolService.GetMcpToolsAsync()`
+
+> **Prompt injection guard:** `GetAgentInstructions()` must sanitize `Activity.From.Name`
+> by stripping control characters (`[\p{Cc}\p{Cf}]`) and capping at 64 characters.
+
+### Python — Update agent.py
+
+**Read** `agent.py` if it exists.
+
+**If agent.py does NOT implement `AgentInterface`:**
+**Write** `agent.py` using the full pattern from `python-ai-teammate.md`.
+- Preserve existing LLM client configuration (endpoint, deployment, API key env vars).
+- Preserve existing system prompt if one exists.
+
+**If agent.py already implements `AgentInterface`:**
+Check and add only what is missing:
+- `_sanitize_display_name()` before injecting into system prompt
+- `setup_mcp_servers()` calling `McpToolRegistrationService().add_tool_servers_to_agent()`
+- `handle_agent_notification_activity()` handling `NotificationType.EMAIL_NOTIFICATION`
+- `token_resolver()` method using `get_cached_agentic_token()`
 
 **Mark task complete.**
 
 ---
 
-## Phase 6 — Add src/client.ts — Client Factory
+## Phase 6 — Client Factory / Observability Integration
 
-**Mark task in progress: "Add src/client.ts — client factory with observability"**
+**Mark task in progress: "Add client factory with observability"**
+
+### NodeJS — Add src/client.ts
 
 This is the most important integration step — it wraps the user's existing LLM code.
 
-### 6.1 Read existing LLM code
+**6.1 Read existing LLM code**
 
 **Read** all files in `existingFiles`. Identify:
 - How the LLM model is instantiated (constructor, env vars used)
@@ -261,33 +483,48 @@ This is the most important integration step — it wraps the user's existing LLM
 - How the LLM is invoked (method name, input/output format)
 - Any existing tools or system prompts
 
-### 6.2 If client.ts does NOT exist
-
-**Write** `src/client.ts` using the `{agentStack}` variant from the reference doc.
-- Preserve the user's existing model instantiation (API keys, deployment names, etc.)
-- Preserve the user's existing system prompt if one exists — replace the placeholder
+**6.2 If client.ts does NOT exist:**
+**Write** `src/client.ts` using the `{agentStack}` variant from `nodejs-ai-teammate.md`.
+- Preserve the user's existing model instantiation and env vars
+- Preserve the user's existing system prompt if one exists
 - Preserve any existing tools or LangGraph configurations
 
-### 6.3 If client.ts already exists
-
+**6.3 If client.ts already exists:**
 Check for each required element and add what is missing:
 - `ObservabilityManager.configure().start()` at module level before other imports
 - `Agent365ExporterOptions` with `maxQueueSize: 10` and `withExporterOptions()`
-- Token resolver using `AgenticTokenCacheInstance.getObservabilityToken` (or custom when
-  `Use_Custom_Resolver=true`)
+- Token resolver using `AgenticTokenCacheInstance.getObservabilityToken`
 - `McpToolRegistrationService` module-level singleton
 - `getClient()` factory calling `toolService.addToolServersToAgent()`
-- `Client` interface with `invokeInferenceScope(prompt: string): Promise<string>`
 - `invokeInferenceScope()` using `InferenceScope.start()` with `withActiveSpanAsync`,
-  `recordInputMessages`, `recordOutputMessages`, `recordFinishReasons`, and `scope.dispose()`
-  in a `finally` block
+  `recordInputMessages`, `recordOutputMessages`, `recordFinishReasons`, and `scope.dispose()` in `finally`
 
-### 6.4 Wire existing LLM invocation
+**6.4 Wire existing LLM invocation:**
+The user's existing LLM invocation goes INSIDE `invokeInferenceScope()`. Show the user a diff summary.
 
-The user's existing LLM invocation goes INSIDE `invokeInferenceScope()` where the `invokeAgent()`
-call is. If the user's invocation is in a different file, import it or inline it here.
+### .NET — Verify Program.cs observability wiring
 
-Show the user a diff summary of what was added to their existing code.
+The observability services are registered in `Program.cs` (Phase 4). Verify:
+- `AddAgenticTracingExporter` is before `AddA365Tracing`
+- `IChatClient` uses `.UseOpenTelemetry()` on the builder chain
+- `IExporterTokenCache<AgenticTokenStruct>` is injected into the agent constructor
+
+If any are missing, **Edit** `Program.cs` to add them.
+
+The user's existing LLM invocation is preserved inside `GetClientAgent()` in `MyAgent.cs`.
+Wrap it with `AgentMetrics.InvokeObservedAgentOperation()` if not already present.
+
+### Python — Verify observability in host_agent_server.py
+
+The observability is configured via `configure_observability()` in `start_server()` (Phase 4).
+Verify in `agent.py`:
+- `token_resolver()` method is implemented using `get_cached_agentic_token()`
+- `setup_mcp_servers()` calls `McpToolRegistrationService().add_tool_servers_to_agent()`
+- `process_user_message()` calls `setup_mcp_servers()` before running the LLM
+
+The user's existing LLM invocation (e.g., `self._agent.run(message)`) is preserved inside
+`process_user_message()`. Wrap with observability spans if the `microsoft_agents_a365_observability_core`
+package provides an inference scope.
 
 **Mark task complete.**
 
@@ -315,33 +552,71 @@ If it already exists, leave it unchanged.
 
 ---
 
-## Phase 8 — Update .env / .env.example
+## Phase 8 — Update Environment Configuration
 
-**Mark task in progress: "Update .env / .env.example with A365 variables"**
+**Mark task in progress: "Update env config with A365 variables"**
 
-**Read** `.env.example` or `.env` — whichever exists. Identify which A365 variables are missing.
+### NodeJS — Update .env / .env.example
 
-Add only the missing variables from the reference doc template, appended to the end of the
-existing file. Do NOT overwrite or reorder existing variables.
+**Read** `.env.example` or `.env`. Append only the missing variables:
 
-Variables to ensure are present:
-- `ENABLE_A365_OBSERVABILITY_EXPORTER=false`
-- `Use_Custom_Resolver=false`
-- `A365_OBSERVABILITY_LOG_LEVEL=`
-- `SERVICE_NAME=my-agent`
-- `BEARER_TOKEN=`
-- `NODE_ENV=development`
-- `PORT=3978`
-- `agentic_type=agentic`
-- `agentic_altBlueprintConnectionName=service_connection`
-- `agentic_scopes=ea9ffc3e-8a23-4a7d-836d-234d7c7565c1/.default`
-- `connections__service_connection__settings__clientId=`
-- `connections__service_connection__settings__clientSecret=`
-- `connections__service_connection__settings__tenantId=`
-- `connectionsMap__0__serviceUrl=*`
-- `connectionsMap__0__connection=service_connection`
+```dotenv
+ENABLE_A365_OBSERVABILITY_EXPORTER=false
+Use_Custom_Resolver=false
+A365_OBSERVABILITY_LOG_LEVEL=
+SERVICE_NAME=my-agent
+BEARER_TOKEN=
+NODE_ENV=development
+PORT=3978
+agentic_type=agentic
+agentic_altBlueprintConnectionName=service_connection
+agentic_scopes=ea9ffc3e-8a23-4a7d-836d-234d7c7565c1/.default
+connections__service_connection__settings__clientId=
+connections__service_connection__settings__clientSecret=
+connections__service_connection__settings__tenantId=
+connectionsMap__0__serviceUrl=*
+connectionsMap__0__connection=service_connection
+```
 
-Also add the LLM variables for the detected framework if not already present.
+Also add the LLM framework env vars if not already present.
+
+### .NET — Update appsettings.json
+
+**Read** `appsettings.json` if it exists. Add any missing sections using the pattern
+from `dotnet-ai-teammate.md`:
+
+- `AgentApplication` section with `AgenticAuthHandlerName` and `UserAuthorization.Handlers.agentic`
+- `TokenValidation` section with `Audiences`
+- `Connections.ServiceConnection` section
+- `ConnectionsMap` array
+- `AIServices.AzureOpenAI` section (with placeholder values `""`)
+
+Do NOT overwrite existing values — only add missing keys.
+
+### Python — Update .env / .env.template
+
+**Read** `.env.template` or `.env`. Append only the missing variables from `python-ai-teammate.md`:
+
+```dotenv
+AUTH_HANDLER_NAME=
+BEARER_TOKEN=
+AZURE_OPENAI_API_KEY=
+AZURE_OPENAI_ENDPOINT=
+AZURE_OPENAI_DEPLOYMENT=
+AZURE_OPENAI_API_VERSION=2024-05-01-preview
+CONNECTIONS__SERVICE_CONNECTION__SETTINGS__CLIENTID=
+CONNECTIONS__SERVICE_CONNECTION__SETTINGS__CLIENTSECRET=
+CONNECTIONS__SERVICE_CONNECTION__SETTINGS__TENANTID=
+CONNECTIONSMAP_0_SERVICEURL=*
+CONNECTIONSMAP_0_CONNECTION=SERVICE_CONNECTION
+USE_AGENTIC_AUTH=true
+OBSERVABILITY_SERVICE_NAME=my-agent
+OBSERVABILITY_SERVICE_NAMESPACE=agents
+ENABLE_OBSERVABILITY=true
+ENABLE_A365_OBSERVABILITY_EXPORTER=false
+PORT=3978
+PYTHON_ENVIRONMENT=development
+```
 
 **Mark task complete.**
 
@@ -351,16 +626,35 @@ Also add the LLM variables for the detected framework if not already present.
 
 **Mark task in progress: "Validate build"**
 
+### NodeJS
 ```bash
 npm install
 npm run build || npx tsc --noEmit
 ```
-
-If the build fails, show the errors and fix them:
-- Missing type imports → add the correct `@types/*` package
-- Module resolution errors → check `tsconfig.json` `module`/`moduleResolution`
-- Import path errors → check `.ts` extension in imports for `node16` module resolution
+Fix errors:
+- Module resolution errors → check `"module": "node16"` AND `"moduleResolution": "node16"` in tsconfig
+- Import path errors → add `.js` extension in imports for `node16` module resolution
 - `Cannot find module` → add the missing package
+
+### .NET
+```bash
+dotnet restore
+dotnet build
+```
+Fix errors:
+- `namespace not found` → check the package is installed and using directive is present
+- `IChatClient` not found → ensure `Microsoft.Extensions.AI.OpenAI` is installed
+- `IAgentHttpAdapter` not found → ensure `Microsoft.Agents.Hosting.AspNetCore` is installed
+
+### Python
+```bash
+uv sync
+# or: pip install -e .
+python -c "import host_agent_server; import agent; print('imports OK')"
+```
+Fix errors:
+- `ModuleNotFoundError` for `microsoft_agents_a365_*` → run `uv add <package>` or `pip install <package>`
+- `requires-python` mismatch → ensure Python 3.11+ is active
 
 Do NOT revert changes on build failure — fix forward.
 
@@ -372,6 +666,7 @@ Do NOT revert changes on build failure — fix forward.
 
 **TaskList** — show all completed tasks.
 
+### NodeJS summary:
 ```
 ✅ AI Teammate transformation complete!
 
@@ -388,21 +683,63 @@ Next steps:
   2. Test locally:    npm run dev  (starts on http://127.0.0.1:3978)
   3. Health check:    curl http://localhost:3978/api/health
   4. Add WorkIQ tools: run the add-workiq-tools skill
-  5. Deploy your agent to a hosting provider and run a365 setup to register the endpoint
+```
+
+### .NET summary:
+```
+✅ AI Teammate transformation complete!
+
+Your agent now has:
+  • Hosting layer:     ASP.NET Core + IAgentHttpAdapter + /api/health + /api/messages
+  • Agent class:       AgentApplication subclass with message, InstallationUpdate handlers
+  • Observability:     AddAgenticTracingExporter + AddA365Tracing + UseOpenTelemetry on IChatClient
+  • WorkIQ tools:      IMcpToolRegistrationService + IMcpToolServerConfigurationService
+  • Auth:              AgenticAuthHandlerName (production) + OboAuthHandlerName (Playground)
+
+Next steps:
+  1. Set appsettings.json ClientId, BOT_ID, BOT_TENANT_ID placeholders
+  2. Run: a365 setup  — register a Blueprint and messaging endpoint
+  3. Test locally:    dotnet run  (starts on http://localhost:3978)
+  4. Health check:    curl http://localhost:3978/api/health
+  5. Add WorkIQ tools: run the add-workiq-tools skill
+```
+
+### Python summary:
+```
+✅ AI Teammate transformation complete!
+
+Your agent now has:
+  • Hosting layer:     aiohttp server + CloudAdapterAiohttp + /api/health + /api/messages
+  • Agent class:       AgentInterface implementation with MCP tooling and notification handling
+  • Observability:     configure_observability() with token resolver
+  • WorkIQ tools:      McpToolRegistrationService.add_tool_servers_to_agent()
+  • Token cache:       token_cache.py with cache_agentic_token / get_cached_agentic_token
+
+Next steps:
+  1. Fill .env with Azure OpenAI credentials and connection settings
+  2. Run: a365 setup  — register a Blueprint and messaging endpoint
+  3. Test locally:    python host_agent_server.py  (starts on port 3978)
+  4. Health check:    curl http://localhost:3978/api/health
+  5. Add WorkIQ tools: run the add-workiq-tools skill
 ```
 
 ---
 
 ## Error Handling
 
-| Situation | Action |
-|-----------|--------|
-| `agentStack` not detected | Ask the user; default to LangChain patterns if still unclear |
-| Existing `index.ts` has complex custom middleware | Preserve it; add A365 routes alongside existing ones |
-| `client.ts` uses a framework not in reference (e.g., LlamaIndex) | Add hosting + agent layers; add observability init; leave LLM invocation as-is and tell user what to integrate manually |
-| Build fails with `module` errors | Ensure both `"module": "node16"` AND `"moduleResolution": "node16"` in tsconfig |
-| Build fails with `import ... from 'langchain'` not found | Run `npm install langchain @langchain/core @langchain/openai @langchain/langgraph` |
-| `AgentApplication` import not found | Check `@microsoft/agents-hosting` is installed |
+| Situation | Language | Action |
+|-----------|----------|--------|
+| `agentStack` not detected | Any | Ask the user; default to AgentFramework patterns |
+| Existing `index.ts` has complex custom middleware | NodeJS | Preserve it; add A365 routes alongside existing ones |
+| `client.ts` uses unrecognized framework (e.g., LlamaIndex) | NodeJS | Add hosting + agent layers; stub `invokeInferenceScope`; tell user what to fill in |
+| Build fails with `module` errors | NodeJS | Ensure both `"module": "node16"` AND `"moduleResolution": "node16"` in tsconfig |
+| `AgentApplication` import not found | NodeJS | Check `@microsoft/agents-hosting` is installed |
+| `IAgentHttpAdapter` not found | .NET | Ensure `Microsoft.Agents.Hosting.AspNetCore` is referenced |
+| `IChatClient` not found | .NET | Ensure `Microsoft.Extensions.AI.OpenAI` is installed |
+| `Microsoft.Agents.A365.*` not found after dotnet add | .NET | Add `--prerelease` flag; check NuGet source includes prerelease feeds |
+| `ModuleNotFoundError` for `microsoft_agents_a365_*` | Python | Run `uv add <package> --prerelease` or ensure PyPI prerelease index is configured |
+| `requires-python` version mismatch | Python | Ensure Python 3.11+ is active in the virtual environment |
+| `USE_AGENTIC_AUTH=false` — MCP tools not loading | Python | Expected in dev mode; set to `true` and provide `BEARER_TOKEN` for production testing |
 
 ---
 
@@ -415,9 +752,18 @@ Never overwrite a file that already has the required pattern — only add what i
 
 ## References
 
-- **Reference patterns:** `${CLAUDE_PLUGIN_ROOT}/skills/make-ai-teammate/references/nodejs-ai-teammate.md`
-- **Agent detection:** `${CLAUDE_PLUGIN_ROOT}/shared/agent-detection.md`
-- **Observability details:** `${CLAUDE_PLUGIN_ROOT}/skills/instrument-observability/references/nodejs-observability.md`
-- **WorkIQ tools:** `${CLAUDE_PLUGIN_ROOT}/skills/add-workiq-tools/references/nodejs-workiq.md`
-- **Notifications:** `${CLAUDE_PLUGIN_ROOT}/skills/make-ai-teammate/references/nodejs-notifications.md`
+**Node.js patterns:**
+- `${CLAUDE_PLUGIN_ROOT}/skills/make-ai-teammate/references/nodejs-ai-teammate.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/make-ai-teammate/references/nodejs-notifications.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/instrument-observability/references/nodejs-observability.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/add-workiq-tools/references/nodejs-workiq.md`
+
+**.NET patterns:**
+- `${CLAUDE_PLUGIN_ROOT}/skills/make-ai-teammate/references/dotnet-ai-teammate.md`
+
+**Python patterns:**
+- `${CLAUDE_PLUGIN_ROOT}/skills/make-ai-teammate/references/python-ai-teammate.md`
+
+**Shared:**
+- `${CLAUDE_PLUGIN_ROOT}/shared/agent-detection.md`
 - **Blueprint registration:** run the `a365-setup` skill after this skill completes

--- a/plugins/agent365/skills/make-ai-teammate/references/dotnet-ai-teammate.md
+++ b/plugins/agent365/skills/make-ai-teammate/references/dotnet-ai-teammate.md
@@ -1,0 +1,499 @@
+# .NET AI Teammate Reference Patterns
+
+Authoritative code patterns for the `make-ai-teammate` skill — .NET AgentFramework variant.
+Source: [Agent365-Samples/dotnet/agent-framework/sample-agent](https://github.com/microsoft/Agent365-Samples/tree/main/dotnet/agent-framework/sample-agent)
+
+---
+
+## Required NuGet Packages
+
+Add to the `.csproj` file:
+
+```xml
+<!-- A365 SDK Packages -->
+<PackageReference Include="Microsoft.Agents.A365.Notifications" Version="*-beta.*" />
+<PackageReference Include="Microsoft.Agents.A365.Tooling.Extensions.AgentFramework" Version="*-beta.*" />
+<PackageReference Include="Microsoft.Agents.A365.Observability.Extensions.AgentFramework" Version="*-beta.*" />
+
+<!-- Agent Framework Packages -->
+<PackageReference Include="Microsoft.Agents.AI" Version="1.0.0-preview.*" />
+<PackageReference Include="Microsoft.Agents.Authentication.Msal" Version="1.3.*-*" />
+<PackageReference Include="Microsoft.Agents.Hosting.AspNetCore" Version="1.3.*-*" />
+<PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.10.0-preview.*" />
+<PackageReference Include="Azure.AI.OpenAI" Version="2.5.0-beta.*" />
+<PackageReference Include="Azure.Identity" Version="1.17.0" />
+
+<!-- OpenTelemetry -->
+<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+<PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+<PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
+```
+
+Install via dotnet CLI (example):
+```bash
+dotnet add package Microsoft.Agents.A365.Notifications --prerelease
+dotnet add package Microsoft.Agents.A365.Tooling.Extensions.AgentFramework --prerelease
+dotnet add package Microsoft.Agents.A365.Observability.Extensions.AgentFramework --prerelease
+dotnet add package Microsoft.Agents.AI --prerelease
+dotnet add package Microsoft.Agents.Authentication.Msal
+dotnet add package Microsoft.Agents.Hosting.AspNetCore
+dotnet add package Microsoft.Extensions.AI.OpenAI --prerelease
+dotnet add package Azure.AI.OpenAI --prerelease
+dotnet add package Azure.Identity
+dotnet add package OpenTelemetry.Exporter.OpenTelemetryProtocol
+dotnet add package OpenTelemetry.Extensions.Hosting
+dotnet add package OpenTelemetry.Instrumentation.AspNetCore
+dotnet add package OpenTelemetry.Instrumentation.Http
+dotnet add package OpenTelemetry.Instrumentation.Runtime
+```
+
+---
+
+## Program.cs — Startup / Service Registration
+
+```csharp
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using YourNamespace;
+using YourNamespace.Agent;
+using Microsoft.Agents.A365.Observability;
+using Microsoft.Agents.A365.Observability.Extensions.AgentFramework;
+using Microsoft.Agents.A365.Tooling.Extensions.AgentFramework.Services;
+using Microsoft.Agents.A365.Tooling.Services;
+using Microsoft.Agents.Builder;
+using Microsoft.Agents.Hosting.AspNetCore;
+using Microsoft.Agents.Storage;
+using Microsoft.Extensions.AI;
+using Azure;
+using Azure.AI.OpenAI;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// OpenTelemetry (Aspire service defaults or manual setup)
+builder.ConfigureOpenTelemetry();
+
+builder.Services.AddControllers();
+builder.Services.AddHttpClient();
+builder.Services.AddHttpContextAccessor();
+builder.Logging.AddConsole();
+
+// ────── A365 Services ──────────────────────────────────────────────────────
+
+// A365 agentic tracing exporter (sends spans to Microsoft Defender)
+builder.Services.AddAgenticTracingExporter(clusterCategory: "production");
+
+// A365 tracing with Agent Framework integration
+builder.AddA365Tracing(config =>
+{
+    config.WithAgentFramework();
+});
+
+// WorkIQ MCP tooling service (loaded per-turn from ToolingManifest.json)
+builder.Services.AddSingleton<IMcpToolRegistrationService, McpToolRegistrationService>();
+builder.Services.AddSingleton<IMcpToolServerConfigurationService, McpToolServerConfigurationService>();
+
+// ────── Auth & Storage ─────────────────────────────────────────────────────
+
+builder.Services.AddAgentAspNetAuthentication(builder.Configuration);
+builder.Services.AddSingleton<IStorage, MemoryStorage>();
+
+// ────── Agent ─────────────────────────────────────────────────────────────
+
+builder.AddAgentApplicationOptions();
+builder.AddAgent<MyAgent>();  // Replace MyAgent with your agent class name
+
+// ────── IChatClient (Azure OpenAI) ────────────────────────────────────────
+
+builder.Services.AddSingleton<IChatClient>(sp =>
+{
+    var config = sp.GetRequiredService<IConfiguration>();
+    var endpoint  = config["AIServices:AzureOpenAI:Endpoint"] ?? string.Empty;
+    var apiKey    = config["AIServices:AzureOpenAI:ApiKey"] ?? string.Empty;
+    var deployment = config["AIServices:AzureOpenAI:DeploymentName"] ?? string.Empty;
+
+    return new AzureOpenAIClient(new Uri(endpoint), new AzureKeyCredential(apiKey))
+        .GetChatClient(deployment)
+        .AsIChatClient()
+        .AsBuilder()
+        .UseFunctionInvocation()
+        .UseOpenTelemetry(sourceName: "agent.inference",
+            configure: cfg => cfg.EnableSensitiveData = true)
+        .Build();
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+    app.UseDeveloperExceptionPage();
+
+app.UseRouting();
+app.UseAuthentication();
+app.UseAuthorization();
+
+// /api/messages — main Teams / A365 message endpoint
+app.MapPost("/api/messages", async (HttpRequest request, HttpResponse response,
+    IAgentHttpAdapter adapter, IAgent agent, CancellationToken cancellationToken) =>
+{
+    await adapter.ProcessAsync(request, response, agent, cancellationToken);
+});
+
+// /api/health — health check (no auth required)
+app.MapGet("/api/health", () => Results.Ok(new { status = "healthy", timestamp = DateTime.UtcNow }));
+
+if (app.Environment.IsDevelopment() || app.Environment.EnvironmentName == "Playground")
+{
+    app.MapGet("/", () => "Agent Framework Sample Agent");
+    app.UseDeveloperExceptionPage();
+    app.MapControllers().AllowAnonymous();
+    app.Urls.Add("http://localhost:3978");
+}
+else
+{
+    app.MapControllers();
+}
+
+app.Run();
+```
+
+---
+
+## Agent/MyAgent.cs — AgentApplication Subclass
+
+```csharp
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Agents.A365.Observability.Caching;
+using Microsoft.Agents.A365.Runtime.Utils;
+using Microsoft.Agents.A365.Tooling.Extensions.AgentFramework.Services;
+using Microsoft.Agents.AI;
+using Microsoft.Agents.Builder;
+using Microsoft.Agents.Builder.App;
+using Microsoft.Agents.Builder.State;
+using Microsoft.Agents.Core.Models;
+using Microsoft.Extensions.AI;
+using System.Collections.Concurrent;
+
+namespace YourNamespace.Agent
+{
+    public class MyAgent : AgentApplication
+    {
+        private const string AgentWelcomeMessage = "Hello! I can help you find information based on what I can access.";
+        private const string AgentHireMessage = "Thank you for hiring me! Looking forward to assisting you!";
+        private const string AgentFarewellMessage = "Thank you for your time, I enjoyed working with you.";
+
+        // Non-interpolated raw string — {{ToolName}} placeholders are literal.
+        // {userName} is the ONLY dynamic token; injected via GetAgentInstructions().
+        private static readonly string AgentInstructionsTemplate = """
+        You will speak like a friendly and professional virtual assistant.
+
+        The user's name is {userName}. Use their name naturally where appropriate.
+
+        Use the tools available to you to help answer the user's questions.
+        """;
+
+        private static string GetAgentInstructions(string? userName)
+        {
+            string safe = string.IsNullOrWhiteSpace(userName) ? "unknown" : userName.Trim();
+            // Strip control characters to prevent prompt injection
+            safe = System.Text.RegularExpressions.Regex.Replace(safe, @"[\p{Cc}\p{Cf}]", " ").Trim();
+            if (safe.Length > 64) safe = safe[..64].TrimEnd();
+            if (string.IsNullOrWhiteSpace(safe)) safe = "unknown";
+            return AgentInstructionsTemplate.Replace("{userName}", safe, StringComparison.Ordinal);
+        }
+
+        private readonly IChatClient? _chatClient;
+        private readonly IConfiguration? _configuration;
+        private readonly IExporterTokenCache<AgenticTokenStruct>? _agentTokenCache;
+        private readonly ILogger<MyAgent>? _logger;
+        private readonly IMcpToolRegistrationService? _toolService;
+        private readonly string? AgenticAuthHandlerName;
+        private readonly string? OboAuthHandlerName;
+        private static readonly ConcurrentDictionary<string, List<AITool>> _agentToolCache = new();
+
+        public static bool TryGetBearerTokenForDevelopment(out string? bearerToken)
+        {
+            bearerToken = Environment.GetEnvironmentVariable("BEARER_TOKEN");
+            return !string.IsNullOrEmpty(bearerToken);
+        }
+
+        public MyAgent(
+            AgentApplicationOptions options,
+            IChatClient chatClient,
+            IConfiguration configuration,
+            IExporterTokenCache<AgenticTokenStruct> agentTokenCache,
+            IMcpToolRegistrationService toolService,
+            ILogger<MyAgent> logger) : base(options)
+        {
+            _chatClient = chatClient;
+            _configuration = configuration;
+            _agentTokenCache = agentTokenCache;
+            _logger = logger;
+            _toolService = toolService;
+
+            AgenticAuthHandlerName = _configuration.GetValue<string>("AgentApplication:AgenticAuthHandlerName");
+            OboAuthHandlerName = _configuration.GetValue<string>("AgentApplication:OboAuthHandlerName");
+
+            var agenticHandlers = !string.IsNullOrEmpty(AgenticAuthHandlerName)
+                ? [AgenticAuthHandlerName] : Array.Empty<string>();
+            var oboHandlers = !string.IsNullOrEmpty(OboAuthHandlerName)
+                ? [OboAuthHandlerName] : Array.Empty<string>();
+
+            // Greet new members
+            OnConversationUpdate(ConversationUpdateEvents.MembersAdded, WelcomeMessageAsync);
+
+            // Install/uninstall lifecycle — dual registration for agentic and non-agentic
+            OnActivity(ActivityTypes.InstallationUpdate, OnInstallationUpdateAsync,
+                isAgenticOnly: true, autoSignInHandlers: agenticHandlers);
+            OnActivity(ActivityTypes.InstallationUpdate, OnInstallationUpdateAsync,
+                isAgenticOnly: false);
+
+            // Message handlers — must come AFTER all other activity handlers
+            OnActivity(ActivityTypes.Message, OnMessageAsync,
+                isAgenticOnly: true, autoSignInHandlers: agenticHandlers);
+            OnActivity(ActivityTypes.Message, OnMessageAsync,
+                isAgenticOnly: false, autoSignInHandlers: oboHandlers);
+        }
+
+        protected async Task WelcomeMessageAsync(
+            ITurnContext turnContext, ITurnState turnState, CancellationToken cancellationToken)
+        {
+            foreach (ChannelAccount member in turnContext.Activity.MembersAdded)
+            {
+                if (member.Id != turnContext.Activity.Recipient.Id)
+                    await turnContext.SendActivityAsync(AgentWelcomeMessage);
+            }
+        }
+
+        protected async Task OnInstallationUpdateAsync(
+            ITurnContext turnContext, ITurnState turnState, CancellationToken cancellationToken)
+        {
+            _logger?.LogInformation(
+                "InstallationUpdate — Action: {Action}, User: {Name}",
+                turnContext.Activity.Action, turnContext.Activity.From?.Name);
+
+            if (turnContext.Activity.Action == InstallationUpdateActionTypes.Add)
+                await turnContext.SendActivityAsync(MessageFactory.Text(AgentHireMessage), cancellationToken);
+            else if (turnContext.Activity.Action == InstallationUpdateActionTypes.Remove)
+                await turnContext.SendActivityAsync(MessageFactory.Text(AgentFarewellMessage), cancellationToken);
+        }
+
+        protected async Task OnMessageAsync(
+            ITurnContext turnContext, ITurnState turnState, CancellationToken cancellationToken)
+        {
+            // Immediate acknowledgement
+            await turnContext.SendActivityAsync("Got it — working on it…");
+
+            // Typing indicator loop (4 second interval)
+            using var typingCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var typingTask = Task.Run(async () =>
+            {
+                while (!typingCts.Token.IsCancellationRequested)
+                {
+                    await Task.Delay(4000, typingCts.Token);
+                    if (!typingCts.Token.IsCancellationRequested)
+                        await turnContext.SendActivityAsync(new Activity { Type = "typing" });
+                }
+            }, typingCts.Token);
+
+            try
+            {
+                // Resolve auth handler for this turn
+                var authHandlerName = turnContext.Activity.IsAgenticActivity()
+                    ? AgenticAuthHandlerName : OboAuthHandlerName;
+
+                // Preload observability token for Defender tracing
+                if (_agentTokenCache != null)
+                {
+                    var agentId = Utility.ResolveAgentIdentity(turnContext);
+                    var tenantId = turnContext.Activity.Conversation?.TenantId;
+                    // Token preload — fire and forget; failure is non-fatal
+                    _ = RefreshObservabilityToken(agentId, tenantId, _agentTokenCache);
+                }
+
+                // Build the LLM agent with MCP tools and run
+                var clientAgent = await GetClientAgent(
+                    turnContext, turnState, _toolService, authHandlerName);
+                var instructions = GetAgentInstructions(turnContext.Activity.From?.Name);
+                var thread = GetConversationThread(clientAgent, turnState);
+
+                // Streaming response
+                var streamingResponse = turnContext.GetStreamingResponse();
+                await foreach (var update in clientAgent!.RunStreamingAsync(
+                    turnContext.Activity.Text, instructions, thread, cancellationToken))
+                {
+                    if (update is TextContent textContent)
+                        streamingResponse.QueueTextChunk(textContent.Text);
+                }
+                await streamingResponse.EndStreamAsync();
+            }
+            finally
+            {
+                await typingCts.CancelAsync();
+                await typingTask.IgnoreCancellationExceptionAsync();
+            }
+        }
+
+        private async Task<AIAgent?> GetClientAgent(
+            ITurnContext context, ITurnState turnState,
+            IMcpToolRegistrationService? toolService, string? authHandlerName)
+        {
+            string? accessToken = null;
+
+            // Try agentic auth first, fall back to BEARER_TOKEN for dev
+            if (!string.IsNullOrEmpty(authHandlerName))
+            {
+                var tokenResult = await context.GetTokenOrDefaultAsync(authHandlerName);
+                accessToken = tokenResult?.Token;
+            }
+            if (string.IsNullOrEmpty(accessToken))
+                TryGetBearerTokenForDevelopment(out accessToken);
+
+            var agentId = Utility.ResolveAgentIdentity(context);
+
+            // Load MCP tools from ToolingManifest.json
+            List<AITool> tools = [];
+            if (toolService != null && !string.IsNullOrEmpty(accessToken))
+            {
+                var toolCacheKey = GetToolCacheKey(turnState);
+                if (!_agentToolCache.TryGetValue(toolCacheKey, out var cachedTools))
+                {
+                    cachedTools = (await toolService.GetMcpToolsAsync(
+                        agentId, accessToken, context.Activity)).ToList();
+                    _agentToolCache[toolCacheKey] = cachedTools;
+                }
+                tools = cachedTools;
+            }
+
+            return new ChatClientAgent(_chatClient!, tools: tools)
+                .UseOpenTelemetry("agent.inference");
+        }
+
+        private static AgentThread GetConversationThread(AIAgent? agent, ITurnState turnState)
+        {
+            const string key = "conversation.threadInfo";
+            var serialized = turnState.Conversation.Get<string>(key);
+            var thread = serialized != null
+                ? JsonSerializer.Deserialize<AgentThread>(serialized) ?? new AgentThread()
+                : new AgentThread();
+            return thread;
+        }
+
+        private string GetToolCacheKey(ITurnState turnState) =>
+            turnState.User.Get<string>("user.toolCacheKey") ?? string.Empty;
+
+        private static async Task RefreshObservabilityToken(
+            string? agentId, string? tenantId,
+            IExporterTokenCache<AgenticTokenStruct> cache)
+        {
+            // Fire-and-forget token refresh for Defender observability
+            try
+            {
+                // Implementation delegates to the A365 observability runtime
+                await cache.RefreshAsync(agentId, tenantId);
+            }
+            catch (Exception)
+            {
+                // Non-fatal — observability tracing degrades gracefully
+            }
+        }
+    }
+}
+```
+
+---
+
+## appsettings.json
+
+```json
+{
+  "AgentApplication": {
+    "StartTypingTimer": false,
+    "RemoveRecipientMention": false,
+    "NormalizeMentions": false,
+    "AgenticAuthHandlerName": "agentic",
+    "UserAuthorization": {
+      "AutoSignin": false,
+      "Handlers": {
+        "agentic": {
+          "Type": "AgenticUserAuthorization",
+          "Settings": {
+            "Scopes": [
+              "https://graph.microsoft.com/.default"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "TokenValidation": {
+    "Audiences": [
+      "{{ClientId}}"
+    ]
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.Agents": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*",
+  "Connections": {
+    "ServiceConnection": {
+      "Settings": {
+        "AuthType": "UserManagedIdentity",
+        "AuthorityEndpoint": "https://login.microsoftonline.com/{{BOT_TENANT_ID}}",
+        "ClientId": "{{BOT_ID}}",
+        "Scopes": [
+          "5a807f24-c9de-44ee-a3a7-329e88a00ffc/.default"
+        ]
+      }
+    }
+  },
+  "ConnectionsMap": [
+    {
+      "ServiceUrl": "*",
+      "Connection": "ServiceConnection"
+    }
+  ],
+  "AIServices": {
+    "AzureOpenAI": {
+      "DeploymentName": "",
+      "Endpoint": "",
+      "ApiKey": ""
+    }
+  }
+}
+```
+
+---
+
+## ToolingManifest.json (empty — populated by add-workiq-tools skill)
+
+```json
+{
+  "mcpServers": []
+}
+```
+
+---
+
+## Key Invariants
+
+| Rule | Why |
+|------|-----|
+| `AddAgenticTracingExporter` before `AddA365Tracing` | Exporter must be registered before the tracer provider builds |
+| `IMcpToolRegistrationService` as Singleton | Service caches tool metadata; transient would re-fetch on every turn |
+| `AgenticAuthHandlerName` from config, not hardcoded | Allows Playground (no auth) and production (agentic) to share the same binary |
+| `GetAgentInstructions()` sanitizes `Activity.From.Name` | Prevents prompt injection via user display names |
+| `/api/health` has no auth middleware | Health checks must pass without a valid JWT (used by ALB/ingress) |
+| Typing indicator loop at 4 s | Prevents Teams from timing out the typing indicator (5 s TTL) |
+| Dual `OnActivity` registrations for `isAgenticOnly: true/false` | A365 production uses agentic auth; AgentsPlayground uses OBO or no auth |
+| `IMcpToolServerConfigurationService` alongside `IMcpToolRegistrationService` | Configuration service reads `ToolingManifest.json`; registration service uses it |

--- a/plugins/agent365/skills/make-ai-teammate/references/python-ai-teammate.md
+++ b/plugins/agent365/skills/make-ai-teammate/references/python-ai-teammate.md
@@ -1,0 +1,492 @@
+# Python AI Teammate Reference Patterns
+
+Authoritative code patterns for the `make-ai-teammate` skill — Python AgentFramework variant.
+Source: [Agent365-Samples/python/agent-framework/sample-agent](https://github.com/microsoft/Agent365-Samples/tree/main/python/agent-framework/sample-agent)
+
+---
+
+## Required Dependencies (pyproject.toml)
+
+```toml
+[project]
+name = "your-agent"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    # AgentFramework SDK
+    "agent-framework-azure-ai",
+
+    # Microsoft Agents SDK — hosting and integration
+    "microsoft-agents-hosting-aiohttp",
+    "microsoft-agents-hosting-core",
+    "microsoft-agents-authentication-msal",
+    "microsoft-agents-activity",
+
+    # Azure SDK
+    "azure-identity",
+
+    # Core
+    "python-dotenv",
+    "aiohttp",
+    "uvicorn[standard]>=0.20.0",
+    "fastapi>=0.100.0",
+    "httpx>=0.24.0",
+    "pydantic>=2.0.0",
+    "typing-extensions>=4.0.0",
+
+    # Microsoft Agent 365 SDK packages
+    "microsoft_agents_a365_tooling >= 0.1.0",
+    "microsoft_agents_a365_tooling_extensions_agentframework >= 0.1.0",
+    "microsoft_agents_a365_observability_core >= 0.1.0",
+    "microsoft_agents_a365_observability_extensions_agent_framework >= 0.1.0",
+    "microsoft_agents_a365_runtime >= 0.1.0",
+    "microsoft_agents_a365_notifications >= 0.1.0"
+]
+
+[tool.uv]
+prerelease = "allow"
+```
+
+Install:
+```bash
+uv sync
+# or
+pip install -e .
+```
+
+---
+
+## token_cache.py
+
+```python
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_agentic_token_cache: dict = {}
+
+
+def cache_agentic_token(tenant_id: str, agent_id: str, token: str) -> None:
+    """Cache agentic token for use by the A365 Observability exporter."""
+    key = f"{tenant_id}:{agent_id}"
+    _agentic_token_cache[key] = token
+    logger.debug(f"Cached agentic token for {key}")
+
+
+def get_cached_agentic_token(tenant_id: str, agent_id: str) -> str | None:
+    """Retrieve cached agentic token for the A365 Observability exporter."""
+    key = f"{tenant_id}:{agent_id}"
+    token = _agentic_token_cache.get(key)
+    if token:
+        logger.debug(f"Retrieved cached agentic token for {key}")
+    else:
+        logger.debug(f"No cached token found for {key}")
+    return token
+```
+
+---
+
+## agent.py — AgentInterface Implementation
+
+```python
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import asyncio
+import logging
+import os
+import re
+from agent_interface import AgentInterface
+from token_cache import cache_agentic_token, get_cached_agentic_token
+
+from agent_framework import ChatAgent
+from agent_framework.azure import AzureOpenAIChatClient
+from microsoft_agents_a365_tooling import McpToolRegistrationService
+from microsoft_agents_a365_notifications import NotificationType
+
+logger = logging.getLogger(__name__)
+
+# Sanitize user display names before injecting into the system prompt
+def _sanitize_display_name(name: str | None, max_len: int = 64) -> str:
+    if not name or not name.strip():
+        return "unknown"
+    safe = re.sub(r"[\x00-\x1f\x7f-\x9f]", " ", name).strip()
+    return safe[:max_len].rstrip() or "unknown"
+
+AGENT_PROMPT_TEMPLATE = """You will speak like a friendly and professional virtual assistant.
+
+The user's name is {user_name}. Use their name naturally where appropriate.
+
+Use the tools available to you to help answer the user's questions.
+"""
+
+
+class MyAgent(AgentInterface):
+    """AI Teammate agent using AgentFramework + A365 tooling."""
+
+    def __init__(self):
+        self._agent: ChatAgent | None = None
+        self._tool_service: McpToolRegistrationService | None = None
+
+    def _create_chat_client(self) -> AzureOpenAIChatClient:
+        endpoint   = os.environ["AZURE_OPENAI_ENDPOINT"]
+        deployment = os.environ["AZURE_OPENAI_DEPLOYMENT"]
+        api_version = os.getenv("AZURE_OPENAI_API_VERSION", "2024-05-01-preview")
+        api_key    = os.getenv("AZURE_OPENAI_API_KEY")
+
+        if api_key:
+            return AzureOpenAIChatClient(
+                endpoint=endpoint,
+                deployment=deployment,
+                api_version=api_version,
+                api_key=api_key,
+            )
+        else:
+            # Fall back to Azure CLI credential (DefaultAzureCredential)
+            from azure.identity import DefaultAzureCredential
+            return AzureOpenAIChatClient(
+                endpoint=endpoint,
+                deployment=deployment,
+                api_version=api_version,
+                credential=DefaultAzureCredential(),
+            )
+
+    def _create_agent(self, tools: list | None = None) -> ChatAgent:
+        chat_client = self._create_chat_client()
+        return ChatAgent(chat_client=chat_client, tools=tools or [])
+
+    async def token_resolver(self, tenant_id: str, agent_id: str) -> str | None:
+        """Token resolver for A365 Observability exporter."""
+        return get_cached_agentic_token(tenant_id, agent_id)
+
+    async def initialize(self) -> None:
+        self._agent = self._create_agent()
+        self._tool_service = McpToolRegistrationService()
+        logger.info("Agent initialized")
+
+    async def setup_mcp_servers(
+        self,
+        auth: str | None,
+        auth_handler_name: str | None,
+        context,
+    ) -> None:
+        """Load WorkIQ MCP tools from ToolingManifest.json into the agent."""
+        if not self._tool_service or not self._agent:
+            return
+
+        use_agentic = os.getenv("USE_AGENTIC_AUTH", "false").lower() == "true"
+        if not use_agentic or not auth:
+            return
+
+        try:
+            self._agent = await self._tool_service.add_tool_servers_to_agent(
+                self._agent, auth, auth_handler_name, context
+            )
+        except Exception as exc:
+            logger.warning(f"MCP tool setup failed (non-fatal): {exc}")
+
+    async def process_user_message(
+        self,
+        message: str,
+        auth: str | None,
+        auth_handler_name: str | None,
+        context,
+    ) -> str:
+        user_name = getattr(getattr(context, "activity", None), "from_property", None)
+        if user_name:
+            user_name = getattr(user_name, "name", None)
+        safe_name = _sanitize_display_name(user_name)
+        prompt = AGENT_PROMPT_TEMPLATE.format(user_name=safe_name)
+
+        await self.setup_mcp_servers(auth, auth_handler_name, context)
+
+        result = await self._agent.run(message, system_prompt=prompt)
+        return self._extract_result(result)
+
+    async def handle_agent_notification_activity(
+        self,
+        notification_type: str,
+        payload,
+        context,
+        auth: str | None,
+        auth_handler_name: str | None,
+    ) -> str | None:
+        if notification_type == NotificationType.EMAIL_NOTIFICATION:
+            # Read email via WorkIQ Mail, then generate reply
+            reply = await self.process_user_message(
+                f"Handle this email notification: {payload}", auth, auth_handler_name, context
+            )
+            return reply
+        return None
+
+    def _extract_result(self, result) -> str:
+        if isinstance(result, str):
+            return result
+        if hasattr(result, "content"):
+            return str(result.content)
+        return str(result)
+
+    async def cleanup(self) -> None:
+        logger.info("Agent cleaned up")
+```
+
+---
+
+## host_agent_server.py — aiohttp Server + A365 Routing
+
+```python
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+import asyncio
+import logging
+import os
+from typing import Type
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from agent_interface import AgentInterface
+from token_cache import cache_agentic_token
+
+from aiohttp import web
+from microsoft_agents_hosting_aiohttp import CloudAdapterAiohttp
+from microsoft_agents_hosting_core import ActivityTypes
+from microsoft_agents_a365_notifications import (
+    agent_notification,
+    ChannelId,
+    NotificationType,
+)
+from microsoft_agents_a365_observability_core import configure as configure_observability
+from microsoft_agents_a365_runtime import get_agent_identity
+
+logger = logging.getLogger(__name__)
+
+AUTH_HANDLER_NAME = os.getenv("AUTH_HANDLER_NAME", "")
+
+
+class GenericAgentHost:
+    def __init__(self, agent: AgentInterface):
+        self._agent = agent
+        self._adapter: CloudAdapterAiohttp | None = None
+        self._app: web.Application | None = None
+
+    def _setup_observability(self):
+        service_name = os.getenv("OBSERVABILITY_SERVICE_NAME", "my-agent")
+        service_namespace = os.getenv("OBSERVABILITY_SERVICE_NAMESPACE", "agents")
+        configure_observability(
+            service_name=service_name,
+            service_namespace=service_namespace,
+            token_resolver=self._agent.token_resolver,
+        )
+
+    def _setup_handlers(self):
+        """Register all activity handlers on the adapter."""
+
+        @self._adapter.on_activity(ActivityTypes.members_added)
+        async def on_members_added(context, state):
+            for member in context.activity.members_added or []:
+                if member.id != context.activity.recipient.id:
+                    await context.send_activity("Hello! I can help you today.")
+
+        @self._adapter.on_activity(ActivityTypes.installation_update)
+        async def on_installation_update(context, state):
+            action = getattr(context.activity, "action", None)
+            if action == "add":
+                await context.send_activity("Thank you for hiring me!")
+            elif action == "remove":
+                await context.send_activity("Thank you for your time!")
+
+        @self._adapter.on_activity(ActivityTypes.message)
+        async def on_message(context, state):
+            # Immediate ack
+            await context.send_activity("Got it — working on it…")
+            await context.send_activity({"type": "typing"})
+
+            auth = None
+            if AUTH_HANDLER_NAME:
+                token_result = await context.get_token(AUTH_HANDLER_NAME)
+                auth = getattr(token_result, "token", None)
+            if not auth:
+                auth = os.getenv("BEARER_TOKEN")
+
+            # Typing indicator loop
+            typing_active = True
+            async def typing_loop():
+                while typing_active:
+                    await asyncio.sleep(4)
+                    if typing_active:
+                        await context.send_activity({"type": "typing"})
+
+            typing_task = asyncio.create_task(typing_loop())
+            try:
+                reply = await self._agent.process_user_message(
+                    context.activity.text or "",
+                    auth,
+                    AUTH_HANDLER_NAME or None,
+                    context,
+                )
+                await context.send_activity(reply)
+            finally:
+                typing_active = False
+                typing_task.cancel()
+
+        @agent_notification.on_agent_notification(
+            channel_id=ChannelId(channel="agents", sub_channel="*")
+        )
+        async def on_notification(context, state):
+            notification_type = getattr(context.activity, "name", None)
+            reply = await self._agent.handle_agent_notification_activity(
+                notification_type,
+                context.activity.value,
+                context,
+                None,
+                AUTH_HANDLER_NAME or None,
+            )
+            if reply:
+                await context.send_activity(reply)
+
+    async def start_server(self):
+        self._setup_observability()
+        await self._agent.initialize()
+
+        self._adapter = CloudAdapterAiohttp(
+            client_id=os.getenv("CONNECTIONS__SERVICE_CONNECTION__SETTINGS__CLIENTID", ""),
+            client_secret=os.getenv("CONNECTIONS__SERVICE_CONNECTION__SETTINGS__CLIENTSECRET", ""),
+            tenant_id=os.getenv("CONNECTIONS__SERVICE_CONNECTION__SETTINGS__TENANTID", ""),
+        )
+        self._setup_handlers()
+
+        self._app = web.Application()
+        self._app.router.add_post("/api/messages", self._handle_messages)
+        self._app.router.add_get("/api/health", self._handle_health)
+
+        port = int(os.getenv("PORT", "3978"))
+        runner = web.AppRunner(self._app)
+        await runner.setup()
+        site = web.TCPSite(runner, "0.0.0.0", port)
+        await site.start()
+        logger.info(f"Agent server running on port {port}")
+        await asyncio.Event().wait()  # keep running
+
+    async def _handle_messages(self, request: web.Request) -> web.Response:
+        return await self._adapter.process(request)
+
+    async def _handle_health(self, request: web.Request) -> web.Response:
+        import json
+        from datetime import datetime, timezone
+        body = json.dumps({"status": "healthy", "timestamp": datetime.now(timezone.utc).isoformat()})
+        return web.Response(text=body, content_type="application/json")
+
+    async def cleanup(self):
+        await self._agent.cleanup()
+
+
+def create_and_run_host(agent_class: Type[AgentInterface]):
+    """Entry point — instantiates the agent class and starts the host server."""
+    agent = agent_class()
+    host = GenericAgentHost(agent)
+    asyncio.run(host.start_server())
+```
+
+---
+
+## agent_interface.py — Abstract Base
+
+```python
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from abc import ABC, abstractmethod
+
+
+class AgentInterface(ABC):
+    @abstractmethod
+    async def initialize(self) -> None: ...
+
+    @abstractmethod
+    async def process_user_message(
+        self,
+        message: str,
+        auth: str | None,
+        auth_handler_name: str | None,
+        context,
+    ) -> str: ...
+
+    @abstractmethod
+    async def cleanup(self) -> None: ...
+
+    async def handle_agent_notification_activity(
+        self,
+        notification_type: str,
+        payload,
+        context,
+        auth: str | None,
+        auth_handler_name: str | None,
+    ) -> str | None:
+        return None
+
+    async def token_resolver(self, tenant_id: str, agent_id: str) -> str | None:
+        return None
+```
+
+---
+
+## .env template
+
+```dotenv
+# Authentication
+AUTH_HANDLER_NAME=
+BEARER_TOKEN=
+
+# Azure OpenAI
+AZURE_OPENAI_API_KEY=
+AZURE_OPENAI_ENDPOINT=
+AZURE_OPENAI_DEPLOYMENT=
+AZURE_OPENAI_API_VERSION=2024-05-01-preview
+
+# A365 Connections
+CONNECTIONS__SERVICE_CONNECTION__SETTINGS__CLIENTID=
+CONNECTIONS__SERVICE_CONNECTION__SETTINGS__CLIENTSECRET=
+CONNECTIONS__SERVICE_CONNECTION__SETTINGS__TENANTID=
+CONNECTIONS__SERVICE_CONNECTION__SETTINGS__SCOPES=
+
+CONNECTIONSMAP_0_SERVICEURL=*
+CONNECTIONSMAP_0_CONNECTION=SERVICE_CONNECTION
+
+# Agentic auth settings
+USE_AGENTIC_AUTH=true
+AGENTAPPLICATION__USERAUTHORIZATION__HANDLERS__AGENTIC__SETTINGS__TYPE=AgenticUserAuthorization
+AGENTAPPLICATION__USERAUTHORIZATION__HANDLERS__AGENTIC__SETTINGS__SCOPES=https://graph.microsoft.com/.default
+
+# Observability
+OBSERVABILITY_SERVICE_NAME=my-agent
+OBSERVABILITY_SERVICE_NAMESPACE=agents
+ENABLE_OBSERVABILITY=true
+ENABLE_A365_OBSERVABILITY_EXPORTER=false
+ENABLE_OTEL=true
+ENABLE_SENSITIVE_DATA=true
+
+# Server
+PORT=3978
+PYTHON_ENVIRONMENT=development
+LOG_LEVEL=INFO
+```
+
+---
+
+## Key Invariants
+
+| Rule | Why |
+|------|-----|
+| `load_dotenv()` at top of `host_agent_server.py` before any imports | Env vars must be set before SDK packages read them at import time |
+| `_sanitize_display_name()` strips control characters | `context.activity.from_property.name` is user-controlled text; prevents prompt injection |
+| `USE_AGENTIC_AUTH` guards MCP setup | MCP tools require a valid agentic token; skipping in dev prevents 401 errors |
+| `agent_notification.on_agent_notification(channel_id=ChannelId(channel="agents", sub_channel="*"))` | Subscribes to all agent notification subtypes including email and WPX_COMMENT |
+| Typing indicator loop at 4 s | Prevents Teams from clearing the typing indicator before the LLM responds |
+| `requires-python = ">=3.11"` | `str | None` union syntax requires 3.10+; `asyncio.TaskGroup` requires 3.11+ |
+| `McpToolRegistrationService` singleton or per-agent instance | Tool metadata can be cached; re-creating per-turn is expensive |
+| `/api/health` returns 200 without auth | Load balancers and A365 infrastructure require unauthenticated health probes |


### PR DESCRIPTION
Extends make-ai-teammate from Node.js-only to all three supported languages:
- .NET AgentFramework (Program.cs + AgentApplication subclass pattern)
- Python AgentFramework (aiohttp + CloudAdapterAiohttp + AgentInterface pattern)

New reference docs:
- dotnet-ai-teammate.md — Program.cs, MyAgent.cs, appsettings.json, NuGet packages
- python-ai-teammate.md — host_agent_server.py, agent.py, token_cache.py, pyproject.toml

SKILL.md now detects language first (.csproj / pyproject.toml / package.json), then LLM framework, and follows the correct path through all 10 phases. Phase tasks, env config, build validation, and final summaries are all language-aware.

Validator updated to check .NET (Program.cs + .csproj + appsettings.json) and Python (host_agent_server.py + agent.py + token_cache.py + pyproject.toml) patterns.

Evals extended from 6 to 10 cases: adds .NET full transformation, .NET partial (hosting present), Python full transformation, and Python idempotency scenarios.

README updated with .NET and Python in Prerequisites, Supported Frameworks, AI Teammate End-to-End Flow file tables, make-ai-teammate section, and starter prompts.