### PR TITLE
Expand a365 setup triggers

### DIFF
--- a/plugins/agent365/skills/a365-setup/SKILL.md
+++ b/plugins/agent365/skills/a365-setup/SKILL.md
@@ -34,7 +34,10 @@ hooks:
 
 > **Trigger phrases** — any of these will activate this skill automatically:
 > "run a365 setup", "create blueprint", "register agent", "setup agent blueprint",
-> "onboard agent", "provision agent", "deploy agent", "publish agent", "a365 full setup"
+> "onboard agent", "provision agent", "deploy agent", "publish agent", "a365 full setup",
+> "make this an a365 agent", "make this agent an a365 agent", "set up a365",
+> "add a365", "configure a365", "a365 setup", "connect to a365", "integrate with a365",
+> "make this agent work with a365", "set up agent 365", "agent 365 setup"
 
 ---
 

--- a/plugins/agent365/skills/a365-setup/SKILL.md
+++ b/plugins/agent365/skills/a365-setup/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: a365-setup
 description: >
-  Full Agent 365 CLI setup lifecycle for AI agents. Asks two path-determination questions
-  (agent type and desired capabilities), then follows the correct path: verifies and installs
-  the CLI, validates Azure prerequisites, configures the agent blueprint (AI Teammate path),
-  runs a365 setup all to provision Blueprint, permissions, and endpoint registration, and
-  publishes the agent manifest (AI Teammate path). Supports .NET AgentFramework, Node.js LangChain, and Python agents.
+  The default entry point for all Agent 365 (A365) requests — use this skill whenever the user
+  wants to "make this an A365 agent", "set up A365", "add A365", or any general A365 onboarding.
+  Asks two path-determination questions (agent type and desired capabilities), then follows the
+  correct path: verifies and installs the CLI, validates Azure prerequisites, configures the
+  agent blueprint (AI Teammate path), runs a365 setup all to provision Blueprint, permissions,
+  and endpoint registration, and publishes the agent manifest (AI Teammate path). Supports
+  .NET AgentFramework, Node.js LangChain, and Python agents.
 compatibility:
   - claude-code
   - vscode-copilot


### PR DESCRIPTION
This pull request expands the list of trigger phrases that will activate the a365 setup skill, making it easier for users to invoke the skill using a wider variety of natural language commands.

Trigger phrase enhancements:

* Added several new trigger phrases to the `SKILL.md` file for the a365 setup skill, including variations like "make this an a365 agent", "set up a365", "connect to a365", and "agent 365 setup", to improve usability and recognition.