### PR TITLE
feat(a365-setup): improve CEA detection with multi-signal approach

### DIFF
--- a/evals/agent365/a365-setup/evals.json
+++ b/evals/agent365/a365-setup/evals.json
@@ -1,17 +1,18 @@
 {
   "skill_name": "a365-setup",
-  "eval_instructions": "Test against real agent projects in clean state. a365-setup is responsible for two things only: (1) detect agent stack + ask capabilities, (2) verify a365 CLI (Step 1) and Azure prerequisites (Step 2), then (3) delegate to the appropriate skill at Step 3. For the AI Teammate path (isAITeammate=true), Step 3 reads and follows make-ai-teammate/SKILL.md. For all other paths (Discoverability, Observability, WorkIQ), Step 3 reads and follows make-a365-agent/SKILL.md. a365-setup itself does NOT run a365 setup all, does NOT create a365.config.json, and does NOT run a365 publish — all of that is handled by the delegated skills.",
+  "eval_instructions": "Test against real agent projects in clean state. a365-setup is responsible for two things only: (1) detect agent stack + ask capabilities, (2) verify a365 CLI (Step 1) and Azure prerequisites (Step 2), then (3) delegate to the appropriate skill at Step 3. For the AI Teammate path (isAITeammate=true), Step 3 reads and follows make-ai-teammate/SKILL.md. For all other paths (Discoverability, Observability, WorkIQ), Step 3 reads and follows make-a365-agent/SKILL.md. a365-setup itself does NOT run a365 setup all, does NOT create a365.config.json, and does NOT run a365 publish — all of that is handled by the delegated skills. The capabilities menu has 4 options: 1=Discoverability, 2=Observability, 3=Tools (WorkIQ), 4=AI Teammate. Options can be combined. Phase 1B shows agent type as 'Custom Engine Agent (CEA)' or 'Standard Agent — no Teams/Copilot integration (Non-M365)'.",
   "evals": [
     {
       "id": 1,
       "prompt": "Run a365 setup for this agent",
-      "description": "Non-AI Teammate path (Discoverability) on a .NET AgentFramework project — a365 CLI and Azure CLI available",
-      "expected_output": "The skill detects .NET + AgentFramework, confirms with user, asks capabilities, user selects Discoverability, creates 3 todos (Step 1, Step 2, Step 3: make-a365-agent), validates a365 CLI (Step 1), validates Azure CLI + .NET SDK (Step 2), then reads and follows make-a365-agent/SKILL.md (Step 3). a365-setup itself does NOT run a365 setup all.",
+      "description": "Non-AI Teammate path (Discoverability, option 1) on a .NET AgentFramework project — a365 CLI and Azure CLI available",
+      "expected_output": "The skill detects .NET + AgentFramework, confirms with user (showing Agent type as Standard Agent or CEA), asks capabilities from 4-option menu, user selects option 1 (Discoverability), creates 3 todos (Step 1, Step 2, Step 3: make-a365-agent), validates a365 CLI (Step 1), validates Azure CLI + .NET SDK (Step 2), then reads and follows make-a365-agent/SKILL.md (Step 3). a365-setup itself does NOT run a365 setup all.",
       "files": [],
       "expectations": [
-        "Phase 1A: Agent stack, language, and Teams/Copilot flag are detected",
-        "Phase 1B: Detection summary is shown and user is asked to confirm",
-        "Phase 1B: Capabilities menu is shown (Discoverability / Discoverability+Observability / AI Teammate)",
+        "Phase 1A: Agent stack, language, and agent type (CEA vs Standard) are detected",
+        "Phase 1B: Detection summary shows Stack, Language, and Agent type (human-readable CEA or Standard Agent label)",
+        "Phase 1B: Capabilities menu shows all 4 options: Discoverability, Observability, Tools, AI Teammate",
+        "Phase 1B: User is told options can be combined",
         "Phase 1C: isAITeammate = false (Discoverability path selected)",
         "Phase 1C: 3 todos created: Step 1 (CLI), Step 2 (Prerequisites), Step 3 (Run the make-a365-agent skill)",
         "Step 1: dotnet --version is checked",
@@ -29,12 +30,13 @@
     {
       "id": 2,
       "prompt": "Create blueprint for this agent",
-      "description": "Non-AI Teammate path on a Node.js LangChain agent — user selects Discoverability+Observability",
-      "expected_output": "Skill detects Node.js + LangChain, confirms, asks capabilities, user selects Discoverability+Observability. Validates CLI and Node.js prerequisites. Delegates to make-a365-agent at Step 3 with context.",
+      "description": "Non-AI Teammate path on a Node.js LangChain agent — user selects options 1 and 2 (Discoverability+Observability)",
+      "expected_output": "Skill detects Node.js + LangChain, confirms agent type, asks capabilities from 4-option menu, user selects '1 and 2' (Discoverability+Observability). Validates CLI and Node.js prerequisites. Delegates to make-a365-agent at Step 3 with context.",
       "files": [],
       "expectations": [
         "Phase 1A: language detected as NodeJS from package.json",
-        "Phase 1B: Detection summary and capabilities menu shown",
+        "Phase 1B: Detection summary shown with Agent type field (CEA or Standard Agent)",
+        "Phase 1B: 4-option capabilities menu shown",
         "Phase 1C: 3 todos created, Todo 3 = Step 3: Run the make-a365-agent skill",
         "Step 1: a365 --version is run",
         "Step 2: az --version is run",
@@ -47,6 +49,23 @@
     },
     {
       "id": 3,
+      "prompt": "Set up A365 for this agent",
+      "description": "CEA detection — Node.js project with teamsapp.yml and @microsoft/teams-ai present, no a365.config.json yet",
+      "expected_output": "Skill detects Node.js project. Phase 1A finds teamsapp.yml (or @microsoft/teams-ai in package.json) and classifies as CEA (usesTeamsOrCopilot=1) without requiring a365.config.json to exist. Phase 1B shows 'Custom Engine Agent (CEA)' as agent type. User confirms. Capabilities menu shown. Skill proceeds normally.",
+      "files": [],
+      "expectations": [
+        "Phase 1A: usesTeamsOrCopilot detected as 1 (CEA) from teamsapp.yml or @microsoft/teams-ai — NOT from a365.config.json alone",
+        "Phase 1A: Detection does NOT require a365.config.json to exist for CEA classification",
+        "Phase 1B: Agent type shown as 'Custom Engine Agent (CEA) — has Teams/Copilot integration'",
+        "Phase 1B: User can correct to Standard Agent if detection is wrong",
+        "Phase 1B: 4-option capabilities menu shown",
+        "Phase 1C: 3 todos created",
+        "Step 1: a365 CLI validated",
+        "Step 2: Azure prerequisites confirmed"
+      ]
+    },
+    {
+      "id": 4,
       "prompt": "Register this agent",
       "description": "Non-AI Teammate path — fresh detection cache exists (under 60 min old)",
       "expected_output": "The skill finds a fresh .a365-workspace-detection.json, skips re-detection, shows the cached values to the user for confirmation, then proceeds to validate CLI, Azure prerequisites, and delegates to make-a365-agent.",
@@ -62,7 +81,7 @@
       ]
     },
     {
-      "id": 4,
+      "id": 5,
       "prompt": "Register agent with Microsoft 365",
       "description": "Error handling — a365 CLI not installed",
       "expected_output": "The skill detects a365 CLI is not installed, provides installation instructions, and exits early. Delegation to make-a365-agent does not happen until CLI is installed.",
@@ -76,7 +95,7 @@
       ]
     },
     {
-      "id": 5,
+      "id": 6,
       "prompt": "Onboard agent to A365",
       "description": "Error handling — Azure CLI not authenticated",
       "expected_output": "The skill validates a365 CLI is installed (Step 1), then in Step 2 detects Azure CLI is not authenticated, provides az login instructions, and pauses. No delegation occurs until authentication is confirmed.",
@@ -91,13 +110,14 @@
       ]
     },
     {
-      "id": 6,
+      "id": 7,
       "prompt": "Make this an AI Teammate agent",
       "description": "AI Teammate path — verifies CLI + prerequisites then delegates to make-ai-teammate",
       "expected_output": "The skill selects AI Teammate path, creates 3 todos (CLI, Prerequisites, invoke make-ai-teammate), validates CLI and Azure prerequisites (Steps 1-2), then reads make-ai-teammate/SKILL.md and follows it from the beginning. Does NOT run a365 setup all, a365 config init, or a365 publish inline.",
       "files": [],
       "expectations": [
-        "Phase 1B: User selects AI Teammate capability",
+        "Phase 1B: 4-option capabilities menu shown",
+        "Phase 1B: User selects option 4 (AI Teammate)",
         "Phase 1C: isAITeammate = true",
         "Phase 1C: 3 todos created: Step 1, Step 2, Step 3 = invoke make-ai-teammate",
         "Step 1: a365 CLI is verified and installed if needed",
@@ -109,7 +129,7 @@
       ]
     },
     {
-      "id": 7,
+      "id": 8,
       "prompt": "Run a365 setup all",
       "description": "Re-run on an agent that was previously set up (non-AI Teammate) — a365.generated.config.json already exists",
       "expected_output": "The skill detects the existing workspace, confirms with user, validates CLI and prereqs, then delegates to make-a365-agent. make-a365-agent runs a365 setup all again (idempotent — existing resources skipped).",

--- a/plugins/agent365/shared/agent-detection.md
+++ b/plugins/agent365/shared/agent-detection.md
@@ -19,7 +19,7 @@ The skill MUST detect and store these three variables before asking ANY question
 
 3. **`usesTeamsOrCopilot`** — Is this a Custom Engine Agent?
    - Possible values: `1` (true) or `0` (false)
-   - Detection: Check for M365/Teams/Copilot signals AND a365.config.json markers
+   - Detection: Check for CEA signals across file presence, packages, and config (see below)
 
 ### Agent Stack Detection Logic
 
@@ -39,12 +39,25 @@ Python → requirements.txt OR .py files
 
 ### Custom Engine Agent Detection (usesTeamsOrCopilot)
 
+Run these checks in parallel (Glob + Grep). Any one positive → `usesTeamsOrCopilot = 1`. All negative → `0`.
+
+**File presence (Glob):**
 ```
-Set usesTeamsOrCopilot = 1 if ALL of these are true:
-  - M365 signals found (channelId.*msteams, TeamsChannel, etc.)
-  - a365.config.json exists OR a365.generated.config.json exists
-  
-Set usesTeamsOrCopilot = 0 otherwise
+teamsapp.yml or teamsapp.local.yml            → CEA (Teams Toolkit project)
+appPackage/manifest.json or manifest/manifest.json  → CEA (Teams app package)
+a365.config.json or a365.generated.config.json → CEA (already A365-registered)
+```
+
+**Package references (Grep in package.json / .csproj / requirements.txt / pyproject.toml):**
+```
+Node.js:  @microsoft/teams-ai  OR  "botbuilder"         → CEA
+.NET:     Microsoft.Teams.AI   OR  Microsoft.Bot.Builder → CEA
+Python:   teams-ai             OR  botbuilder-core       → CEA
+```
+
+**Config/env signals (Grep in .env, appsettings.json):**
+```
+BOT_ID, MicrosoftAppId, or TEAMS_APP_ID present         → CEA
 ```
 
 ---
@@ -77,17 +90,20 @@ Grep: "biz.?chat" (regex)        in ToolingManifest.json, manifest.json
 Grep: "teams.?channel" (regex)   in ToolingManifest.json, manifest.json
 ```
 
-**If any M365 signal is found**, first check for M365 custom engine markers before stopping:
+**If any M365 signal is found**, check for CEA markers before stopping:
 
 ```
-Glob: **/a365.config.json                            → M365 custom engine agent (allowed)
-Glob: **/a365.generated.config.json                 → M365 custom engine agent (allowed)
-Grep: "entraAppId"      in a365.config.json         → agentType 1 (Entra app ID)
-Grep: "blueprintId"     in a365.config.json         → agentType 2 (Blueprint)
+Glob: teamsapp.yml or teamsapp.local.yml              → Teams Toolkit CEA (allowed)
+Glob: appPackage/manifest.json or manifest/manifest.json → Teams app package (allowed)
+Glob: a365.config.json or a365.generated.config.json  → already A365-registered CEA (allowed)
+Grep: @microsoft/teams-ai or botbuilder in package.json → Node.js CEA (allowed)
+Grep: Microsoft.Teams.AI or Microsoft.Bot.Builder in .csproj → .NET CEA (allowed)
+Grep: teams-ai or botbuilder-core in requirements.txt/pyproject.toml → Python CEA (allowed)
+Grep: BOT_ID or MicrosoftAppId or TEAMS_APP_ID in .env/appsettings.json → CEA (allowed)
 ```
 
-- **M365 signal found AND a365 custom engine marker found** → This is an M365 custom engine agent (agentType 1 or 2). **Do NOT block.** Continue to Step 2 and pre-fill `agentType` accordingly.
-- **M365 signal found AND NO a365 custom engine marker found** → Likely a Teams/BizChat/Copilot channel bot. **STOP** (see message below), unless user explicitly confirms AI Teammate intent.
+- **M365 signal found AND any CEA marker found** → This is a Custom Engine Agent. **Do NOT block.** Set `usesTeamsOrCopilot = 1`, continue to Step 2.
+- **M365 signal found AND NO CEA marker found** → Likely a Teams/BizChat/Copilot channel bot. **STOP** (see message below), unless user explicitly confirms AI Teammate intent.
 
 > Tell the user (STOP case only):
 > "This agent is configured for Teams channels, BizChat, or Microsoft Copilot.
@@ -212,7 +228,7 @@ The agent already has an Entra app registration but NO A365 Blueprint. You are a
 | Entra app ID referenced | `Grep "entraAppId" **/a365.config.json` OR `Grep "MicrosoftAppId" **/appsettings.json` |
 | No `needDeployment` field | `a365.config.json` exists but lacks `needDeployment` |
 
-**Pre-fill:** `agentType = 1`. Capabilities options: Observability, Observability + WorkIQ.
+**Pre-fill:** `agentType = 1`, `usesTeamsOrCopilot = 1`. Capabilities menu: all 4 options apply; options 2 (Observability) and 3 (Tools/WorkIQ) are most relevant.
 
 ### agentType 2 — M365 custom engine agent (Blueprint)
 
@@ -224,7 +240,7 @@ The agent has both an Entra app registration AND an existing A365 Blueprint. You
 | M365 auth signals present | See Step 1 greps above |
 | `needDeployment` in config | `Grep "needDeployment" **/a365.config.json` |
 
-**Pre-fill:** `agentType = 2`. Capabilities options: AI Teammate only.
+**Pre-fill:** `agentType = 2`, `usesTeamsOrCopilot = 1`. Capabilities menu: option 4 (AI Teammate) is the primary path; options 2 and 3 can be combined.
 
 ### agentType 3 — All other agents
 
@@ -236,7 +252,7 @@ Standard A365 agent with no M365 custom engine configuration. Fresh setup or Dis
 | No existing a365 config | `a365.config.json` absent |
 | Standard agent framework | dotnet-agentframework or nodejs-langchain detected |
 
-**Pre-fill:** `agentType = 3`. Capabilities options: Discoverability, Discoverability + Observability, AI Teammate.
+**Pre-fill:** `agentType = 3`, `usesTeamsOrCopilot = 0`. Capabilities menu: all 4 options apply; options can be combined.
 
 ### Discoverability detection signals
 

--- a/plugins/agent365/skills/a365-setup/SKILL.md
+++ b/plugins/agent365/skills/a365-setup/SKILL.md
@@ -50,7 +50,7 @@ hooks:
 
 **First: Check for detection cache.** Read `.a365-workspace-detection.json` if it exists. If `detectedAt` is within the last 60 minutes, load `agentStack`, `programmingLanguage`, and `usesTeamsOrCopilot` from it and skip the detection steps below — go straight to Phase 1B.
 
-Run all three detection globs **in parallel** (single tool call with multiple Glob/Grep):
+Run all three detection steps **in parallel** (single tool call with multiple Glob/Grep):
 
 **Step 1: Detect Agent Stack** → Store as `agentStack`
 - Check for .csproj + Microsoft.Agents.* → `Agent Framework`
@@ -64,48 +64,64 @@ Run all three detection globs **in parallel** (single tool call with multiple Gl
 - package.json exists → `NodeJS`
 - requirements.txt OR .py files → `Python`
 
-**Step 3: Detect Custom Engine Agent** → Store as `usesTeamsOrCopilot`
-- M365 signals (Teams/Copilot references) AND (a365.config.json OR a365.generated.config.json exists) → `1`
-- Otherwise → `0`
+**Step 3: Detect Agent Type** → Store as `usesTeamsOrCopilot`
+
+Check the following signals **in parallel** (Glob + Grep). Any one positive result → `1` (CEA). All negative → `0`.
+
+*File presence signals (Glob):*
+- `teamsapp.yml` or `teamsapp.local.yml` exists → CEA (Teams Toolkit project)
+- `appPackage/manifest.json` or `manifest/manifest.json` exists → CEA (Teams app package)
+- `a365.config.json` or `a365.generated.config.json` exists → CEA (already A365-registered)
+
+*Package reference signals (Grep in package.json / .csproj / requirements.txt / pyproject.toml):*
+- Node.js: `@microsoft/teams-ai` or `"botbuilder"` in package.json → CEA
+- .NET: `Microsoft.Teams.AI` or `Microsoft.Bot.Builder` in .csproj → CEA
+- Python: `teams-ai` or `botbuilder-core` in requirements.txt or pyproject.toml → CEA
+
+*Config/env signals (Grep in .env, appsettings.json):*
+- `BOT_ID`, `MicrosoftAppId`, or `TEAMS_APP_ID` present → CEA
+
+If none of the above are found → `0` (Standard Agent / Non-M365 Agent)
 
 ### Phase 1B: User Validation Questions
 
-Present **all three detections in a single message** and wait for ONE response:
+Present **all four detections in a single message** and wait for ONE response:
 
 ```
 Here's what we detected about your agent:
-  • Stack:          {agentStack}
-  • Language:       {programmingLanguage}
-  • Teams/Copilot:  {usesTeamsOrCopilot == 1 ? "Yes" : "No"}
+  • Stack:         {agentStack}
+  • Language:      {programmingLanguage}
+  • Agent type:    {usesTeamsOrCopilot == 1
+                     ? "Custom Engine Agent (CEA) — has Teams/Copilot integration"
+                     : "Standard Agent — no Teams/Copilot integration (Non-M365)"}
 
-Reply **yes** to confirm, or describe any corrections (e.g. "language is NodeJS" or "it's not Teams").
+Reply **yes** to confirm, or describe any corrections.
+Examples: "language is NodeJS", "it's a Custom Engine Agent", "it's not Teams".
 ```
 
-- If the user replies **yes / y**: accept all three values and proceed to Question 4.
-- If the user describes corrections: update the relevant variable(s) and proceed to Question 4.
+- If the user replies **yes / y**: accept all values and proceed to Question 4.
+- If the user says it's a CEA / Custom Engine Agent: set `usesTeamsOrCopilot = 1` and proceed to Question 4.
+- If the user says it's Standard / Non-M365: set `usesTeamsOrCopilot = 0` and proceed to Question 4.
+- If the user describes other corrections: update the relevant variable(s) and proceed to Question 4.
 
 After confirming, write `.a365-workspace-detection.json` (see `agent-detection.md` cache format).
 
 **Question 4: What capabilities do you want to enable?**
 
-Present only the options that apply based on `usesTeamsOrCopilot`:
+Present these four options:
 
-- **If `usesTeamsOrCopilot = 1`** (Custom Engine Agent):
-  1. Observability
-  2. Observability and Work IQ
-  3. AI Teammate
-- **If `usesTeamsOrCopilot = 0`** (Standard Agent):
-  1. Discoverability
-  2. Discoverability and Observability
-  3. AI Teammate
+  1. Discoverability — make the agent findable in the M365 catalog
+  2. Observability — end-to-end activity tracing for every message, LLM call, and tool use, visible in the Agent 365 portal and Microsoft Defender
+  3. Tools — add WorkIQ MCP tools (M365 data: email, calendar, Teams, SharePoint, OneDrive)
+  4. AI Teammate — full Teams/Copilot integration with hosting layer, registration, and publish
 
 Wait for the answer. Store as `capabilities`.
 
-> **Note:** The setup automatically includes all prerequisite capabilities for your selection.
+> **Note:** Options can be combined — e.g. a user can say "1 and 2" for Discoverability + Observability.
 
 ### Phase 1C: Determine Path and Create Todos
 
-After all four questions are answered, set `isAITeammate = true` if `capabilities = AI Teammate`, else `isAITeammate = false`. Then create all todos for the path and mark Todo 1 in-progress:
+After all four questions are answered, set `isAITeammate = true` if the user selected option **4 (AI Teammate)**, else `isAITeammate = false`. Then create all todos for the path and mark Todo 1 in-progress:
 
 **AI Teammate path** — `isAITeammate = true` (3 todos total):
 - Todo 1: `Step 1: Verify and Install/Update the Agent 365 CLI`


### PR DESCRIPTION
Replace the old detection logic (required M365 signals AND an existing a365.config.json) with a 3-tier check that correctly classifies fresh CEA projects before any A365 registration has run:

- File presence: teamsapp.yml, appPackage/manifest.json, a365 configs
- Package refs: @microsoft/teams-ai, botbuilder, Microsoft.Teams.AI, Microsoft.Bot.Builder, teams-ai, botbuilder-core (per language)
- Env/config: BOT_ID, MicrosoftAppId, TEAMS_APP_ID

Any one positive signal → CEA. Phase 1B now shows a human-readable agent type label (CEA vs Standard Agent) with override instructions. Flat 4-option capabilities menu replaces old branching 3-option menu.

Fix HARD STOP in agent-detection.md to accept any CEA marker as the exception — not just a365.config.json — preventing false-blocking of fresh Teams Toolkit projects.

Add eval 3 covering CEA detection via structural signals without a pre-existing a365.config.json.