### PR TITLE
docs: AI Teammate / Standard Agent taxonomy, auth mode constraints, CEA guard, and pre-populated ToolingManifest

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -141,7 +141,7 @@ When a user asks for any of the trigger phrases below, follow the corresponding 
 - "prepare agent for a365"
 
 **Summary of what this skill does:**
-1. Asks a two-stage question: agent kind (AI Teammate or System Agent) then auth mode (`user-delegated`, `agentic-identity`, or `S2S`)
+1. Asks a two-stage question: agent kind (AI Teammate / Digital Worker or Non-DW / Non-Digital Worker) then auth mode (`user-delegated`, `agentic-identity`, or `S2S`)
 2. Installs the observability package (`Microsoft.Agents.A365.Observability.Runtime` + `Microsoft.Agents.A365.Observability.Hosting` for .NET; `@microsoft/agents-a365-observability` + `@microsoft/agents-a365-observability-hosting` for Node.js; `microsoft-agents-a365-observability-core` + `microsoft-agents-a365-observability-hosting` for Python)
 3. **OBO path** (user-delegated / agentic-identity): wires `AddAgenticTracingExporter()` and per-turn `RegisterObservability(new AgenticTokenStruct(..., "AGENTIC"))`
 4. **S2S path (.NET only)**: creates `Observability/ObservabilityServiceExtensions.cs` and `Observability/ObservabilityTokenService.cs` scaffolds; wires `AddAgent365Observability()` and `InvokeAgentScope.Start().FromTurnContext()`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -141,7 +141,7 @@ When a user asks for any of the trigger phrases below, follow the corresponding 
 - "prepare agent for a365"
 
 **Summary of what this skill does:**
-1. Asks a two-stage question: agent kind (AI Teammate / Digital Worker or Non-DW / Non-Digital Worker) then auth mode (`user-delegated`, `agentic-identity`, or `S2S`)
+1. Asks a two-stage question: agent kind (AI Teammate (Digital Worker) or Standard Agent (Non Digital Worker)) then auth mode (`user-delegated`, `agentic-identity`, or `S2S`)
 2. Installs the observability package (`Microsoft.Agents.A365.Observability.Runtime` + `Microsoft.Agents.A365.Observability.Hosting` for .NET; `@microsoft/agents-a365-observability` + `@microsoft/agents-a365-observability-hosting` for Node.js; `microsoft-agents-a365-observability-core` + `microsoft-agents-a365-observability-hosting` for Python)
 3. **OBO path** (user-delegated / agentic-identity): wires `AddAgenticTracingExporter()` and per-turn `RegisterObservability(new AgenticTokenStruct(..., "AGENTIC"))`
 4. **S2S path (.NET only)**: creates `Observability/ObservabilityServiceExtensions.cs` and `Observability/ObservabilityTokenService.cs` scaffolds; wires `AddAgent365Observability()` and `InvokeAgentScope.Start().FromTurnContext()`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,10 +220,10 @@ Skills reference shared docs via `Read ${CLAUDE_PLUGIN_ROOT}/shared/<file>.md`.
 
 `shared/agent-detection.md` contains the **Agent Type and Auth Mode Detection** section used by both `instrument-observability` and `add-workiq-tools`. It implements a two-stage question flow:
 
-- **Stage 1 — Agent kind:** AI Teammate or System Agent (pre-filled from `usesTeamsOrCopilot` cache if available).
+- **Stage 1 — Agent kind:** AI Teammate (Digital Worker / DW) or Non-Digital Worker (Non-DW) (pre-filled from `usesTeamsOrCopilot` cache if available).
 - **Stage 2 — Auth mode:** depends on agent kind:
-  - AI Teammate → `user-delegated` (signed-in user OBO) or `agentic-identity` (agent's own Azure AD user)
-  - System Agent → `agentic-identity` (assistive) or `S2S` (autonomous, no user token)
+  - AI Teammate (DW) → `user-delegated` (signed-in user OBO) or `agentic-identity` (agent's own Azure AD user)
+  - Non-DW → `agentic-identity` (Assistive / OBO) or `S2S` (Autonomous / Service Principal, no user token)
 
 All three `authMode` values use `authHandlerName: "AGENTIC"` in SDK code — the difference is Azure AD provisioning. Results are cached in `.a365-workspace-detection.json` under `agentType` and `authMode` fields so subsequent skill invocations skip re-questioning. If `authMode = S2S` and the skill is `add-workiq-tools`, a compatibility warning is surfaced before Phase 4 (WorkIQ requires a user token).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,10 +220,10 @@ Skills reference shared docs via `Read ${CLAUDE_PLUGIN_ROOT}/shared/<file>.md`.
 
 `shared/agent-detection.md` contains the **Agent Type and Auth Mode Detection** section used by both `instrument-observability` and `add-workiq-tools`. It implements a two-stage question flow:
 
-- **Stage 1 — Agent kind:** AI Teammate (Digital Worker / DW) or Non-Digital Worker (Non-DW) (pre-filled from `usesTeamsOrCopilot` cache if available).
+- **Stage 1 — Agent kind:** AI Teammate (Digital Worker) or Standard Agent (Non Digital Worker) (pre-filled from `usesTeamsOrCopilot` cache if available).
 - **Stage 2 — Auth mode:** depends on agent kind:
-  - AI Teammate (DW) → `user-delegated` (signed-in user OBO) or `agentic-identity` (agent's own Azure AD user)
-  - Non-DW → `agentic-identity` (Assistive / OBO) or `S2S` (Autonomous / Service Principal, no user token)
+  - AI Teammate (Digital Worker) → `user-delegated` (signed-in user OBO) or `agentic-identity` (agent's own Azure AD user)
+  - Standard Agent (Non Digital Worker) → `agentic-identity` (Assistive / OBO) or `S2S` (Autonomous / Service Principal, no user token)
 
 All three `authMode` values use `authHandlerName: "AGENTIC"` in SDK code — the difference is Azure AD provisioning. Results are cached in `.a365-workspace-detection.json` under `agentType` and `authMode` fields so subsequent skill invocations skip re-questioning. If `authMode = S2S` and the skill is `add-workiq-tools`, a compatibility warning is surfaced before Phase 4 (WorkIQ requires a user token).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ plugins/agent365/
 │   └── plugin.json               # Skill registry (skills directory path)
 ├── skills/
 │   ├── make-ai-teammate/
-│   │   ├── SKILL.md              # Hosting layer, agent class, notifications, empty ToolingManifest.json
+│   │   ├── SKILL.md              # Hosting layer, agent class, notifications, pre-populated ToolingManifest.json
 │   │   └── references/
 │   │       ├── nodejs-ai-teammate.md     # Complete hosting + agent + client patterns (Node.js LangChain/OpenAI/Claude)
 │   │       ├── nodejs-notifications.md  # Notification + lifecycle event patterns (Node.js)

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Check which Agent 365 capabilities have already been applied to this agent and t
 
 - **6 skills** covering full AI Teammate transformation, Blueprint provisioning for all capability paths, WorkIQ MCP tools, observability instrumentation, and local testing with AgentsPlayground
 - **Multi-language support** — Node.js (LangChain, OpenAI Agents SDK, Claude SDK, Semantic Kernel, Google ADK), .NET (AgentFramework, Semantic Kernel), and Python (AgentFramework, LangChain, OpenAI, Claude, Semantic Kernel, Google ADK)
-- **Auth mode detection** — two-stage question flow determines agent kind (AI Teammate vs System Agent) and auth mode (user-delegated / agentic-identity / S2S); drives the correct observability and WorkIQ token path; cached in `.a365-workspace-detection.json` across skills
+- **Auth mode detection** — two-stage question flow determines agent kind (AI Teammate (Digital Worker) vs Standard Agent (Non Digital Worker)) and auth mode (user-delegated / agentic-identity / S2S); drives the correct observability and WorkIQ token path; cached in `.a365-workspace-detection.json` across skills
 - **Automatic agent detection** — skills detect your LLM framework, programming language, and Custom Engine Agent status, then ask validation questions before any code runs
 - **Non-destructive and idempotent** — skills wrap existing code without deleting anything; re-running skips what is already configured
 - **WorkIQ MCP tools** — pre-built M365 integrations for Mail, Calendar, Teams, SharePoint, OneDrive, Word, User profiles, Copilot, and Dataverse/Dynamics 365

--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ Handles Steps 1–2 for every path: installs/updates the a365 CLI, validates Azu
 
 Provisions a **Non-Digital Worker (Non-DW)** agent with Agent 365. A Non-DW agent has no Agentic User identity (no UPN) — it is task-oriented, system-oriented, or assistive, and appears as a system or service agent rather than a virtual teammate. It authenticates via an Entra App ID or Agent Blueprint + Agent Identity, in one of two execution modes:
 
-> **Custom Engine Agents (CEA)** are supported as Non-DW agents at GA. CEA is **not** supported as an AI Teammate (Digital Worker) at GA.
+> **Taxonomy:** Non-DW is a broad category. **CEA (Custom Engine Agent) is a specific subset** — built on a custom runtime, often with Teams/M365 integration. CEA ⊂ Non-DW, but not all Non-DW agents are CEAs. Other Non-DW types include Agent Builder agents, SharePoint agents, background automation / import / sync agents, policy / classifier agents, and 3P system agents with no Teams surface.
+>
+> **At GA:** CEA is the primary supported Non-DW path. CEA is **not** supported as an AI Teammate (Digital Worker) at GA.
 
 - **Assistive (OBO)** — acts on behalf of the signed-in user via On-Behalf-Of flow
 - **Autonomous (S2S / Service Principal)** — runs independently, no user required

--- a/README.md
+++ b/README.md
@@ -40,48 +40,46 @@ Or manually copy `.github/copilot-instructions.md` to your workspace's `.github/
 
 ## Recommended Workflow
 
-Three entry points — choose the one that fits your goal:
+**Start with `a365-setup`** — it verifies CLI and Azure prerequisites, asks which capabilities you want, then delegates to the right skill:
 
 ```
-        make-ai-teammate          make-a365-agent          a365-setup
-        (AI Teammate path)        (Standard / CEA)    (verifies CLI + Azure,
-               ↓                        ↓               then delegates to one
-         a365 setup all           a365 setup all          of the two above)
-          + publish + Teams
-               ↓                        ↓
-    ┌──────────┴────────┐   ┌───────────┴───────────┐
-    │                   │   │                       │
-instrument-         add-workiq-tools     instrument-      add-workiq-tools
-observability       (optional)           observability    (optional)
-(strongly rec.)                          (optional)
+a365-setup  (recommended entry point — handles CLI, Azure, Blueprint)
+│
+├─ AI Teammate (Digital Worker)  → make-ai-teammate  (adds hosting layer + DW identity)
+│                                      ├─ instrument-observability  (optional, offered automatically)
+│                                      └─ add-workiq-tools          (optional, offered automatically)
+│
+└─ Non-Digital Worker (Non-DW)   → make-a365-agent  (Blueprint + Entra permissions)
+      Assistive (OBO) or                  ├─ instrument-observability  (optional, offered automatically)
+      Autonomous (S2S)                    └─ add-workiq-tools          (optional, Assistive only)
 
-test-local   ← no prerequisite; can run after any step
+test-local  ← standalone; run at any point to test your agent locally
 ```
 
-`a365-setup` writes `.a365-workspace-detection.json`. The `add-workiq-tools` and
-`instrument-observability` skills read that file to skip re-detection and to confirm
-the agent is registered before they run.
+`a365-setup` writes `.a365-workspace-detection.json`. All downstream skills read this file to skip re-detection.
 
-**Already have a registered Standard Agent?** You can add WorkIQ and Observability at any time without re-running setup:
+**Already registered? Run skills directly:**
 
 ```
-"Add WorkIQ tools to this agent"          → add-workiq-tools
-"Add observability to this agent"         → instrument-observability
+"Make this agent an AI Teammate"    → make-ai-teammate       (Blueprint must exist)
+"Add observability to this agent"   → instrument-observability
+"Add WorkIQ tools to this agent"    → add-workiq-tools
+"Test this agent locally"           → test-local
 ```
-
-Both skills detect the existing registration from `.a365-workspace-detection.json` and run standalone.
 
 ---
 
 ## Skills
 
-### `make-ai-teammate` — Transform Any Agent into an AI Teammate
+### `make-ai-teammate` — Transform Any Agent into an AI Teammate (Digital Worker)
 
-An **AI Teammate** is an agent registered with Microsoft Agent 365 that can receive direct messages in Microsoft Teams, respond to email notifications, and access Microsoft 365 data through WorkIQ tools — all authenticated through your tenant's Entra ID.
+An **AI Teammate** is a **Digital Worker (DW)** — an agent with a first-class M365 identity. It has an Agentic User with a UPN, mailbox, and presence in your tenant, and behaves like a real colleague inside Teams, Outlook, and other Microsoft 365 apps. It is designed for ongoing, human-like teamwork.
 
 **Before this skill:** Your agent is a standalone script or HTTP server with no Teams presence.
 
-**After this skill:** Your agent has the full A365 hosting layer — Express + CloudAdapter (Node.js), ASP.NET Core (\.NET), or aiohttp (Python) — with an AgentApplication class, message routing, typing indicators, email notification handling, ToolingManifest.json, and all required packages. Ready to register with `a365-setup`.
+**After this skill:** Your agent has the full A365 hosting layer — Express + CloudAdapter (Node.js), ASP.NET Core (\.NET), or aiohttp (Python) — with an AgentApplication class, message routing, typing indicators, email notification handling, and ToolingManifest.json. Then offers Observability and WorkIQ tools as optional add-ons.
+
+**Prerequisite:** `a365-setup` must create the Blueprint and Agentic User identity first. This skill is normally invoked automatically from `a365-setup` after prerequisites are confirmed; it can also be run directly against an already-registered agent.
 
 **Trigger phrases:**
 ```
@@ -99,8 +97,8 @@ Detects your agent stack and asks which capabilities you want, then delegates to
 
 | Path | Delegated to |
 |------|-------------|
-| **AI Teammate** | `make-ai-teammate` — full code generation + registration + publish |
-| **Discoverability / Observability / WorkIQ** | `make-a365-agent` — Blueprint provisioning + optional observability/WorkIQ |
+| **AI Teammate (Digital Worker)** | `make-ai-teammate` — adds A365 hosting layer + DW identity (Blueprint created by a365-setup) |
+| **Non-Digital Worker (Non-DW)** — Discoverability / Observability / WorkIQ | `make-a365-agent` — Blueprint provisioning + optional observability/WorkIQ |
 
 Handles Steps 1–2 for every path: installs/updates the a365 CLI, validates Azure CLI login, checks Entra ID roles, and confirms language-specific build tools. After prerequisites are confirmed, all remaining work is handed off.
 
@@ -114,9 +112,14 @@ Handles Steps 1–2 for every path: installs/updates the a365 CLI, validates Azu
 
 ---
 
-### `make-a365-agent` — Provision Non-AI Teammate Agents
+### `make-a365-agent` — Provision Non-Digital Worker (Non-DW) Agents
 
-Provisions a non-AI Teammate agent with Agent 365 — for Discoverability, Observability, and WorkIQ paths. Normally invoked from `a365-setup` after CLI and Azure prerequisites are confirmed, but can also be called directly.
+Provisions a **Non-Digital Worker (Non-DW)** agent with Agent 365. A Non-DW agent has no Agentic User identity (no UPN) — it is task-oriented, system-oriented, or assistive, and appears as a system or service agent rather than a virtual teammate. It authenticates via an Entra App ID or Agent Blueprint + Agent Identity, in one of two execution modes:
+
+- **Assistive (OBO)** — acts on behalf of the signed-in user via On-Behalf-Of flow
+- **Autonomous (S2S / Service Principal)** — runs independently, no user required
+
+Normally invoked from `a365-setup` after CLI and Azure prerequisites are confirmed, but can also be called directly.
 
 | Capability | What it does |
 |-----------|-------------|
@@ -140,6 +143,7 @@ Always shows a dry-run preview before applying anything. `a365 setup all` is ide
 ### `add-workiq-tools` — Add WorkIQ MCP Tools
 
 > **Prerequisite:** `a365-setup` must be run first.
+> **Auth requirement:** WorkIQ requires a user in the loop — supported for AI Teammates (DW) and Non-DW Assistive (OBO) agents. Not available for Non-DW Autonomous (S2S) agents.
 
 Adds pre-built Microsoft 365 integration tools to your agent. Runs `a365 develop list-available`
 to show the MCP server catalog, adds selected servers via `a365 develop add-mcp-servers`
@@ -163,12 +167,15 @@ Available tools: Mail, Calendar, Teams, SharePoint, OneDrive, Word, User, Copilo
 > **Prerequisite:** `a365-setup` must be run first.
 
 Instruments OpenTelemetry-based tracing, context propagation, and the A365 exporter. Before
-wiring any code, asks a two-stage question to determine **agent kind** (AI Teammate or System
-Agent) and **auth mode** (`user-delegated`, `agentic-identity`, or `S2S`) — the answers drive
-which token path is wired:
+wiring any code, asks a two-stage question to determine **agent kind** and **auth mode** — the answers drive which token path is wired:
 
-- **user-delegated / agentic-identity** (OBO): `AddAgenticTracingExporter` + per-turn `RegisterObservability` with `AgenticTokenStruct`
-- **S2S** (.NET only): creates `Observability/ObservabilityServiceExtensions.cs` and `Observability/ObservabilityTokenService.cs` scaffolds (3-hop FMI token chain) + `AddAgent365Observability()` — no per-turn token call
+**Stage 1 — Agent kind:**
+- **AI Teammate (Digital Worker)**: has Agentic User with UPN; then asks whether it uses `user-delegated` (OBO as signed-in user) or `agentic-identity` (OBO as agent's own M365 identity). **Both support Observability and WorkIQ.**
+- **Non-Digital Worker (Non-DW)**: no Agentic User; then asks whether it is `Assistive (OBO)` or `Autonomous (S2S / Service Principal)`. **Observability supports both; WorkIQ is OBO only (Assistive mode).**
+
+**Wiring by auth mode:**
+- **user-delegated / agentic-identity / Assistive OBO**: `AddAgenticTracingExporter` + per-turn `RegisterObservability` with `AgenticTokenStruct`
+- **Autonomous S2S** (.NET only): creates `Observability/ObservabilityServiceExtensions.cs` and `Observability/ObservabilityTokenService.cs` scaffolds (3-hop FMI token chain) + `AddAgent365Observability()` — no per-turn token call
 
 All new code is marked `// A365 Observability — best-effort instrumentation` and changes are non-destructive and idempotent.
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Handles Steps 1–2 for every path: installs/updates the a365 CLI, validates Azu
 
 Provisions a **Non-Digital Worker (Non-DW)** agent with Agent 365. A Non-DW agent has no Agentic User identity (no UPN) — it is task-oriented, system-oriented, or assistive, and appears as a system or service agent rather than a virtual teammate. It authenticates via an Entra App ID or Agent Blueprint + Agent Identity, in one of two execution modes:
 
+> **Custom Engine Agents (CEA)** are supported as Non-DW agents at GA. CEA is **not** supported as an AI Teammate (Digital Worker) at GA.
+
 - **Assistive (OBO)** — acts on behalf of the signed-in user via On-Behalf-Of flow
 - **Autonomous (S2S / Service Principal)** — runs independently, no user required
 
@@ -125,7 +127,7 @@ Normally invoked from `a365-setup` after CLI and Azure prerequisites are confirm
 |-----------|-------------|
 | **Discoverability** | Blueprint + Entra permissions. Agent appears in the M365 catalog. |
 | **Discoverability + Observability** | Same, then invokes `instrument-observability`. |
-| **Observability** (Custom Engine Agent) | Blueprint + permissions, then invokes `instrument-observability`. |
+| **Observability** (Custom Engine Agent / Non-DW) | Blueprint + permissions, then invokes `instrument-observability`. Supports Assistive (OBO) and Autonomous (S2S). |
 | **Observability + WorkIQ** | Same, then also invokes `add-workiq-tools`. |
 
 Always shows a dry-run preview before applying anything. `a365 setup all` is idempotent — safe to re-run. WorkIQ MCP calls use OAuth On-Behalf-Of (OBO) tokens; users consent on first data access.
@@ -264,9 +266,10 @@ Register this agent for discoverability and add A365 observability so I can
 track LLM calls and tool invocations in Microsoft Defender.
 ```
 
-**Custom Engine Agent — add observability and WorkIQ:**
+**Custom Engine Agent (Non-DW) — add observability and WorkIQ:**
 ```
 This is a Custom Engine Agent already available in Microsoft Teams and Copilot.
+It is a Non-Digital Worker (Non-DW) agent — not an AI Teammate.
 Add A365 observability and WorkIQ Mail, Calendar, and Teams tools.
 ```
 

--- a/USER_FLOWS.md
+++ b/USER_FLOWS.md
@@ -1,0 +1,1353 @@
+# Agent 365 Skills — End-to-End User Flows
+
+This document describes the complete user journey for each skill in the Agent 365 Skills repository. Each skill transforms or enhances an agent in a specific way.
+
+---
+
+## Table of Contents
+
+1. [a365-setup](#1-a365-setup) — Entry point for A365 registration
+2. [make-ai-teammate](#2-make-ai-teammate) — Transform agent into Teams AI Teammate
+3. [make-a365-agent](#3-make-a365-agent) — Provision non-AI Teammate agents
+4. [instrument-observability](#4-instrument-observability) — Add OpenTelemetry tracing
+5. [add-workiq-tools](#5-add-workiq-tools) — Add Microsoft 365 data access
+6. [test-local](#6-test-local) — Local testing with AgentsPlayground
+
+---
+
+## 1. a365-setup
+
+### Purpose
+Entry point for Agent 365 registration. Installs CLI, validates Azure prerequisites, then delegates to specialized skills based on user's capability choice.
+
+### Trigger Phrases
+- "run a365 setup"
+- "create blueprint"
+- "register agent"
+- "setup agent blueprint"
+- "onboard agent"
+
+### Prerequisites
+- An existing agent project (Node.js, .NET, or Python)
+- Azure CLI access
+- Entra ID permissions (Agent ID Administrator or higher)
+
+### User Flow
+
+#### Step 1: Agent Detection & Validation
+**System Actions:**
+- Detects agent stack (LangChain, OpenAI, AgentFramework, etc.)
+- Detects programming language (.NET, Node.js, Python)
+- Detects agent type (AI Teammate (Digital Worker) vs Standard Agent (Non Digital Worker))
+- Caches detection results in `.a365-workspace-detection.json`
+
+**User Interaction:**
+```
+Here's what we detected about your agent:
+  • Stack:         LangChain
+  • Language:      NodeJS
+  • Agent type:    Custom Engine Agent (CEA) — has Teams/Copilot integration
+
+Reply **yes** to confirm, or describe any corrections.
+```
+
+**User Provides:** Confirmation or corrections
+
+#### Step 2: Capability Selection
+**User Interaction:**
+```
+What capabilities do you want to enable?
+
+  1. Discoverability — make the agent findable in the M365 catalog
+  2. Observability — end-to-end activity tracing
+  3. Tools — add WorkIQ MCP tools (M365 data access)
+  4. AI Teammate — full Teams/Copilot integration
+
+Options can be combined (e.g., "1 and 2").
+```
+
+**User Provides:** Capability choice(s)
+
+#### Step 3: CLI Installation
+**System Actions:**
+- Checks if `a365` CLI is installed
+- Installs or updates to latest version if needed
+- Validates installation with `a365 --version`
+
+**Automatic — No User Input Required**
+
+#### Step 4: Azure Prerequisites
+**System Actions:**
+- Validates Azure CLI login (`az login`)
+- Checks Entra ID roles
+- Verifies custom client app "Agent 365 CLI" exists
+- Validates language-specific build tools (dotnet/node/python)
+
+**User Interaction (if issues found):**
+- May prompt for Azure login
+- May request installation of missing build tools
+- May ask user to switch to account with proper permissions
+
+#### Step 5: Delegation
+**System Actions:**
+Based on capability selection:
+- **AI Teammate (option 4)** → Delegates to `make-ai-teammate` skill
+- **Discoverability/Observability/Tools** → Delegates to `make-a365-agent` skill
+
+**No Further User Input — Flow Continues in Delegated Skill**
+
+### What Gets Created/Modified
+- `.a365-workspace-detection.json` — Detection cache
+- `a365` CLI globally installed
+- No code changes (done by delegated skill)
+
+### Next Steps
+Automatically continues in the delegated skill based on capability choice.
+
+---
+
+## 2. make-ai-teammate
+
+### Purpose
+Transforms a non-M365 agent into a Microsoft Agent 365 AI Teammate by adding hosting layer, routing, notifications, and Teams/Copilot integration.
+
+### Trigger Phrases
+- "make this agent an ai teammate"
+- "transform agent to ai teammate"
+- "add ai teammate hosting"
+- "convert agent to teams agent"
+
+### Prerequisites
+- `a365-setup` must be run first (creates `.a365-workspace-detection.json`)
+- Existing LLM agent code (Node.js LangChain/OpenAI/Claude, .NET AgentFramework, Python AgentFramework)
+
+### User Flow
+
+#### Phase 0: Load Detection & Confirm
+**System Actions:**
+- Reads `.a365-workspace-detection.json`
+- Scans existing code for LLM entry points
+- Checks what's already present (hosting, agent class, notifications)
+
+**User Interaction:**
+```
+Language: NodeJS  |  Framework: LangChain  |  Existing code: src/chain.ts
+
+Already present:
+  • Hosting layer:   ❌
+  • Agent class:     ❌
+  • Notifications:   ❌
+
+Reply **yes** to confirm, or describe corrections.
+```
+
+**User Provides:** Confirmation
+
+#### Phase 1-2: Package Installation & Setup
+**System Actions:**
+- Installs required `@microsoft/agents-*` packages (Node.js)
+- Or adds NuGet packages (`.NET`)
+- Or updates `pyproject.toml` (Python)
+- Configures `tsconfig.json` for Node16 module resolution (Node.js only)
+
+**Automatic — No User Input**
+
+#### Phase 3-6: Code Generation
+**System Actions:**
+
+**For Node.js:**
+- Creates `src/index.ts` — Express + CloudAdapter hosting
+- Creates `src/agent.ts` — AgentApplication class with message/notification handlers
+- Creates `src/client.ts` — Wraps existing LLM code
+- Updates environment variables in `.env`
+
+**For .NET:**
+- Updates `Program.cs` — A365 services + endpoints
+- Creates `Agent/MyAgent.cs` — AgentApplication subclass
+- Updates `appsettings.json` with auth config
+
+**For Python:**
+- Creates `host_agent_server.py` — aiohttp server
+- Creates `agent_interface.py` — Agent interface
+- Updates `agent.py` — AgentInterface implementation
+- Updates `.env.template`
+
+**User Interaction:**
+None during code generation — all automatic
+
+#### Phase 7: Manifest Creation
+**System Actions:**
+- Creates empty `ToolingManifest.json`
+- Notifies user that WorkIQ tools can be added via `add-workiq-tools` skill
+
+#### Phase 8-9: Build Validation
+**System Actions:**
+- Runs build command (`npm run build`, `dotnet build`, or `pip install`)
+- Reports any errors that need fixing
+
+**User Interaction (if errors):**
+May need to fix build errors and re-run
+
+#### Phase 10: Azure Registration
+**System Actions:**
+- Collects agent identity info (name, description)
+- Creates `a365.config.json` with configuration
+- Runs `a365 setup all --dry-run` (preview)
+
+**User Interaction:**
+```
+Agent Name: (e.g., "contoso-hr-assistant")
+Agent Description: (What does your agent do?)
+Support Contact Email: (for users who need help)
+
+Here's what `a365 setup all` will create. Does this look correct?
+[Shows dry-run output]
+
+Type **yes** to proceed or **no** to abort.
+```
+
+**User Provides:** 
+- Agent name
+- Description
+- Email
+- Approval
+
+**System Actions After Approval:**
+- Runs `a365 setup all` (creates Blueprint in Entra ID)
+- Reviews and publishes `manifest/manifest.json`
+- Runs `a365 publish` to upload to M365
+- Provides Teams Developer Portal registration link
+
+#### Phase 11: Teams Developer Portal
+**User Interaction:**
+```
+To complete registration:
+1. Open: https://dev.teams.microsoft.com/agents
+2. Click "Request an Agent Instance" 
+3. Use Blueprint ID: {agentBlueprintId}
+4. Submit for admin approval at: https://admin.cloud.microsoft/#/agents/all/requested
+```
+
+**User Actions:**
+- Opens Teams Developer Portal
+- Requests agent instance
+- Admin approves the request
+
+#### Phase 12: Follow-on Capabilities
+**User Interaction:**
+```
+✅ AI Teammate code is ready!
+
+Suggested next steps:
+  1. Add observability — track every message and LLM call (Strongly Recommended)
+     Reply: "yes" to add now
+  
+  2. Add WorkIQ tools — M365 data access (Optional)
+     Reply: "add workiq" to add now
+  
+  3. Test locally — run with AgentsPlayground
+     Reply: "test local" to launch now
+```
+
+**User Provides:** Choice of next action
+
+### What Gets Created/Modified
+
+**Node.js:**
+- `src/index.ts` — New hosting layer
+- `src/agent.ts` — New agent class
+- `src/client.ts` — New LLM wrapper
+- `ToolingManifest.json` — Empty manifest
+- `.env` / `.env.example` — Updated with A365 vars
+- `tsconfig.json` — Updated module resolution
+- `package.json` — Added A365 packages
+
+**.NET:**
+- `Program.cs` — Updated with A365 services
+- `Agent/MyAgent.cs` — New agent class
+- `appsettings.json` — Added A365 config
+- `ToolingManifest.json` — Empty manifest
+- `.csproj` — Added NuGet packages
+
+**Python:**
+- `host_agent_server.py` — New server
+- `agent_interface.py` — New interface
+- `agent.py` — Updated implementation
+- `ToolingManifest.json` — Empty manifest
+- `.env.template` — Updated vars
+- `pyproject.toml` — Added dependencies
+
+**All Languages:**
+- `a365.config.json` — Agent configuration
+- `a365.generated.config.json` — Blueprint ID from setup
+- `manifest/manifest.json` — Teams app manifest
+
+### Next Steps
+- Add observability (strongly recommended)
+- Add WorkIQ tools (optional)
+- Test locally with AgentsPlayground
+- Deploy to Azure (user's choice)
+
+---
+
+## 3. make-a365-agent
+
+### Purpose
+Provisions non-AI Teammate agents with Agent 365 for Discoverability, Observability, or WorkIQ capabilities. Runs `a365 setup all` and offers optional add-ons.
+
+### Trigger Phrases
+- "provision agent with a365"
+- "run a365 setup all"
+- "discoverability setup"
+- "observability setup"
+
+### Prerequisites
+- Usually called from `a365-setup` after CLI and prerequisites validated
+- Can be invoked directly if `.a365-workspace-detection.json` exists
+
+### User Flow
+
+#### Phase 0: Load Context
+**System Actions:**
+- Checks if called from `a365-setup` (has session context)
+- If direct invocation: reads `.a365-workspace-detection.json`
+- If no cache: asks capability selection
+
+**User Interaction (if no session context):**
+```
+What capabilities would you like to enable?
+
+  1. Discoverability — make the agent findable in the M365 catalog
+  2. Observability — end-to-end activity tracing
+  3. Tools — add WorkIQ MCP tools
+```
+
+**User Provides:** Capability choice (if asked)
+
+#### Phase 1: Collect Inputs
+**User Interaction:**
+```
+To provision your agent with Agent 365, I need:
+
+  1. Agent Name — short, unique identifier (e.g., "contoso-hr-agent")
+     Rules: lowercase letters, numbers, hyphens. 3–20 chars.
+
+  2. Project directory — full path to agent code, or "current"
+```
+
+**User Provides:**
+- Agent name
+- Project path
+
+#### Phase 2: Registration
+
+**Step 2.1 — Dry Run Preview**
+**System Actions:**
+```bash
+a365 setup all --agent-name <name> --dry-run
+```
+
+**User Interaction:**
+```
+Here's what `a365 setup all` will create:
+[Shows dry-run output with resources to be created]
+
+Does this look correct? Type **yes** to proceed or **no** to abort.
+```
+
+**User Provides:** Approval (yes/no)
+
+**Step 2.2 — Apply Setup**
+**System Actions (after approval):**
+```bash
+a365 setup all --agent-name <name>
+```
+
+Creates:
+- Agent 365 Blueprint in Entra ID
+- Agent identity + app registration
+- Required Entra ID permissions
+
+**Step 2.3 — Show Results**
+**System Actions:**
+- Displays Setup Summary table from CLI
+- Shows admin consent instructions (if needed)
+- Writes `a365.generated.config.json` with Blueprint ID
+
+**User Interaction (if admin consent needed):**
+```
+If admin consent is required, have a Global Admin run:
+
+Option A: Entra Portal
+  [Shows portal steps]
+
+Option B: PowerShell
+  [Shows PowerShell script]
+```
+
+**User Action (if applicable):**
+- Forwards to Global Admin
+- Admin grants consent
+
+#### Phase 3: Add Observability (Optional)
+
+**User Interaction:**
+```
+Your agent is provisioned. Observability lets you track every message,
+LLM call, and tool invocation in the Agent 365 portal and Microsoft Defender.
+
+Would you like to add observability now?
+  • yes  — I'll run the instrument-observability skill now
+  • skip — you can add it later
+```
+
+**User Provides:** yes/skip
+
+**System Actions (if yes):**
+- Automatically invokes `instrument-observability` skill
+- (See instrument-observability flow below)
+
+#### Phase 4: Add WorkIQ Tools (Optional)
+
+**User Interaction:**
+```
+Would you like to add WorkIQ tools? These give your agent access to
+Microsoft 365 data — email, calendar, Teams, SharePoint, OneDrive, and more.
+
+Note: WorkIQ MCP calls use OAuth On-Behalf-Of tokens.
+
+  • yes  — I'll run the add-workiq-tools skill now
+  • skip — you can add it later
+```
+
+**User Provides:** yes/skip
+
+**System Actions (if yes):**
+- Automatically invokes `add-workiq-tools` skill
+- (See add-workiq-tools flow below)
+
+#### Phase 5: Final Summary
+
+**System Actions:**
+```
+✅ Agent provisioned with Agent 365!
+
+Your agent now has:
+  • Blueprint:       Created in Entra ID
+  • Discoverability: Agent appears in M365 catalog
+  [• Observability:  OpenTelemetry + A365 tracing]  (if added)
+  [• WorkIQ tools:   M365 data access via MCP]      (if added)
+
+Next steps:
+  1. If admin consent was required, ensure Global Admin ran the script
+  2. Test discovery: search for your agent in Microsoft 365 apps
+  3. Add observability (if not done)
+  4. Add WorkIQ tools (if not done)
+```
+
+### What Gets Created/Modified
+- `a365.generated.config.json` — Blueprint ID and settings
+- Entra ID resources — Blueprint, app registration, permissions
+- Potentially updates to code (if observability/WorkIQ added)
+
+### Next Steps
+- Grant admin consent (if required)
+- Add observability (if skipped)
+- Add WorkIQ tools (if skipped)
+- Test agent functionality
+
+---
+
+## 4. instrument-observability
+
+### Purpose
+Adds OpenTelemetry-based observability to agents. Captures every message, LLM call, and tool invocation with traces sent to Agent 365 portal and Microsoft Defender. **Required for store publishing.**
+
+### Trigger Phrases
+- "instrument observability for this agent"
+- "add a365 observability"
+- "enable tracing"
+- "add otel"
+- "instrument for store publishing"
+
+### Prerequisites
+- `a365-setup` must be run first (creates `.a365-workspace-detection.json`)
+- Works with .NET, Node.js, Python agents
+
+### User Flow
+
+#### Phase 0: Load Detection & Validate
+**System Actions:**
+- Reads `.a365-workspace-detection.json`
+- Detects agent stack and programming language
+
+**User Interaction:**
+```
+Here's what we detected about your agent:
+  • Stack:    AgentFramework
+  • Language: DotNet
+
+Reply **yes** to confirm, or describe corrections.
+```
+
+**User Provides:** Confirmation
+
+#### Phase 0.5: Agent Type & Auth Mode
+
+**User Interaction:**
+```
+To configure observability correctly, I need to know:
+
+1. What kind of agent is this?
+   • AI Teammate — works with Teams/Copilot, has Teams UI
+   • System Agent — backend service, no Teams UI
+
+2. How does this agent authenticate? (based on your choice above)
+   
+   For AI Teammate:
+     • user-delegated — uses signed-in user's identity (OBO)
+     • agentic-identity — agent has its own Azure AD user account
+   
+   For System Agent:
+     • agentic-identity — agent as assistive service with user context
+     • S2S — autonomous service, no user token
+```
+
+**User Provides:**
+- Agent kind (AI Teammate (Digital Worker) or Standard Agent (Non Digital Worker))
+- Auth mode (user-delegated, agentic-identity, or S2S)
+
+**System Actions:**
+- Caches choices to `.a365-workspace-detection.json`
+- Determines code pattern to use (OBO vs S2S paths differ)
+
+#### Phase 1: Detect Agent Type
+**System Actions:**
+- Scans for .csproj, package.json, or requirements.txt
+- Identifies entry point file (Program.cs, index.ts, app.py)
+- Identifies message handler location
+- Loads appropriate reference patterns
+
+**Automatic — No User Input**
+
+#### Phase 2: Install Packages
+
+**System Actions:**
+
+**For .NET:**
+```bash
+dotnet add package Microsoft.Agents.A365.Observability.Runtime
+dotnet add package Microsoft.Agents.A365.Observability.Hosting
+```
+
+**For Node.js:**
+```bash
+npm install @microsoft/agents-a365-observability
+npm install @microsoft/agents-a365-runtime
+npm install @microsoft/agents-a365-observability-hosting
+```
+
+**For Python:**
+```bash
+pip install microsoft-agents-a365-observability-core
+pip install microsoft-agents-a365-runtime
+pip install microsoft-agents-a365-observability-hosting
+```
+
+**User Interaction (optional):**
+```
+Which AI framework does your agent use?
+  • Semantic Kernel
+  • OpenAI
+  • Agent Framework
+  • LangChain
+  • None / Other
+```
+
+**System Actions (based on choice):**
+Installs optional auto-instrumentation extensions
+
+#### Phase 3: Wire Entry Point
+
+**System Actions:**
+
+**For .NET (OBO path — user-delegated or agentic-identity):**
+- Adds `builder.Services.AddAgenticTracingExporter();`
+- Adds `builder.AddA365Tracing();`
+- Optionally registers `BaggageTurnMiddleware`
+
+**For .NET (S2S path):**
+- Creates `Observability/ObservabilityServiceExtensions.cs`
+- Creates `Observability/ObservabilityTokenService.cs` (FMI 3-hop token chain)
+- Adds `builder.Services.AddAgent365Observability();`
+- Adds `builder.AddA365Tracing();`
+
+**For Node.js:**
+- Imports `ObservabilityManager`
+- Calls `ObservabilityManager.configure().withTokenResolver(...).start()`
+- Optionally registers `BaggageMiddleware`
+
+**For Python:**
+- Imports `configure` from observability package
+- Calls `configure()` with service name and token resolver
+- Optionally registers `BaggageMiddleware`
+
+**All marked with:**
+```
+// A365 Observability — best-effort instrumentation (verify against official sample)
+```
+
+#### Phase 4: Add Baggage Context to Handler
+
+**System Actions:**
+
+**For .NET (OBO path):**
+- Injects `IExporterTokenCache<AgenticTokenStruct>` in constructor
+- Adds `using var baggage = new BaggageBuilder().FromTurnContext(turnContext).Build();`
+- Calls `_agentTokenCache.RegisterObservability(new AgenticTokenStruct(..., authHandlerName: "AGENTIC"))`
+- Adds inline comment: `// A365 auth mode: user-delegated` (or agentic-identity)
+
+**For .NET (S2S path):**
+- Injects `Agent365ObservabilityContext` in constructor
+- Uses `InvokeAgentScope.Start(...).FromTurnContext(turnContext)` (no per-turn RegisterObservability)
+- Adds inline comment: `// A365 auth mode: S2S — FMI token chain via ObservabilityTokenService`
+
+**For Node.js:**
+- Imports `BaggageBuilder`, `AgenticTokenCacheInstance`
+- Calls `AgenticTokenCacheInstance.RefreshObservabilityToken(...)`
+- Wraps handler in `baggageScope.run(async () => { ... })`
+- Adds inline comment: `// A365 auth mode: {authMode}`
+
+**For Python:**
+- Imports `BaggageBuilder`, `populate`, `AgenticTokenCache`
+- Calls `token_cache.register_observability(...)`
+- Wraps handler with baggage context
+- Adds inline comment: `# A365 auth mode: {authMode}`
+
+**Note:** All three auth modes use `authHandlerName: "AGENTIC"` in code — the identity in traces is determined by Azure AD provisioning.
+
+#### Phase 5: Token Resolver
+**System Actions:**
+- For AI Teammate with hosting packages: built-in cache handles this automatically
+- For S2S .NET: `ObservabilityTokenService` background service handles FMI token chain
+- No custom resolver needed in most cases
+
+#### Phase 5.5: Manual Instrumentation Scopes
+
+**User Interaction:**
+```
+Do you want to add InvokeAgentScope, InferenceScope, and ExecuteToolScope wrappers?
+These are **required for store publishing**.
+
+  • yes — add now (recommended)
+  • skip — I'll add manually later
+```
+
+**User Provides:** yes/skip
+
+**System Actions (if yes):**
+- Wraps message handler with `InvokeAgentScope`
+- Wraps LLM calls with `InferenceScope`
+- Wraps tool calls with `ExecuteToolScope`
+- All following language-specific patterns from reference docs
+
+#### Phase 6: Configuration Files
+
+**System Actions:**
+
+**For .NET:**
+- Updates `appsettings.json` with `Agent365Observability` section
+- For S2S: adds `ClientId` + `ClientSecret` placeholders
+- Creates `appsettings.Development.json` with exporter disabled
+
+**For Node.js:**
+- Updates `.env` with observability variables:
+  - `OBSERVABILITY_SERVICE_NAME`
+  - `OBSERVABILITY_SERVICE_NAMESPACE`
+  - `AGENTIC_APP_ID`
+
+**For Python:**
+- Updates `.env` or `.env.template` with observability variables
+
+#### Phase 7: Build Validation
+**System Actions:**
+```bash
+# .NET
+dotnet build
+
+# Node.js
+npm run build
+
+# Python
+pip install -e .
+python -c "import observability_module"
+```
+
+**User Interaction (if errors):**
+Shows build errors and asks user to fix
+
+#### Phase 8: Final Summary
+
+**System Actions:**
+```
+✅ Observability instrumented!
+
+Your agent now has:
+  • OpenTelemetry tracing      (/InvokeAgent, /Inference, /ExecuteTool spans)
+  • A365 exporter              (sends to Agent 365 portal + Microsoft Defender)
+  • Baggage propagation        (conversation_id, user_id, agent_id)
+  • Token caching              (reduces auth overhead)
+  • Manual scopes              (required for store publishing)
+
+Auth mode: {authMode}
+  - user-delegated: Traces attributed to signed-in user
+  - agentic-identity: Traces attributed to agent's Azure AD user
+  - S2S: Traces show agent service identity (.NET only, FMI 3-hop chain)
+
+Next steps:
+  1. Test locally to see traces in console
+  2. View traces in Agent 365 portal: https://portal.agent365.microsoft.com
+  3. Deploy to see traces in Microsoft Defender
+```
+
+### What Gets Created/Modified
+
+**All Languages:**
+- Entry point file — Observability configuration added
+- Message handler file — Baggage context added
+- Package manifest — A365 observability packages added
+- Configuration files — Observability settings added
+- All new code marked with: `// A365 Observability — best-effort instrumentation`
+
+**.NET Specific (S2S path only):**
+- `Observability/ObservabilityServiceExtensions.cs` — DI extension
+- `Observability/ObservabilityTokenService.cs` — FMI token service
+
+### Next Steps
+- Test agent locally to verify traces emit
+- View traces in Agent 365 portal
+- Deploy to production to enable Defender integration
+
+---
+
+## 5. add-workiq-tools
+
+### Purpose
+Adds WorkIQ MCP tool servers to agents, giving access to Microsoft 365 data (email, calendar, Teams, SharePoint, OneDrive, Word, Copilot, Dataverse).
+
+### Trigger Phrases
+- "add workiq tools"
+- "add work intelligence tools"
+- "wire up workiq"
+- "add mcp tools to this agent"
+
+### Prerequisites
+- `a365-setup` must be run first
+- Works with .NET, Node.js, Python agents
+
+### User Flow
+
+#### Phase 0A: Load Detection
+**System Actions:**
+- Reads `.a365-workspace-detection.json`
+- Validates prerequisites
+
+**User Interaction:**
+```
+Here's what we detected about your agent:
+  • Stack:    LangChain
+  • Language: NodeJS
+
+Reply **yes** to confirm, or describe corrections.
+```
+
+**User Provides:** Confirmation
+
+#### Phase 0B: Agent Type & Auth Mode
+**System Actions:**
+- Checks if `agentType` and `authMode` already cached
+- If not: follows same two-stage question as instrument-observability
+
+**User Interaction (if needed):**
+```
+1. Agent kind?
+   • AI Teammate
+   • System Agent
+
+2. Auth mode? (based on agent kind)
+   • user-delegated / agentic-identity / S2S
+```
+
+**User Provides:** Agent kind and auth mode (if asked)
+
+**Note:** If `authMode = S2S`, a warning is shown that WorkIQ requires user tokens and won't work in S2S mode.
+
+#### Phase 1: Detect & Check Prerequisites
+**System Actions:**
+- Checks `a365` CLI is installed
+- Runs `a365 develop list-configured` to show current state
+- Checks for `AGENTIC_APP_ID` in config files
+
+**Automatic — No User Input**
+
+#### Phase 2: Show Catalog & Select Tools
+
+**System Actions:**
+```bash
+a365 develop list-available
+```
+
+**User Interaction:**
+```
+Available WorkIQ tool servers:
+
+  • Work IQ Mail         — Read, send, manage email
+  • Work IQ Calendar     — Read/create events, check availability
+  • Work IQ Teams        — Read channel messages, list teams
+  • Work IQ SharePoint   — Search documents, read files
+  • Work IQ OneDrive     — Manage OneDrive files
+  • Work IQ Word         — Read and write Word documents
+  • Work IQ User         — Get user profile and presence
+  • Work IQ Copilot      — Chat with M365 Copilot
+  • Dataverse and Dynamics 365 — CRUD and domain actions
+
+Which would you like to add? (Select multiple or "All")
+```
+
+**User Provides:** Tool selection
+
+#### Phase 3: Add MCP Servers
+
+**System Actions:**
+```bash
+a365 develop add-mcp-servers "Work IQ Mail" "Work IQ Calendar" ...
+```
+
+- Updates or creates `ToolingManifest.json`
+- Adds selected servers to manifest
+
+**Then validates:**
+```bash
+a365 develop list-configured
+```
+
+**Automatic — No User Input**
+
+#### Phase 4: Wire Code
+
+**System Actions:**
+
+**For .NET:**
+1. Installs packages:
+   ```bash
+   dotnet add package Microsoft.Agents.A365.Tooling --prerelease
+   dotnet add package Microsoft.Agents.A365.Tooling.Extensions.AgentFramework --prerelease
+   ```
+
+2. Registers services in `Program.cs`:
+   ```csharp
+   // A365 WorkIQ — added by add-workiq-tools skill
+   builder.Services.AddSingleton<IMcpToolRegistrationService, McpToolRegistrationService>();
+   ```
+
+3. Adds to agent class:
+   ```csharp
+   // A365 WorkIQ — added by add-workiq-tools skill
+   // A365 auth mode: {authMode}
+   var workIQTools = await _toolService.GetMcpToolsAsync(
+       agentId,
+       UserAuthorization,  // "AGENTIC" handler
+       handlerForMcp,
+       context
+   );
+   ```
+
+**For Node.js:**
+1. Installs packages:
+   ```bash
+   npm install @microsoft/agents-a365-tooling
+   npm install @microsoft/agents-a365-tooling-extensions-langchain
+   ```
+
+2. Adds to client file:
+   ```typescript
+   // A365 WorkIQ — added by add-workiq-tools skill
+   import { McpToolRegistrationService } from '@microsoft/agents-a365-tooling-extensions-langchain';
+   const toolService = new McpToolRegistrationService();
+   
+   // In getClient():
+   // A365 auth mode: {authMode}
+   const agentWithTools = await toolService.addToolServersToAgent(
+       personalizedAgent,
+       authorization,
+       "AGENTIC",
+       turnContext,
+       process.env.BEARER_TOKEN ?? ''
+   );
+   ```
+
+**For Python:**
+1. Installs packages:
+   ```bash
+   pip install microsoft-agents-a365-tooling
+   pip install microsoft-agents-a365-tooling-extensions-agent-framework
+   ```
+
+2. Adds to agent:
+   ```python
+   # A365 WorkIQ — added by add-workiq-tools skill
+   from microsoft_agents_a365.tooling.extensions.agent_framework import McpToolRegistrationService
+   
+   _tool_service = McpToolRegistrationService()
+   
+   # In handler:
+   # A365 auth mode: {authMode}
+   work_iq_tools = await _tool_service.get_mcp_tools_async(
+       agent_id,
+       turn_context.activity.caller_id,
+       "AGENTIC",
+       turn_context
+   )
+   ```
+
+**All marked with:**
+```
+// A365 WorkIQ — added by add-workiq-tools skill
+```
+
+#### Phase 5: Permissions Handoff
+
+**User Interaction:**
+```
+⚠️ WorkIQ tools require Microsoft Graph permissions.
+
+A Global Administrator must grant admin consent using ONE of these options:
+
+Option 1 — Automated (Recommended):
+  a365 setup permissions mcp
+
+Option 2 — Include in full setup:
+  a365 setup all
+
+The admin can run these commands from any machine with the a365 CLI installed.
+
+Forward this to your Global Admin, or run it yourself if you have that role.
+```
+
+**User Action:**
+- Forwards to Global Admin
+- Admin runs permission grant command
+
+#### Phase 6: Dev Token Setup
+
+**User Interaction:**
+```
+For local testing, you'll need a development token.
+
+Get one with:
+  a365 develop get-token
+
+This token goes in your .env file as BEARER_TOKEN.
+It's user-delegated, so it will only access YOUR M365 data during local testing.
+
+Would you like me to show you how to add it to .env?
+  • yes — show me
+  • skip — I'll handle it
+```
+
+**User Provides:** yes/skip
+
+**System Actions (if yes):**
+- Shows how to run `a365 develop get-token`
+- Shows how to add `BEARER_TOKEN=...` to `.env`
+
+#### Phase 7: Build Validation
+**System Actions:**
+```bash
+# .NET
+dotnet build
+
+# Node.js
+npm run build
+
+# Python
+pip install -e .
+```
+
+#### Phase 8: Final Summary
+
+**System Actions:**
+```
+✅ WorkIQ tools added!
+
+Your agent now has access to:
+  [• Work IQ Mail]        (if selected)
+  [• Work IQ Calendar]    (if selected)
+  [... etc ...]
+
+Files modified:
+  • ToolingManifest.json  — MCP server configuration
+  • [Language-specific files]
+
+Auth mode: {authMode}
+  - user-delegated: Tools access signed-in user's M365 data
+  - agentic-identity: Tools access on behalf of agent's identity
+  - S2S: ⚠️ Not supported for WorkIQ (requires user token)
+
+Next steps:
+  1. Have Global Admin run: a365 setup permissions mcp
+  2. Get dev token: a365 develop get-token
+  3. Test locally with user's own M365 data
+  4. Deploy to production
+```
+
+### What Gets Created/Modified
+- `ToolingManifest.json` — MCP server entries
+- Package manifest — Tooling packages added
+- Code files — `GetMcpToolsAsync` calls added
+- All new code marked with: `// A365 WorkIQ — added by add-workiq-tools skill`
+
+### Next Steps
+- Admin grants permissions
+- Get dev token for local testing
+- Test WorkIQ tool invocation
+- Deploy to production
+
+---
+
+## 6. test-local
+
+### Purpose
+Launches agent locally and opens AgentsPlayground for interactive testing without deployment. Works with any AI Teammate stack.
+
+### Trigger Phrases
+- "test this agent locally"
+- "run agent locally"
+- "open agentsplayground"
+- "local test this agent"
+
+### Prerequisites
+- Agent code must build successfully
+- Works with .NET, Node.js, Python AI Teammate agents
+
+### User Flow
+
+#### Phase 1: Detect Agent Type
+**System Actions:**
+- Checks `.a365-workspace-detection.json` (if exists)
+- Or scans for .csproj, package.json, requirements.txt
+- Determines default port (5000 for .NET, 3978 for Node.js/Python)
+- Determines start command
+
+**User Interaction (if needed):**
+```
+I couldn't detect the agent type. What are you working with?
+  • .NET (AgentFramework or Semantic Kernel)
+  • Node.js (LangChain, OpenAI, Claude SDK, Semantic Kernel, Google ADK)
+  • Python (AgentFramework, LangChain, OpenAI, Claude, Semantic Kernel, Google ADK)
+```
+
+**User Provides:** Agent type (if asked)
+
+**System Actions:**
+- Checks if build tool is installed (dotnet/node/python)
+
+**User Interaction (if tool missing):**
+```
+{BuildTool} is required but not found. Install it now?
+  • Yes — install via winget (Windows) or brew (macOS)
+  • No — I'll install manually and re-run
+```
+
+**User Provides:** yes/no
+
+**System Actions (if yes):**
+Attempts automatic installation
+
+#### Phase 2: Install AgentsPlayground
+**System Actions:**
+```bash
+agentsplayground --version
+```
+
+**User Interaction (if not installed):**
+```
+AgentsPlayground CLI is not installed. Install it now with
+`npm install -g @microsoft/agentsplayground`?
+
+  • Yes, install it
+  • No, I'll install it manually
+```
+
+**User Provides:** yes/no
+
+**System Actions (if yes):**
+```bash
+npm install -g @microsoft/agentsplayground
+```
+
+#### Phase 3: Build Agent
+**System Actions:**
+```bash
+# .NET
+dotnet build
+
+# Node.js
+npm install
+npm run build
+
+# Python
+pip install -r requirements.txt
+```
+
+**User Interaction (if build fails):**
+Shows errors and stops — asks user to fix before continuing
+
+#### Phase 4: Launch
+
+**User Interaction:**
+```
+Ready to start the agent and open AgentsPlayground for a local test?
+
+  • Yes — start agent and open playground
+  • No — show me the commands and I'll run them manually
+```
+
+**User Provides:** yes/no
+
+**System Actions (if yes):**
+
+**Starts agent in background:**
+```bash
+# .NET
+dotnet run
+
+# Node.js
+npm start
+
+# Python
+python host_agent_server.py
+```
+
+**Waits for agent to be ready (polls /api/messages endpoint)**
+
+**Then launches AgentsPlayground:**
+```bash
+agentsplayground -e "http://localhost:{port}/api/messages" -c "emulator"
+```
+
+**Opens browser to AgentsPlayground UI**
+
+**User Interaction (if no):**
+```
+Terminal 1 — start your agent:
+  .NET:    dotnet run
+  Node.js: npm start
+  Python:  python host_agent_server.py
+
+Terminal 2 — open AgentsPlayground:
+  agentsplayground -e "http://localhost:{port}/api/messages" -c "emulator"
+```
+
+#### Phase 5: Testing Session
+
+**User Actions:**
+- Types messages in AgentsPlayground UI
+- Tests agent responses
+- Verifies WorkIQ tools work (if added)
+- Checks that observability traces emit (if instrumented)
+
+**Agent runs in background — user can:**
+- See console logs
+- Monitor requests
+- Debug issues
+
+#### Phase 6: Wrap Up
+
+**User Interaction:**
+```
+Local test complete!
+
+To stop the agent:
+  • Press Ctrl+C in the terminal where the agent is running
+  • Or close the terminal
+
+To test again:
+  • Run this skill again
+  • Or manually run the commands shown above
+```
+
+### What Gets Created/Modified
+- No files modified (read-only testing)
+- Agent runs on localhost
+- AgentsPlayground opens in browser
+
+### Next Steps
+- Fix any issues found during testing
+- Deploy to Azure when ready
+- Test production deployment
+
+---
+
+## Skill Dependency Flow
+
+```
+┌─────────────┐
+│ a365-setup  │  Entry point
+└──────┬──────┘
+       │
+       ├─── AI Teammate selected ───→ ┌──────────────────┐
+       │                               │ make-ai-teammate │
+       │                               └────────┬─────────┘
+       │                                        │
+       │                                        ├──→ instrument-observability (strongly recommended)
+       │                                        │
+       │                                        └──→ add-workiq-tools (optional)
+       │
+       └─── Other paths ──────────────→ ┌─────────────────┐
+                                         │ make-a365-agent │
+                                         └────────┬────────┘
+                                                  │
+                                                  ├──→ instrument-observability (optional)
+                                                  │
+                                                  └──→ add-workiq-tools (optional)
+
+┌────────────┐
+│ test-local │  Can be run at any time after make-ai-teammate
+└────────────┘
+```
+
+## Common User Journeys
+
+### Journey 1: New AI Teammate (Full Stack)
+1. User: "run a365 setup"
+2. System detects agent, asks for capabilities
+3. User selects "4. AI Teammate"
+4. → `make-ai-teammate` runs
+5. System generates hosting code, runs setup, publishes to Teams
+6. User approves manifest, registers in Teams Dev Portal
+7. System offers observability
+8. User: "yes"
+9. → `instrument-observability` runs
+10. System offers WorkIQ tools
+11. User: "yes"
+12. → `add-workiq-tools` runs
+13. User: "test local"
+14. → `test-local` runs
+15. AgentsPlayground opens, user tests agent
+
+**Result:** Fully instrumented AI Teammate ready for Teams deployment
+
+### Journey 2: System Agent with Observability Only
+1. User: "run a365 setup"
+2. System detects agent
+3. User selects "2. Observability"
+4. → `make-a365-agent` runs
+5. System runs `a365 setup all`
+6. System automatically offers and runs `instrument-observability`
+7. System offers WorkIQ tools
+8. User: "skip"
+
+**Result:** System agent with observability, discoverable in M365 catalog
+
+### Journey 3: Add Tools to Existing Agent
+1. User has already run `a365-setup` previously
+2. User: "add workiq tools"
+3. → `add-workiq-tools` runs directly
+4. Shows catalog, user selects tools
+5. System wires code, shows permission handoff instructions
+
+**Result:** WorkIQ tools added to already-provisioned agent
+
+### Journey 4: Local Testing Only
+1. User has make-ai-teammate code ready
+2. User: "test this agent locally"
+3. → `test-local` runs directly
+4. System builds agent, launches playground
+5. User tests in browser
+
+**Result:** Quick local test without deployment
+
+---
+
+## Technical Notes
+
+### Authentication Modes Explained
+
+All skills that instrument code (observability, WorkIQ) ask for `authMode` which determines how the agent authenticates:
+
+| Mode | Description | Identity in Traces | Use Case |
+|------|-------------|-------------------|----------|
+| **user-delegated** | Agent uses signed-in user's token (OBO) | End user | AI Teammate where user is logged in |
+| **agentic-identity** | Agent has its own Azure AD user account | Agent's Azure AD user | AI Teammate (Digital Worker) or Standard Agent (Non Digital Worker) operating as assistant |
+| **S2S** | Service-to-service, no user context | Agent service principal | Background automation (.NET only) |
+
+**Code is identical** — all use `authHandlerName: "AGENTIC"`. The difference is in Azure AD provisioning.
+
+### Non-Destructive Principles
+
+All skills follow these rules:
+- ✅ Add new files
+- ✅ Add new code sections to existing files
+- ✅ Install new packages
+- ✅ Update configuration files by adding new keys
+- ❌ Never delete existing code
+- ❌ Never restructure existing logic
+- ❌ Never replace user's LLM implementation
+
+### Idempotency
+
+All skills can be run multiple times safely:
+- Existing resources are skipped (Azure setup)
+- Existing code is preserved
+- Package installations check before adding
+- Build validation confirms everything works
+
+---
+
+## Support & Troubleshooting
+
+### Common Issues
+
+**"a365-setup must be run first"**
+- Detection cache is missing or stale
+- Solution: Run `a365-setup` before specialized skills
+
+**Build failures after code generation**
+- Usually missing imports or module resolution issues
+- For Node.js: Check `tsconfig.json` has `"module": "node16"` AND `"moduleResolution": "node16"`
+- For .NET: Check package references are restored
+- For Python: Check virtual environment is active
+
+**Admin consent required**
+- WorkIQ and some observability features need Global Admin approval
+- Forward PowerShell script to admin
+- Or run `a365 setup permissions mcp` as admin
+
+**AgentsPlayground won't connect**
+- Check agent is running on expected port
+- For .NET: Ensure `requireAuth: false` in `MapAgentApplicationEndpoints`
+- Check firewall isn't blocking localhost
+
+### Getting Help
+
+- Agent 365 Troubleshooting Guide: https://learn.microsoft.com/en-us/microsoft-agent-365/developer/troubleshooting
+- CLI Reference: https://learn.microsoft.com/en-us/microsoft-agent-365/developer/agent-365-cli
+- GitHub Issues: https://github.com/microsoft/Agent365-devTools/issues
+
+---
+
+## Glossary
+
+- **A365** — Agent 365 (Microsoft's agent platform)
+- **Blueprint** — Agent identity registered in Entra ID
+- **CEA** — Custom Engine Agent (has Teams/Copilot integration)
+- **MCP** — Model Context Protocol (tool server standard)
+- **OBO** — On-Behalf-Of (OAuth flow where agent acts as user)
+- **S2S** — Service-to-Service (agent authenticates as itself)
+- **WorkIQ** — Pre-built tools for M365 data access
+- **AgentsPlayground** — Local testing UI that simulates Teams chat
+
+---
+
+*Last updated: Based on current skill implementations in the repository*

--- a/evals/agent365/a365-setup/evals.json
+++ b/evals/agent365/a365-setup/evals.json
@@ -1,16 +1,16 @@
 {
   "skill_name": "a365-setup",
-  "eval_instructions": "Test against real agent projects in clean state. a365-setup detects agentStack (Agent Framework/LangChain/OpenAI), programmingLanguage, and usesTeamsOrCopilot (CEA=1, Standard=0), asks the final capabilities question, then verifies CLI (Step 1) and Azure prerequisites (Step 2), and delegates to the right skill at Step 3. For the AI Teammate path (isAITeammate=true), Step 3 reads make-ai-teammate/SKILL.md. For all other paths, Step 3 reads make-a365-agent/SKILL.md. a365-setup does NOT run a365 setup all, does NOT create a365.config.json, and does NOT run a365 publish. Capabilities menu: Discoverability, Observability, Tools (WorkIQ), AI Teammate — combinable. Phase 1B shows agent type as 'Custom Engine Agent (CEA)' or 'Standard Agent — no Teams/Copilot integration (Non-M365)'. CEA detection uses multi-signal check: strong standalone signals (teamsapp.yml, Teams app manifests, teams-ai SDK packages, existing a365 configs) or paired signals (generic botbuilder packages + structural marker, env vars + structural marker). Phase 1C derives registrationType from usesTeamsOrCopilot: usesTeamsOrCopilot=1 → registrationType=1 (CEA/Entra app ID path); usesTeamsOrCopilot=0 → registrationType=3 (Standard path). registrationType is derived, never asked.",
+  "eval_instructions": "Test against real agent projects in clean state. a365-setup detects agentStack (Agent Framework/LangChain/OpenAI), programmingLanguage, and usesTeamsOrCopilot (CEA=1, Non-DW=0), asks the final capabilities question, then verifies CLI (Step 1) and Azure prerequisites (Step 2), and delegates to the right skill at Step 3. For the AI Teammate path (isAITeammate=true), Step 3 reads make-ai-teammate/SKILL.md. For all other paths, Step 3 reads make-a365-agent/SKILL.md. a365-setup does NOT run a365 setup all, does NOT create a365.config.json, and does NOT run a365 publish. Capabilities menu: Discoverability, Observability, Tools (WorkIQ), AI Teammate — combinable. Phase 1B shows agent type as 'Custom Engine Agent (CEA)' or 'Non-DW agent — no Teams/Copilot markers detected'. CEA detection uses multi-signal check: strong standalone signals (teamsapp.yml, Teams app manifests, teams-ai SDK packages, existing a365 configs) or paired signals (generic botbuilder packages + structural marker, env vars + structural marker). Phase 1C derives registrationType from usesTeamsOrCopilot: usesTeamsOrCopilot=1 → registrationType=1 (CEA/Entra app ID path); usesTeamsOrCopilot=0 → registrationType=3 (Standard path). registrationType is derived, never asked.",
   "evals": [
     {
       "id": 1,
       "prompt": "Run a365 setup for this agent",
       "description": "Non-AI Teammate path (Discoverability, option 1) on a .NET AgentFramework project — a365 CLI and Azure CLI available",
-      "expected_output": "The skill detects .NET + AgentFramework, confirms with user (showing Agent type as Standard Agent or CEA), asks capabilities from 4-option menu, user selects option 1 (Discoverability), creates 3 todos (Step 1, Step 2, Step 3: make-a365-agent), validates a365 CLI (Step 1), validates Azure CLI + .NET SDK (Step 2), then reads and follows make-a365-agent/SKILL.md (Step 3). a365-setup itself does NOT run a365 setup all.",
+      "expected_output": "The skill detects .NET + AgentFramework, confirms with user (showing Agent type as Non-DW agent or CEA), asks capabilities from 4-option menu, user selects option 1 (Discoverability), creates 3 todos (Step 1, Step 2, Step 3: make-a365-agent), validates a365 CLI (Step 1), validates Azure CLI + .NET SDK (Step 2), then reads and follows make-a365-agent/SKILL.md (Step 3). a365-setup itself does NOT run a365 setup all.",
       "files": [],
       "expectations": [
-        "Phase 1A: Agent stack, language, and agent type (CEA vs Standard) are detected",
-        "Phase 1B: Detection summary shows Stack, Language, and Agent type (human-readable CEA or Standard Agent label)",
+        "Phase 1A: Agent stack, language, and agent type (CEA vs Non-DW) are detected",
+        "Phase 1B: Detection summary shows Stack, Language, and Agent type (human-readable CEA or Non-DW agent label)",
         "Phase 1B: Capabilities menu shows all 4 options: Discoverability, Observability, Tools (WorkIQ), AI Teammate",
         "Phase 1B: User is told options can be combined",
         "Phase 1C: isAITeammate = false (Discoverability path selected)",
@@ -36,7 +36,7 @@
       "files": [],
       "expectations": [
         "Phase 1A: language detected as NodeJS from package.json",
-        "Phase 1B: Detection summary shown with Agent type field (CEA or Standard Agent)",
+        "Phase 1B: Detection summary shown with Agent type field (CEA or Non-DW agent)",
         "Phase 1B: 4-option capabilities menu shown: Discoverability, Observability, Tools (WorkIQ), AI Teammate",
         "Phase 1C: 3 todos created, Todo 3 = Step 3: Run the make-a365-agent skill",
         "Step 1: a365 --version is run",
@@ -58,7 +58,7 @@
         "Phase 1A: usesTeamsOrCopilot detected as 1 (CEA) from teamsapp.yml or @microsoft/teams-ai — NOT from a365.config.json alone",
         "Phase 1A: Detection does NOT require a365.config.json to exist for CEA classification",
         "Phase 1B: Agent type shown as 'Custom Engine Agent (CEA) — has Teams/Copilot integration'",
-        "Phase 1B: User can correct to Standard Agent if detection is wrong",
+        "Phase 1B: User can correct to Non-DW agent if detection is wrong",
         "Phase 1B: 4-option capabilities menu shown: Discoverability, Observability, Tools (WorkIQ), AI Teammate",
         "Phase 1C: registrationType = 1 (derived from usesTeamsOrCopilot=1 — CEA/Entra app ID path)",
         "Phase 1C: 3 todos created",

--- a/evals/agent365/add-workiq-tools/evals.json
+++ b/evals/agent365/add-workiq-tools/evals.json
@@ -6,10 +6,10 @@
       "id": 1,
       "prompt": "Add workiq tools to this agent",
       "description": "Full flow on a .NET AgentFramework project — a365 setup not yet run",
-      "expected_output": "The skill detects .NET AgentFramework, determines agentType and authMode via two-stage question (AI Teammate vs Non-DW, then auth mode — with S2S warning if selected), runs a365 develop list-available, asks the user which servers to add, runs a365 develop add-mcp-servers, installs the tooling NuGet package, wires GetMcpToolsAsync in the agent class, registers IMcpToolRegistrationService in Program.cs, explains that a365 setup all will apply permissions, shows how to get a dev token, and validates the build.",
+      "expected_output": "The skill detects .NET AgentFramework, determines agentType and authMode via two-stage question (AI Teammate (Digital Worker) vs Standard Agent (Non Digital Worker), then auth mode — with S2S warning if selected), runs a365 develop list-available, asks the user which servers to add, runs a365 develop add-mcp-servers, installs the tooling NuGet package, wires GetMcpToolsAsync in the agent class, registers IMcpToolRegistrationService in Program.cs, explains that a365 setup all will apply permissions, shows how to get a dev token, and validates the build.",
       "files": [],
       "expectations": [
-        "Phase 0B: Agent type question presented — AI Teammate or Non-DW",
+        "Phase 0B: Agent type question presented — AI Teammate (Digital Worker) or Standard Agent (Non Digital Worker)",
         "Phase 0B: Auth mode question presented based on agent type selection",
         "Phase 0B: agentType and authMode determined and stored in .a365-workspace-detection.json",
         "Phase 0B: If authMode is S2S, WorkIQ compatibility warning is shown before proceeding to Phase 4",
@@ -42,7 +42,7 @@
       "expected_output": "The skill detects Node.js LangChain, determines agentType and authMode via two-stage question (with S2S warning if selected), runs a365 develop list-available, adds selected servers via CLI, installs @microsoft/agents-a365-tooling, wires A365McpToolClient.getToolsAsync in the agent, adds env vars to .env, explains that a Global Administrator must run a365 setup permissions mcp since blueprint already exists, shows a365 develop get-token, and validates the build.",
       "files": [],
       "expectations": [
-        "Phase 0B: Agent type question presented — AI Teammate or Non-DW",
+        "Phase 0B: Agent type question presented — AI Teammate (Digital Worker) or Standard Agent (Non Digital Worker)",
         "Phase 0B: Auth mode question presented based on agent type selection",
         "Phase 0B: agentType and authMode determined and stored in .a365-workspace-detection.json",
         "Phase 0B: If authMode is S2S, WorkIQ compatibility warning is shown before proceeding to Phase 4",
@@ -118,7 +118,7 @@
       "expected_output": "The skill detects Python AgentFramework, determines agentType and authMode via two-stage question, runs a365 develop list-available, adds the two servers via CLI, installs microsoft-agents-a365-tooling and the agent-framework extension, wires McpToolRegistrationService and get_mcp_tools_async in the agent class, adds BEARER_TOKEN and ENV=development to .env, explains that a Global Administrator must run a365 setup permissions mcp since blueprint already exists, shows a365 develop get-token, and validates imports.",
       "files": [],
       "expectations": [
-        "Phase 0B: Agent type question presented — AI Teammate or Non-DW",
+        "Phase 0B: Agent type question presented — AI Teammate (Digital Worker) or Standard Agent (Non Digital Worker)",
         "Phase 0B: Auth mode question presented based on agent type selection",
         "Phase 0B: agentType and authMode stored in .a365-workspace-detection.json",
         "Phase 1: Agent type is detected as Python",

--- a/evals/agent365/add-workiq-tools/evals.json
+++ b/evals/agent365/add-workiq-tools/evals.json
@@ -6,10 +6,10 @@
       "id": 1,
       "prompt": "Add workiq tools to this agent",
       "description": "Full flow on a .NET AgentFramework project — a365 setup not yet run",
-      "expected_output": "The skill detects .NET AgentFramework, determines agentType and authMode via two-stage question (AI Teammate vs System Agent, then auth mode — with S2S warning if selected), runs a365 develop list-available, asks the user which servers to add, runs a365 develop add-mcp-servers, installs the tooling NuGet package, wires GetMcpToolsAsync in the agent class, registers IMcpToolRegistrationService in Program.cs, explains that a365 setup all will apply permissions, shows how to get a dev token, and validates the build.",
+      "expected_output": "The skill detects .NET AgentFramework, determines agentType and authMode via two-stage question (AI Teammate vs Non-DW, then auth mode — with S2S warning if selected), runs a365 develop list-available, asks the user which servers to add, runs a365 develop add-mcp-servers, installs the tooling NuGet package, wires GetMcpToolsAsync in the agent class, registers IMcpToolRegistrationService in Program.cs, explains that a365 setup all will apply permissions, shows how to get a dev token, and validates the build.",
       "files": [],
       "expectations": [
-        "Phase 0B: Agent type question presented — AI Teammate or System Agent",
+        "Phase 0B: Agent type question presented — AI Teammate or Non-DW",
         "Phase 0B: Auth mode question presented based on agent type selection",
         "Phase 0B: agentType and authMode determined and stored in .a365-workspace-detection.json",
         "Phase 0B: If authMode is S2S, WorkIQ compatibility warning is shown before proceeding to Phase 4",
@@ -42,7 +42,7 @@
       "expected_output": "The skill detects Node.js LangChain, determines agentType and authMode via two-stage question (with S2S warning if selected), runs a365 develop list-available, adds selected servers via CLI, installs @microsoft/agents-a365-tooling, wires A365McpToolClient.getToolsAsync in the agent, adds env vars to .env, explains that a Global Administrator must run a365 setup permissions mcp since blueprint already exists, shows a365 develop get-token, and validates the build.",
       "files": [],
       "expectations": [
-        "Phase 0B: Agent type question presented — AI Teammate or System Agent",
+        "Phase 0B: Agent type question presented — AI Teammate or Non-DW",
         "Phase 0B: Auth mode question presented based on agent type selection",
         "Phase 0B: agentType and authMode determined and stored in .a365-workspace-detection.json",
         "Phase 0B: If authMode is S2S, WorkIQ compatibility warning is shown before proceeding to Phase 4",
@@ -118,7 +118,7 @@
       "expected_output": "The skill detects Python AgentFramework, determines agentType and authMode via two-stage question, runs a365 develop list-available, adds the two servers via CLI, installs microsoft-agents-a365-tooling and the agent-framework extension, wires McpToolRegistrationService and get_mcp_tools_async in the agent class, adds BEARER_TOKEN and ENV=development to .env, explains that a Global Administrator must run a365 setup permissions mcp since blueprint already exists, shows a365 develop get-token, and validates imports.",
       "files": [],
       "expectations": [
-        "Phase 0B: Agent type question presented — AI Teammate or System Agent",
+        "Phase 0B: Agent type question presented — AI Teammate or Non-DW",
         "Phase 0B: Auth mode question presented based on agent type selection",
         "Phase 0B: agentType and authMode stored in .a365-workspace-detection.json",
         "Phase 1: Agent type is detected as Python",

--- a/evals/agent365/instrument-observability/evals.json
+++ b/evals/agent365/instrument-observability/evals.json
@@ -14,7 +14,7 @@
         "Phase 1: references/dotnet-observability.md is read for patterns",
         "Phase 1: Entry point (Program.cs) is identified",
         "Phase 1: Message handler file is identified",
-        "Phase 0.5: Agent type question presented — AI Teammate or System Agent",
+        "Phase 0.5: Agent type question presented — AI Teammate (Digital Worker) or Non-DW",
         "Phase 0.5: Auth mode question presented based on agent type selection",
         "Phase 0.5: agentType and authMode determined and stored in .a365-workspace-detection.json",
         "Phase 0.5: authMode is one of: user-delegated, agentic-identity, or S2S",
@@ -41,7 +41,7 @@
         "Phase 6: Agent365Observability section (AgentBlueprintId, TenantId, AgentName, AgentDescription) and Logging.LogLevel entries added",
         "Phase 7: dotnet build is run to validate",
         "Phase 7: Build succeeds without errors",
-        "Phase 8: Final summary lists agent kind (AI Teammate or System Agent), authMode, packages installed, files modified",
+        "Phase 8: Final summary lists agent kind (AI Teammate (Digital Worker) or Non-DW), authMode, packages installed, files modified",
         "Phase 8: User is reminded to update observability endpoint in config",
         "Phase 8: User is reminded to review against official samples"
       ]
@@ -58,7 +58,7 @@
         "Phase 1: references/nodejs-observability.md is read for patterns",
         "Phase 1: Entry point (index.ts, index.js, app.ts, or app.js) is identified",
         "Phase 1: Message handler location is identified",
-        "Phase 0.5: Agent type question presented — AI Teammate or System Agent",
+        "Phase 0.5: Agent type question presented — AI Teammate (Digital Worker) or Non-DW",
         "Phase 0.5: Auth mode question presented based on agent type selection",
         "Phase 0.5: agentType and authMode determined and stored in .a365-workspace-detection.json",
         "Phase 0.5: authMode is one of: user-delegated, agentic-identity, or S2S",
@@ -86,7 +86,7 @@
         "Phase 7: npm install is run to ensure new packages are installed",
         "Phase 7: npm run build (or compile) is attempted",
         "Phase 7: Build succeeds or no build script exists (both acceptable)",
-        "Phase 8: Final summary lists agent kind (AI Teammate or System Agent), authMode, packages installed, files modified",
+        "Phase 8: Final summary lists agent kind (AI Teammate (Digital Worker) or Non-DW), authMode, packages installed, files modified",
         "Phase 8: User is reminded to update observability endpoint in .env",
         "Phase 8: User is reminded to review against official samples"
       ]
@@ -160,7 +160,7 @@
         "Phase 1: references/python-observability.md is read for patterns",
         "Phase 1: Entry point (main.py, app.py, or similar) is identified",
         "Phase 1: Message handler location is identified",
-        "Phase 0.5: Agent type question presented — AI Teammate or System Agent",
+        "Phase 0.5: Agent type question presented — AI Teammate (Digital Worker) or Non-DW",
         "Phase 0.5: Auth mode question presented based on agent type selection",
         "Phase 0.5: agentType and authMode determined and stored in .a365-workspace-detection.json",
         "Phase 0.5: authMode is one of: user-delegated, agentic-identity, or S2S",
@@ -186,7 +186,7 @@
         "Phase 6: .env.example is also updated if it exists",
         "Phase 7: python -c import check run to verify packages are installed",
         "Phase 7: Import check succeeds",
-        "Phase 8: Final summary lists agent kind (AI Teammate or System Agent), authMode, packages installed, files modified",
+        "Phase 8: Final summary lists agent kind (AI Teammate (Digital Worker) or Non-DW), authMode, packages installed, files modified",
         "Phase 8: User is reminded to set ENABLE_A365_OBSERVABILITY_EXPORTER=true in production",
         "Phase 8: User is reminded to review against official samples"
       ]
@@ -215,7 +215,7 @@
     {
       "id": 8,
       "prompt": "Instrument observability for this agent",
-      "description": "Test on a .NET System Agent — authMode: S2S (FMI token chain, no user OBO)",
+      "description": "Test on a .NET Non-DW agent — authMode: S2S (FMI token chain, no user OBO)",
       "expected_output": "The skill detects .NET, determines agentType as system-agent and authMode as S2S, installs Microsoft.Agents.A365.Observability.Runtime plus Azure.Identity and Microsoft.Identity.Client, creates Observability/ObservabilityServiceExtensions.cs and Observability/ObservabilityTokenService.cs scaffold files, wires AddAgent365Observability() and AddA365Tracing() in Program.cs (NOT AddAgenticTracingExporter), injects Agent365ObservabilityContext into the agent class with no per-turn RegisterObservability() call, uses InvokeAgentScope.Start().FromTurnContext() for baggage, updates appsettings.json with EnableAgent365Exporter: true including ClientId, and validates the build passes.",
       "files": [],
       "expectations": [
@@ -240,7 +240,7 @@
         "Phase 6: Agent365Observability section includes both ClientId and ClientSecret fields for FMI chain (MSI in prod, secret as local-dev fallback)",
         "Phase 6: appsettings.Development.json updated with EnableAgent365Exporter: false",
         "Phase 7: dotnet build is run and succeeds",
-        "Phase 8: Final summary lists agent kind (System Agent), authMode (S2S), scaffold files created, packages installed",
+        "Phase 8: Final summary lists agent kind (Non-DW agent), authMode (S2S), scaffold files created, packages installed",
         "Phase 8: User is reminded to populate Agent365Observability:ClientId and ClientSecret in appsettings"
       ]
     }

--- a/evals/agent365/instrument-observability/evals.json
+++ b/evals/agent365/instrument-observability/evals.json
@@ -14,7 +14,7 @@
         "Phase 1: references/dotnet-observability.md is read for patterns",
         "Phase 1: Entry point (Program.cs) is identified",
         "Phase 1: Message handler file is identified",
-        "Phase 0.5: Agent type question presented — AI Teammate (Digital Worker) or Non-DW",
+        "Phase 0.5: Agent type question presented — AI Teammate (Digital Worker) or Standard Agent (Non Digital Worker)",
         "Phase 0.5: Auth mode question presented based on agent type selection",
         "Phase 0.5: agentType and authMode determined and stored in .a365-workspace-detection.json",
         "Phase 0.5: authMode is one of: user-delegated, agentic-identity, or S2S",
@@ -41,7 +41,7 @@
         "Phase 6: Agent365Observability section (AgentBlueprintId, TenantId, AgentName, AgentDescription) and Logging.LogLevel entries added",
         "Phase 7: dotnet build is run to validate",
         "Phase 7: Build succeeds without errors",
-        "Phase 8: Final summary lists agent kind (AI Teammate (Digital Worker) or Non-DW), authMode, packages installed, files modified",
+        "Phase 8: Final summary lists agent kind (AI Teammate (Digital Worker) or Standard Agent (Non Digital Worker)), authMode, packages installed, files modified",
         "Phase 8: User is reminded to update observability endpoint in config",
         "Phase 8: User is reminded to review against official samples"
       ]
@@ -58,7 +58,7 @@
         "Phase 1: references/nodejs-observability.md is read for patterns",
         "Phase 1: Entry point (index.ts, index.js, app.ts, or app.js) is identified",
         "Phase 1: Message handler location is identified",
-        "Phase 0.5: Agent type question presented — AI Teammate (Digital Worker) or Non-DW",
+        "Phase 0.5: Agent type question presented — AI Teammate (Digital Worker) or Standard Agent (Non Digital Worker)",
         "Phase 0.5: Auth mode question presented based on agent type selection",
         "Phase 0.5: agentType and authMode determined and stored in .a365-workspace-detection.json",
         "Phase 0.5: authMode is one of: user-delegated, agentic-identity, or S2S",
@@ -86,7 +86,7 @@
         "Phase 7: npm install is run to ensure new packages are installed",
         "Phase 7: npm run build (or compile) is attempted",
         "Phase 7: Build succeeds or no build script exists (both acceptable)",
-        "Phase 8: Final summary lists agent kind (AI Teammate (Digital Worker) or Non-DW), authMode, packages installed, files modified",
+        "Phase 8: Final summary lists agent kind (AI Teammate (Digital Worker) or Standard Agent (Non Digital Worker)), authMode, packages installed, files modified",
         "Phase 8: User is reminded to update observability endpoint in .env",
         "Phase 8: User is reminded to review against official samples"
       ]
@@ -160,7 +160,7 @@
         "Phase 1: references/python-observability.md is read for patterns",
         "Phase 1: Entry point (main.py, app.py, or similar) is identified",
         "Phase 1: Message handler location is identified",
-        "Phase 0.5: Agent type question presented — AI Teammate (Digital Worker) or Non-DW",
+        "Phase 0.5: Agent type question presented — AI Teammate (Digital Worker) or Standard Agent (Non Digital Worker)",
         "Phase 0.5: Auth mode question presented based on agent type selection",
         "Phase 0.5: agentType and authMode determined and stored in .a365-workspace-detection.json",
         "Phase 0.5: authMode is one of: user-delegated, agentic-identity, or S2S",
@@ -186,7 +186,7 @@
         "Phase 6: .env.example is also updated if it exists",
         "Phase 7: python -c import check run to verify packages are installed",
         "Phase 7: Import check succeeds",
-        "Phase 8: Final summary lists agent kind (AI Teammate (Digital Worker) or Non-DW), authMode, packages installed, files modified",
+        "Phase 8: Final summary lists agent kind (AI Teammate (Digital Worker) or Standard Agent (Non Digital Worker)), authMode, packages installed, files modified",
         "Phase 8: User is reminded to set ENABLE_A365_OBSERVABILITY_EXPORTER=true in production",
         "Phase 8: User is reminded to review against official samples"
       ]

--- a/plugins/agent365/shared/agent-detection.md
+++ b/plugins/agent365/shared/agent-detection.md
@@ -436,22 +436,26 @@ Write marker: `.a365obs-appid-warned` to avoid repeating the warning.
 ### Stage 1 — What kind of agent is this?
 
 Pre-fill from cache if `usesTeamsOrCopilot` is already known:
-- `usesTeamsOrCopilot = 1` → suggest **A — AI Teammate**, ask to confirm
-- `usesTeamsOrCopilot = 0` → suggest **B — System Agent**, ask to confirm
+- `usesTeamsOrCopilot = 1` → suggest **A — AI Teammate (Digital Worker)**, ask to confirm
+- `usesTeamsOrCopilot = 0` → suggest **B — Non-Digital Worker (Non-DW)**, ask to confirm
 
 ```
 AskUserQuestion:
   question: |
     🤖 First — what kind of agent is this?
 
-    A — AI Teammate
-        Works alongside a user in Teams, Outlook, or other Microsoft 365 apps
+    A — AI Teammate (Digital Worker / DW)
+        Has a first-class M365 identity — an Agentic User with a UPN, mailbox, and
+        presence in your tenant. Behaves like a real colleague inside Teams and Outlook.
+        Designed for ongoing, human-like teamwork.
 
-    B — System Agent
-        Runs on its own, no user actively in the loop
+    B — Non-Digital Worker (Non-DW) agent
+        No Agentic User identity (no UPN). Task-oriented, system-oriented, or assistive.
+        Uses an Entra App ID or Agent Blueprint + Agent Identity.
+        Appears as a system or service agent, not as a virtual teammate.
   options:
-    - "A — AI Teammate"
-    - "B — System Agent"
+    - "A — AI Teammate (Digital Worker)"
+    - "B — Non-Digital Worker (Non-DW) agent"
 ```
 
 Store as **`agentType`**: A → `ai-teammate` · B → `system-agent`
@@ -486,53 +490,55 @@ AskUserQuestion:
 
 ---
 
-### Stage 2b — If System Agent
+### Stage 2b — If Non-Digital Worker (Non-DW)
 
 ```
 AskUserQuestion:
   question: |
-    What does your agent need?
+    How does this Non-DW agent execute?
 
-    1 — Runs autonomously
-        Agent authenticates as itself, no user required
+    1 — Autonomous (S2S / Service Principal)
+        Agent runs independently as itself — no signed-in user required.
+        Authenticates with Entra App ID or Agent Blueprint credentials.
         → Docs: https://learn.microsoft.com/en-us/microsoft-agent-365/developer/authentication-flow
 
-    2 — Assistive
-        Agent acts on behalf of the user triggering it
+    2 — Assistive (OBO)
+        Agent acts on behalf of the signed-in user via On-Behalf-Of flow.
         → Docs: https://learn.microsoft.com/en-us/entra/agent-id/agent-on-behalf-of-oauth-flow
 
-    ✅ Both options work with Observability
-    ⚠️  "Runs autonomously" is not supported by WorkIQ tools (WorkIQ requires a user in the loop)
+    ✅ Both modes work with Observability
+    ⚠️  Autonomous (S2S) is not supported by WorkIQ tools — WorkIQ requires a user in the loop
   options:
-    - "1 — Runs autonomously"
-    - "2 — Assistive"
+    - "1 — Autonomous (S2S / Service Principal)"
+    - "2 — Assistive (OBO)"
 ```
 
 | Choice | `authMode` |
 |--------|-----------|
-| Runs autonomously | `S2S` |
-| Assistive | `agentic-identity` |
+| Autonomous (S2S / Service Principal) | `S2S` |
+| Assistive (OBO) | `agentic-identity` |
 
 ---
 
 ### Full result mapping
 
-| `agentType` | Choice | `authMode` |
-|------------|--------|-----------|
-| `ai-teammate` | Access data as the signed-in user | `user-delegated` |
-| `ai-teammate` | Its own persistent identity in your org | `agentic-identity` |
-| `system-agent` | Runs autonomously | `S2S` |
-| `system-agent` | Assistive | `agentic-identity` |
+| `agentType` | Label | `authMode` |
+|------------|-------|-----------|
+| `ai-teammate` (Digital Worker) | Access data as the signed-in user | `user-delegated` |
+| `ai-teammate` (Digital Worker) | Its own persistent identity in your org | `agentic-identity` |
+| `system-agent` (Non-DW) | Autonomous (S2S / Service Principal) | `S2S` |
+| `system-agent` (Non-DW) | Assistive (OBO) | `agentic-identity` |
 
 ---
 
 ### Compatibility table
 
-| `authMode` | Observability | WorkIQ tools |
-|-----------|---------------|-------------|
-| `user-delegated` | ✅ Traces attributed to the signed-in user | ✅ M365 data scoped to the signed-in user |
-| `agentic-identity` | ✅ Traces attributed to agent's own identity | ✅ M365 data scoped to agent identity |
-| `S2S` | ✅ Traces attributed to agent (no user context) | ⚠️ Not supported — WorkIQ requires a user in the loop |
+| Agent kind | `authMode` | Observability | WorkIQ tools |
+|-----------|-----------|---------------|-------------|
+| AI Teammate (DW) | `user-delegated` (OBO as signed-in user) | ✅ | ✅ M365 data scoped to signed-in user |
+| AI Teammate (DW) | `agentic-identity` (OBO as agent's own M365 identity) | ✅ | ✅ M365 data scoped to agent identity |
+| Non-DW | `agentic-identity` / Assistive (OBO) | ✅ | ✅ OBO only |
+| Non-DW | `S2S` / Autonomous (Service Principal) | ✅ | ⚠️ Not supported — WorkIQ requires a user in the loop |
 
 ---
 
@@ -550,13 +556,16 @@ Add this inline comment wherever the auth handler is wired:
 
 ### Prerequisite for `agentic-identity`
 
-An **agentic user** must be provisioned in Azure AD — a real user object with a mailbox, OneDrive, and `agent@tenant` UPN. If not yet done, remind the user:
+The `agentic-identity` authMode is used in two distinct contexts:
 
-> "Agentic identity requires an agentic user provisioned in Azure AD.
-> Follow the identity setup guide:
-> https://learn.microsoft.com/en-us/microsoft-agent-365/developer/identity"
+- **AI Teammate (Digital Worker)** — The agentic user IS the DW's identity: a real Azure AD user object with a mailbox, OneDrive, and `agent@tenant` UPN. If not yet provisioned, remind the user:
+  > "An AI Teammate requires an agentic user provisioned in Azure AD.
+  > Follow the identity setup guide:
+  > https://learn.microsoft.com/en-us/microsoft-agent-365/developer/identity"
 
-`user-delegated` has no additional Azure AD setup requirement — it uses the signed-in user's existing token. `S2S` uses the agent blueprint's own credentials.
+- **Non-DW agent (Assistive OBO)** — No agentic user (no UPN). The agent uses its own Entra App ID or Agent Blueprint identity to facilitate the OBO flow on behalf of the signed-in user.
+
+`user-delegated` has no additional Azure AD setup requirement — it uses the signed-in user's existing token. `S2S` authenticates with the agent blueprint's own credentials (service principal).
 
 ---
 

--- a/plugins/agent365/shared/agent-detection.md
+++ b/plugins/agent365/shared/agent-detection.md
@@ -440,25 +440,25 @@ Write marker: `.a365obs-appid-warned` to avoid repeating the warning.
 
 Pre-fill from cache if `usesTeamsOrCopilot` is already known:
 - `usesTeamsOrCopilot = 1` → suggest **A — AI Teammate (Digital Worker)**, ask to confirm
-- `usesTeamsOrCopilot = 0` → suggest **B — Non-Digital Worker (Non-DW)**, ask to confirm
+- `usesTeamsOrCopilot = 0` → suggest **B — Standard Agent (Non Digital Worker)**, ask to confirm
 
 ```
 AskUserQuestion:
   question: |
     🤖 First — what kind of agent is this?
 
-    A — AI Teammate (Digital Worker / DW)
+    A — AI Teammate (Digital Worker)
         Has a first-class M365 identity — an Agentic User with a UPN, mailbox, and
         presence in your tenant. Behaves like a real colleague inside Teams and Outlook.
         Designed for ongoing, human-like teamwork.
 
-    B — Non-Digital Worker (Non-DW) agent
+    B — Standard Agent (Non Digital Worker)
         No Agentic User identity (no UPN). Task-oriented, system-oriented, or assistive.
         Uses an Entra App ID or Agent Blueprint + Agent Identity.
         Appears as a system or service agent, not as a virtual teammate.
   options:
     - "A — AI Teammate (Digital Worker)"
-    - "B — Non-Digital Worker (Non-DW) agent"
+    - "B — Standard Agent (Non Digital Worker)"
 ```
 
 Store as **`agentType`**: A → `ai-teammate` · B → `system-agent`
@@ -493,12 +493,12 @@ AskUserQuestion:
 
 ---
 
-### Stage 2b — If Non-Digital Worker (Non-DW)
+### Stage 2b — If Standard Agent (Non Digital Worker)
 
 ```
 AskUserQuestion:
   question: |
-    How does this Non-DW agent execute?
+    How does this Standard Agent (Non Digital Worker) execute?
 
     1 — Autonomous (S2S / Service Principal)
         Agent runs independently as itself — no signed-in user required.
@@ -529,8 +529,8 @@ AskUserQuestion:
 |------------|-------|-----------|
 | `ai-teammate` (Digital Worker) | Access data as the signed-in user | `user-delegated` |
 | `ai-teammate` (Digital Worker) | Its own persistent identity in your org | `agentic-identity` |
-| `system-agent` (Non-DW) | Autonomous (S2S / Service Principal) | `S2S` |
-| `system-agent` (Non-DW) | Assistive (OBO) | `agentic-identity` |
+| `system-agent` (Standard Agent / Non Digital Worker) | Autonomous (S2S / Service Principal) | `S2S` |
+| `system-agent` (Standard Agent / Non Digital Worker) | Assistive (OBO) | `agentic-identity` |
 
 ---
 
@@ -540,8 +540,8 @@ AskUserQuestion:
 |-----------|-----------|---------------|-------------|
 | AI Teammate (DW) | `user-delegated` (OBO as signed-in user) | ✅ | ✅ M365 data scoped to signed-in user |
 | AI Teammate (DW) | `agentic-identity` (OBO as agent's own M365 identity) | ✅ | ✅ M365 data scoped to agent identity |
-| Non-DW | `agentic-identity` / Assistive (OBO) | ✅ | ✅ OBO only |
-| Non-DW | `S2S` / Autonomous (Service Principal) | ✅ | ⚠️ Not supported — WorkIQ requires a user in the loop |
+| Standard Agent (Non Digital Worker) | `agentic-identity` / Assistive (OBO) | ✅ | ✅ OBO only |
+| Standard Agent (Non Digital Worker) | `S2S` / Autonomous (Service Principal) | ✅ | ⚠️ Not supported — WorkIQ requires a user in the loop |
 
 ---
 

--- a/plugins/agent365/shared/agent-detection.md
+++ b/plugins/agent365/shared/agent-detection.md
@@ -17,9 +17,12 @@ The skill MUST detect and store these three variables before asking ANY question
    - Possible values: `DotNet`, `Python`, `NodeJS`
    - Detection: File extension analysis
 
-3. **`usesTeamsOrCopilot`** — Is this a Custom Engine Agent?
-   - Possible values: `1` (true) or `0` (false)
+3. **`usesTeamsOrCopilot`** — Does this agent have M365 / Teams / Copilot integration markers?
+   - Possible values: `1` (M365 CEA detected) or `0` (no M365 integration detected)
    - Detection: Check for CEA signals across file presence, packages, and config (see below)
+   - Note: `0` does not mean the agent is not a Non-DW — it may be a non-M365 CEA, a background
+     automation agent, Agent Builder agent, SharePoint agent, or other Non-DW type. It simply means
+     no Teams/Copilot markers were detected, so the M365 CEA registration path is not triggered.
 
 ### Agent Stack Detection Logic
 

--- a/plugins/agent365/shared/agent-detection.md
+++ b/plugins/agent365/shared/agent-detection.md
@@ -123,14 +123,14 @@ explicitly listed CEA markers above are sufficient exceptions: the structural fi
 Teams AI SDK package references (`@microsoft/teams-ai`, `Microsoft.Teams.AI`, `teams-ai`).
 Do not treat generic Bot Framework packages as standalone CEA markers.
 
-- **M365 signal found AND any CEA marker found** → This is a Custom Engine Agent. **Do NOT block.** Set `usesTeamsOrCopilot = 1`, continue to Step 2.
-- **M365 signal found AND NO CEA marker found** → Likely a Teams/BizChat/Copilot channel bot. **STOP** (see message below), unless user explicitly confirms AI Teammate intent.
+- **M365 signal found AND any CEA marker found** → This is a Custom Engine Agent (Non-DW). **Do NOT block.** Set `usesTeamsOrCopilot = 1`, continue to Step 2.
+- **M365 signal found AND NO CEA marker found** → Likely a Teams/BizChat/Copilot channel bot. **STOP** (see message below), unless user explicitly confirms CEA or AI Teammate intent.
 
 > Tell the user (STOP case only):
 > "This agent is configured for Teams channels, BizChat, or Microsoft Copilot.
 > Non-AI-teammate channel bots cannot be registered as A365 blueprints.
-> Only AI Teammate agents and M365 custom engine agents are supported.
-> If this detection is wrong (e.g., this is an M365 custom engine agent), confirm explicitly."
+> Only AI Teammate (Digital Worker) agents and Custom Engine Agents (as Non-DW) are supported.
+> If this detection is wrong (e.g., this is a Custom Engine Agent), confirm explicitly."
 
 Write marker: `.a365setup-m365-blocked` (setup) or skip instrumentation (observability).
 

--- a/plugins/agent365/skills/a365-setup/SKILL.md
+++ b/plugins/agent365/skills/a365-setup/SKILL.md
@@ -104,7 +104,7 @@ Here's what we detected about your agent:
   • Stack:         {agentStack}
   • Language:      {programmingLanguage}
   • Agent type:    {usesTeamsOrCopilot == 1
-                     ? "Custom Engine Agent (CEA) — has Teams/Copilot integration"
+                     ? "Custom Engine Agent (CEA) — Non-Digital Worker (Non-DW) with Teams/Copilot integration"
                      : "Standard Agent — no Teams/Copilot integration (Non-M365)"}
 
 Reply **yes** to confirm, or describe any corrections.
@@ -120,12 +120,19 @@ After confirming, write `.a365-workspace-detection.json` (see `agent-detection.m
 
 **Final question: What capabilities do you want to enable?**
 
-Present these four options:
+Present these options (omit or note option 4 if CEA was detected — see below):
 
   1. Discoverability — make the agent findable in the M365 catalog
   2. Observability — end-to-end activity tracing for every message, LLM call, and tool use, visible in the Agent 365 portal and Microsoft Defender
   3. Tools — add WorkIQ MCP tools (M365 data: email, calendar, Teams, SharePoint, OneDrive)
-  4. AI Teammate — full Teams/Copilot integration with hosting layer, registration, and publish
+  4. AI Teammate (Digital Worker) — agent gets a first-class M365 identity (Agentic User with UPN)
+     ⚠️  NOT available for Custom Engine Agents at GA — CEA is supported as Non-DW only
+
+> **CEA guard:** If `usesTeamsOrCopilot = 1` (CEA detected) and the user selects option 4, respond:
+> "Custom Engine Agents are supported as Non-Digital Worker (Non-DW) agents at GA.
+>  AI Teammate (Digital Worker) is not available for CEA at GA.
+>  Please choose from options 1–3."
+> Then re-present options 1–3 and wait for a new answer.
 
 Wait for the answer. Store as `capabilities`.
 
@@ -135,7 +142,10 @@ Wait for the answer. Store as `capabilities`.
 
 After the capabilities question is answered (and the detection/confirmation above is complete):
 
-1. Set `isAITeammate = true` if the user selected **AI Teammate**, else `isAITeammate = false`.
+1. Set `isAITeammate = true` if the user selected **AI Teammate (Digital Worker)**, else `isAITeammate = false`.
+   - **If `usesTeamsOrCopilot = 1` (CEA) AND `isAITeammate = true`:** This combination is not supported at GA.
+     Tell the user: "CEA is supported as a Non-DW agent at GA — AI Teammate (Digital Worker) is not available for CEA."
+     Set `isAITeammate = false` and route to the Standard/CEA path.
 2. Derive `registrationType` from Phase 1A signals (do not ask the user):
    - `registrationType = 1` if `usesTeamsOrCopilot = 1` (CEA — Entra app ID path)
    - `registrationType = 3` if `usesTeamsOrCopilot = 0` (Standard agent path)

--- a/plugins/agent365/skills/a365-setup/SKILL.md
+++ b/plugins/agent365/skills/a365-setup/SKILL.md
@@ -93,7 +93,7 @@ Check the following signals **in parallel** (Glob + Grep).
 - `botbuilder-core` in requirements.txt or pyproject.toml + structural marker → CEA
 - `BOT_ID`, `MicrosoftAppId`, or `TEAMS_APP_ID` in .env/appsettings.json + structural marker → CEA
 
-If no strong standalone signal and no valid pairing → `0` (Standard Agent / Non-M365 Agent)
+If no strong standalone signal and no valid pairing → `0` (Non-DW, no M365 integration detected — may be a non-M365 CEA or other Non-DW type)
 
 ### Phase 1B: User Validation Questions
 
@@ -104,8 +104,8 @@ Here's what we detected about your agent:
   • Stack:         {agentStack}
   • Language:      {programmingLanguage}
   • Agent type:    {usesTeamsOrCopilot == 1
-                     ? "Custom Engine Agent (CEA) — Non-Digital Worker (Non-DW) with Teams/Copilot integration"
-                     : "Standard Agent — no Teams/Copilot integration (Non-M365)"}
+                     ? "M365 Custom Engine Agent (CEA) — Non-DW with Teams/Copilot integration"
+                     : "Non-DW agent — no Teams/Copilot markers detected (may be a non-M365 CEA, background agent, or other Non-DW type)"}
 
 Reply **yes** to confirm, or describe any corrections.
 Examples: "language is NodeJS", "it's a Custom Engine Agent", "it's not Teams".
@@ -113,7 +113,7 @@ Examples: "language is NodeJS", "it's a Custom Engine Agent", "it's not Teams".
 
 - If the user replies **yes / y**: accept all values and proceed to the final capabilities question below.
 - If the user says it's a CEA / Custom Engine Agent: set `usesTeamsOrCopilot = 1` and proceed to the final capabilities question below.
-- If the user says it's Standard / Non-M365: set `usesTeamsOrCopilot = 0` and proceed to the final capabilities question below.
+- If the user says it's Non-M365 / no Teams integration / a non-M365 CEA or other Non-DW type: set `usesTeamsOrCopilot = 0` and proceed to the final capabilities question below.
 - If the user describes other corrections: update the relevant variable(s) and proceed to the final capabilities question below.
 
 After confirming, write `.a365-workspace-detection.json` (see `agent-detection.md` cache format).
@@ -148,7 +148,7 @@ After the capabilities question is answered (and the detection/confirmation abov
      Set `isAITeammate = false` and route to the Standard/CEA path.
 2. Derive `registrationType` from Phase 1A signals (do not ask the user):
    - `registrationType = 1` if `usesTeamsOrCopilot = 1` (CEA — Entra app ID path)
-   - `registrationType = 3` if `usesTeamsOrCopilot = 0` (Standard agent path)
+   - `registrationType = 3` if `usesTeamsOrCopilot = 0` (Non-DW / no M365 integration path)
    - (`registrationType = 2` — Blueprint already exists — is set by make-ai-teammate, not here)
 
 Then create all todos for the path and mark Todo 1 in-progress:

--- a/plugins/agent365/skills/instrument-observability/SKILL.md
+++ b/plugins/agent365/skills/instrument-observability/SKILL.md
@@ -4,10 +4,10 @@ description: >
   Instruments Microsoft Agent 365 observability into existing .NET AgentFramework, Node.js, or
   Python agents. Adds OTel-based tracing, context propagation, A365 exporter, manual
   instrumentation scopes (InvokeAgentScope, InferenceScope, ExecuteToolScope — required for
-  store publishing), and updates configuration files. Asks a two-stage question (agent kind +
-  auth mode) to determine the correct token path: OBO (user-delegated / agentic-identity) or
-  S2S (FMI token chain, .NET with ObservabilityTokenService scaffold files). Non-destructive
-  and idempotent.
+  store publishing), and updates configuration files. Asks a two-stage question — agent kind
+  (AI Teammate / Digital Worker, or Non-Digital Worker / Non-DW) and auth mode — to determine
+  the correct token path: OBO (user-delegated / agentic-identity / Assistive) or Autonomous S2S
+  (FMI token chain, .NET with ObservabilityTokenService scaffold files). Non-destructive and idempotent.
 compatibility:
   - claude-code
   - vscode-copilot
@@ -28,7 +28,7 @@ hooks:
       prompt: |
         Before ending, verify ALL of the following:
         1. Agent type was correctly detected (.NET AgentFramework, Node.js, or Python).
-        2. agentType (ai-teammate or system-agent) and authMode (user-delegated, agentic-identity, or S2S) were determined and authMode is recorded in an inline comment in the message handler.
+        2. agentType (ai-teammate/Digital Worker or system-agent/Non-DW) and authMode (user-delegated, agentic-identity, or S2S) were determined and authMode is recorded in an inline comment in the message handler.
         3. A365 observability packages were installed (check package.json, .csproj, or pyproject.toml/requirements.txt).
         4. Observability was configured in the entry point (Program.cs, index.js/ts, or app.py).
         5. For OBO path: BaggageBuilder context added to the message handler (or BaggageMiddleware registered). For S2S path (.NET): InvokeAgentScope.Start().FromTurnContext() used; scaffold files Observability/ObservabilityServiceExtensions.cs and Observability/ObservabilityTokenService.cs exist; no per-turn RegisterObservability call.
@@ -106,15 +106,17 @@ Reply **yes** to confirm, or describe any corrections.
 
 ---
 
-## Phase 0.5: Agent Type and Authentication Mode
+## Phase 0.5: Agent Kind and Authentication Mode
 
-**TaskCreate** — "Determine agent type and authentication mode"
+**TaskCreate** — "Determine agent kind and authentication mode"
 
 **Read** `${CLAUDE_PLUGIN_ROOT}/shared/agent-detection.md` — section **"Agent Type and Auth Mode Detection"** — and follow it exactly.
 
 If `agentType` and `authMode` are already present in the detection cache (from a prior skill run in this session), confirm the values with the user and skip the questions.
 
-Store `agentType` (`ai-teammate` or `system-agent`) and `authMode` (`user-delegated`, `agentic-identity`, or `S2S`).
+Store `agentType` (`ai-teammate` = Digital Worker, or `system-agent` = Non-DW) and `authMode`:
+- **AI Teammate (DW):** `user-delegated` (OBO as signed-in user) or `agentic-identity` (OBO as agent's own M365 identity)
+- **Non-DW:** `agentic-identity` (Assistive OBO) or `S2S` (Autonomous / Service Principal)
 
 The `authMode` value drives Phases 3–5: OBO and S2S paths differ in entry point wiring (Phase 3), message handler pattern (Phase 4), and token resolver (Phase 5). **Phases 2, 6, 7, and 8 are identical regardless of `authMode`.**
 

--- a/plugins/agent365/skills/instrument-observability/SKILL.md
+++ b/plugins/agent365/skills/instrument-observability/SKILL.md
@@ -5,7 +5,7 @@ description: >
   Python agents. Adds OTel-based tracing, context propagation, A365 exporter, manual
   instrumentation scopes (InvokeAgentScope, InferenceScope, ExecuteToolScope — required for
   store publishing), and updates configuration files. Asks a two-stage question — agent kind
-  (AI Teammate / Digital Worker, or Non-Digital Worker / Non-DW) and auth mode — to determine
+  (AI Teammate (Digital Worker) or Standard Agent (Non Digital Worker)) and auth mode — to determine
   the correct token path: OBO (user-delegated / agentic-identity / Assistive) or Autonomous S2S
   (FMI token chain, .NET with ObservabilityTokenService scaffold files). Non-destructive and idempotent.
 compatibility:
@@ -28,7 +28,7 @@ hooks:
       prompt: |
         Before ending, verify ALL of the following:
         1. Agent type was correctly detected (.NET AgentFramework, Node.js, or Python).
-        2. agentType (ai-teammate/Digital Worker or system-agent/Non-DW) and authMode (user-delegated, agentic-identity, or S2S) were determined and authMode is recorded in an inline comment in the message handler.
+        2. agentType (ai-teammate/AI Teammate (Digital Worker) or system-agent/Standard Agent (Non Digital Worker)) and authMode (user-delegated, agentic-identity, or S2S) were determined and authMode is recorded in an inline comment in the message handler.
         3. A365 observability packages were installed (check package.json, .csproj, or pyproject.toml/requirements.txt).
         4. Observability was configured in the entry point (Program.cs, index.js/ts, or app.py).
         5. For OBO path: BaggageBuilder context added to the message handler (or BaggageMiddleware registered). For S2S path (.NET): InvokeAgentScope.Start().FromTurnContext() used; scaffold files Observability/ObservabilityServiceExtensions.cs and Observability/ObservabilityTokenService.cs exist; no per-turn RegisterObservability call.
@@ -114,9 +114,9 @@ Reply **yes** to confirm, or describe any corrections.
 
 If `agentType` and `authMode` are already present in the detection cache (from a prior skill run in this session), confirm the values with the user and skip the questions.
 
-Store `agentType` (`ai-teammate` = Digital Worker, or `system-agent` = Non-DW) and `authMode`:
-- **AI Teammate (DW):** `user-delegated` (OBO as signed-in user) or `agentic-identity` (OBO as agent's own M365 identity)
-- **Non-DW:** `agentic-identity` (Assistive OBO) or `S2S` (Autonomous / Service Principal)
+Store `agentType` (`ai-teammate` = AI Teammate (Digital Worker), or `system-agent` = Standard Agent (Non Digital Worker)) and `authMode`:
+- **AI Teammate (Digital Worker):** `user-delegated` (OBO as signed-in user) or `agentic-identity` (OBO as agent's own M365 identity)
+- **Standard Agent (Non Digital Worker):** `agentic-identity` (Assistive OBO) or `S2S` (Autonomous / Service Principal)
 
 The `authMode` value drives Phases 3–5: OBO and S2S paths differ in entry point wiring (Phase 3), message handler pattern (Phase 4), and token resolver (Phase 5). **Phases 2, 6, 7, and 8 are identical regardless of `authMode`.**
 
@@ -591,7 +591,7 @@ If yes, invoke the `test-local` skill.
    ✅ A365 observability instrumented successfully!
 
    **Agent type:** [.NET AgentFramework | Node.js | Python]
-   **Agent kind:** [AI Teammate | System Agent]
+   **Agent kind:** [AI Teammate (Digital Worker) | Standard Agent (Non Digital Worker)]
    **Auth mode:** [Access data as signed-in user | Its own persistent identity | Runs autonomously]
    **Packages installed:** [list packages]
    **Files modified:** [list files]

--- a/plugins/agent365/skills/instrument-observability/references/dotnet-observability.md
+++ b/plugins/agent365/skills/instrument-observability/references/dotnet-observability.md
@@ -46,7 +46,7 @@ dotnet add package Microsoft.Agents.A365.Observability.Extensions.AgentFramework
 
 ## Program.cs — S2S Path (`authMode: S2S`)
 
-Use this pattern for System Agents that run without a signed-in user (autonomous / S2S).
+Use this pattern for Non-DW agents that run without a signed-in user (Autonomous / S2S).
 Requires two scaffold files in `Observability/` — create these before wiring Program.cs.
 
 ### Scaffold: `Observability/ObservabilityServiceExtensions.cs`

--- a/plugins/agent365/skills/make-a365-agent/SKILL.md
+++ b/plugins/agent365/skills/make-a365-agent/SKILL.md
@@ -81,11 +81,12 @@ What capabilities would you like to enable? (options can be combined)
   2. Observability — end-to-end activity tracing for every message, LLM call,
      and tool use, visible in the Agent 365 portal and Microsoft Defender
   3. Tools — add WorkIQ MCP tools (M365 data: email, calendar, Teams, SharePoint, OneDrive)
-  4. AI Teammate — full Teams/Copilot integration (handled by a different skill)
+  4. AI Teammate (Digital Worker) — the agent needs a first-class M365 identity
+     (Agentic User with UPN, mailbox, presence). Handled by a different skill.
 ```
 
-   - If the user selects **option 4 (AI Teammate)** — stop here and tell them:
-     > "AI Teammate setup is handled by the `make-ai-teammate` skill. Run `/agent365:a365-setup` and select option 4, or invoke `make-ai-teammate` directly."
+   - If the user selects **option 4 (AI Teammate / Digital Worker)** — stop here and tell them:
+     > "AI Teammate (Digital Worker) setup is handled by the `make-ai-teammate` skill. Run `/agent365:a365-setup` and select the AI Teammate path, or invoke `make-ai-teammate` directly."
    - Otherwise store the answer as `capabilities` and continue.
 
 **Create all todos for this session:**

--- a/plugins/agent365/skills/make-ai-teammate/SKILL.md
+++ b/plugins/agent365/skills/make-ai-teammate/SKILL.md
@@ -31,7 +31,7 @@ hooks:
         1. src/index.ts has Express + CloudAdapter + /api/health + /api/messages pattern.
         2. src/agent.ts has AgentApplication subclass with message, notification, InstallationUpdate handlers.
         3. src/client.ts has getClient() factory wrapping the user's LLM code.
-        4. ToolingManifest.json exists (even if empty mcpServers array).
+        4. ToolingManifest.json exists with Calendar and Mail MCP servers pre-populated.
         5. .env / .env.example has all required A365 variables.
         6. tsconfig.json has module: "node16" and moduleResolution: "node16".
         7. All required @microsoft/agents-* packages are in package.json.
@@ -387,16 +387,33 @@ Agent calls `self._agent.run()` directly in `process_user_message()`. No changes
 
 **Mark task in progress: "Add ToolingManifest.json"**
 
-**Glob** `ToolingManifest.json`. If it does not exist, **Write** an empty manifest:
+**Glob** `ToolingManifest.json`. If it does not exist, **Write** it pre-populated with the Calendar and Mail WorkIQ servers:
 
 ```json
 {
-  "mcpServers": []
+  "mcpServers": [
+    {
+      "mcpServerName": "mcp_CalendarTools",
+      "mcpServerUniqueName": "mcp_CalendarTools",
+      "url": "https://agent365.svc.cloud.microsoft/agents/servers/mcp_CalendarTools",
+      "scope": "Tools.ListInvoke.All",
+      "audience": "910333d2-47e9-43ca-981f-6df2f4531ef4",
+      "publisher": "Microsoft"
+    },
+    {
+      "mcpServerName": "mcp_MailTools",
+      "mcpServerUniqueName": "mcp_MailTools",
+      "url": "https://agent365.svc.cloud.microsoft/agents/servers/mcp_MailTools",
+      "scope": "Tools.ListInvoke.All",
+      "audience": "16b1878d-62c7-4009-aa25-68989d63bbad",
+      "publisher": "Microsoft"
+    }
+  ]
 }
 ```
 
 Tell the user:
-> "ToolingManifest.json created. To add WorkIQ tools (Mail, Calendar, Teams, etc.), run the `add-workiq-tools` skill."
+> "ToolingManifest.json created with Calendar and Mail WorkIQ servers. To add more WorkIQ tools or wire them into agent code, run the `add-workiq-tools` skill."
 
 If it already exists, leave it unchanged.
 
@@ -532,7 +549,7 @@ Your agent now has:
   • Hosting layer         (/api/health + /api/messages)
   • Agent routing         (message, notification, InstallationUpdate handlers)
   • Email notifications + install/uninstall lifecycle
-  • ToolingManifest.json  (empty — add WorkIQ tools with add-workiq-tools skill)
+  • ToolingManifest.json  (pre-populated: Calendar + Mail WorkIQ servers)
   [• Observability:        OpenTelemetry + A365 tracing exporter wired]  (if added)
   [• WorkIQ tools:         M365 data access via MCP]                     (if added)
 

--- a/plugins/agent365/skills/make-ai-teammate/SKILL.md
+++ b/plugins/agent365/skills/make-ai-teammate/SKILL.md
@@ -53,8 +53,12 @@ hooks:
         5. ToolingManifest.json exists.
         6. .env / .env.template has all required A365 variables.
 
-        If any item failed or was skipped, return {"ok": false, "reason": "<specific item>"}.
-        If all items completed successfully, return {"ok": true}.
+        Also verify for all languages:
+        - instrument-observability was offered and either invoked or explicitly skipped by user.
+        - add-workiq-tools was offered and either invoked or explicitly skipped by user.
+
+        If any item failed or was incomplete, return {"ok": false, "reason": "<specific item>"}.
+        If all items completed (or were explicitly skipped by the user), return {"ok": true}.
       timeout: 45000
 ---
 
@@ -160,6 +164,8 @@ TaskCreate: "Add src/client.ts — LLM client factory"               [skip if ex
 TaskCreate: "Add ToolingManifest.json"                              [skip if hasManifest]
 TaskCreate: "Update .env / .env.example with A365 variables"
 TaskCreate: "Validate build (npm run build)"
+TaskCreate: "Add Observability (optional)"
+TaskCreate: "Add WorkIQ Tools (optional)"
 ```
 
 **.NET tasks (only create if not already present):**
@@ -170,6 +176,8 @@ TaskCreate: "Add Agent/MyAgent.cs — AgentApplication subclass"                
 TaskCreate: "Update appsettings.json with A365 auth and connection config"
 TaskCreate: "Add ToolingManifest.json"                                           [skip if hasManifest]
 TaskCreate: "Validate build (dotnet build)"
+TaskCreate: "Add Observability (optional)"
+TaskCreate: "Add WorkIQ Tools (optional)"
 ```
 
 **Python tasks (only create if not already present):**
@@ -181,6 +189,8 @@ TaskCreate: "Update agent.py — AgentInterface implementation"                 
 TaskCreate: "Add ToolingManifest.json"                                           [skip if hasManifest]
 TaskCreate: "Update .env / .env.template with A365 variables"
 TaskCreate: "Validate setup (uv sync or pip install)"
+TaskCreate: "Add Observability (optional)"
+TaskCreate: "Add WorkIQ Tools (optional)"
 ```
 
 ---
@@ -463,6 +473,54 @@ Do NOT revert changes on build failure — fix forward.
 
 ---
 
+## Phase 9.5 — Offer Observability (Optional)
+
+**Mark task in progress: "Add Observability (optional)"**
+
+Ask the user:
+
+```
+Your AI Teammate code is ready. Observability lets you track every message, LLM call,
+and tool invocation in the Agent 365 portal and Microsoft Defender.
+
+  Would you like to add observability now?
+    • yes  — I'll run the instrument-observability skill now
+    • skip — you can add it later by running the instrument-observability skill
+```
+
+**If yes:** **Read** `${CLAUDE_PLUGIN_ROOT}/skills/instrument-observability/SKILL.md` and follow it.
+
+**If skip:** Note that the user can run the `instrument-observability` skill at any time.
+
+**Mark task complete: "Add Observability (optional)"**
+
+---
+
+## Phase 9.6 — Offer WorkIQ Tools (Optional)
+
+**Mark task in progress: "Add WorkIQ Tools (optional)"**
+
+Ask the user:
+
+```
+Would you like to add WorkIQ tools? These give your agent access to Microsoft 365 data —
+email, calendar, Teams messages, SharePoint files, OneDrive, and more.
+
+Note: WorkIQ MCP calls use OAuth On-Behalf-Of (OBO) tokens. Users will be prompted to
+consent the first time the agent accesses their data.
+
+  • yes  — I'll run the add-workiq-tools skill now
+  • skip — you can add it later by running the add-workiq-tools skill
+```
+
+**If yes:** **Read** `${CLAUDE_PLUGIN_ROOT}/skills/add-workiq-tools/SKILL.md` and follow it.
+
+**If skip:** Note that the user can run the `add-workiq-tools` skill at any time.
+
+**Mark task complete: "Add WorkIQ Tools (optional)"**
+
+---
+
 ## Phase 10 — Final Summary and Next Steps
 
 **TaskList** — show all completed tasks, then tell the user:
@@ -471,15 +529,17 @@ Do NOT revert changes on build failure — fix forward.
 ✅ AI Teammate code is ready!
 
 Your agent now has:
-  • Hosting layer       (/api/health + /api/messages)
-  • Agent routing       (message, notification, InstallationUpdate handlers)
+  • Hosting layer         (/api/health + /api/messages)
+  • Agent routing         (message, notification, InstallationUpdate handlers)
   • Email notifications + install/uninstall lifecycle
-  • ToolingManifest.json (empty — add WorkIQ tools with add-workiq-tools skill)
+  • ToolingManifest.json  (empty — add WorkIQ tools with add-workiq-tools skill)
+  [• Observability:        OpenTelemetry + A365 tracing exporter wired]  (if added)
+  [• WorkIQ tools:         M365 data access via MCP]                     (if added)
 
-Suggested next steps:
-  1. Test locally:       run the test-local skill
-  2. Add WorkIQ tools:   run the add-workiq-tools skill
-  3. Add observability:  run the instrument-observability skill
+Next steps:
+  1. Test locally: run the test-local skill
+  2. Add observability:  run the instrument-observability skill  (if not done)
+  3. Add WorkIQ tools:   run the add-workiq-tools skill          (if not done)
 ```
 
 ---

--- a/plugins/agent365/skills/make-ai-teammate/references/dotnet-ai-teammate.md
+++ b/plugins/agent365/skills/make-ai-teammate/references/dotnet-ai-teammate.md
@@ -339,11 +339,28 @@ namespace YourNamespace.Agent
 
 ---
 
-## ToolingManifest.json (empty — populated by add-workiq-tools skill)
+## ToolingManifest.json (pre-populated with Calendar + Mail WorkIQ servers)
 
 ```json
 {
-  "mcpServers": []
+  "mcpServers": [
+    {
+      "mcpServerName": "mcp_CalendarTools",
+      "mcpServerUniqueName": "mcp_CalendarTools",
+      "url": "https://agent365.svc.cloud.microsoft/agents/servers/mcp_CalendarTools",
+      "scope": "Tools.ListInvoke.All",
+      "audience": "910333d2-47e9-43ca-981f-6df2f4531ef4",
+      "publisher": "Microsoft"
+    },
+    {
+      "mcpServerName": "mcp_MailTools",
+      "mcpServerUniqueName": "mcp_MailTools",
+      "url": "https://agent365.svc.cloud.microsoft/agents/servers/mcp_MailTools",
+      "scope": "Tools.ListInvoke.All",
+      "audience": "16b1878d-62c7-4009-aa25-68989d63bbad",
+      "publisher": "Microsoft"
+    }
+  ]
 }
 ```
 
@@ -358,4 +375,4 @@ namespace YourNamespace.Agent
 | `/api/health` has no auth middleware | Health checks must pass without a valid JWT (used by ALB/ingress) |
 | Typing indicator loop at 4 s | Prevents Teams from timing out the typing indicator (5 s TTL) |
 | Dual `OnActivity` registrations for `isAgenticOnly: true/false` | A365 production uses agentic auth; AgentsPlayground uses OBO or no auth |
-| `ToolingManifest.json` created empty | Populated later by the `add-workiq-tools` skill |
+| `ToolingManifest.json` created with Calendar + Mail servers | Add more servers with the `add-workiq-tools` skill |

--- a/plugins/agent365/skills/make-ai-teammate/references/nodejs-ai-teammate.md
+++ b/plugins/agent365/skills/make-ai-teammate/references/nodejs-ai-teammate.md
@@ -415,13 +415,20 @@ Same structure as LangChain variant — replace `createAgent` / `ReactAgent` wit
       "scope": "Tools.ListInvoke.All",
       "audience": "910333d2-47e9-43ca-981f-6df2f4531ef4",
       "publisher": "Microsoft"
+    },
+    {
+      "mcpServerName": "mcp_MailTools",
+      "mcpServerUniqueName": "mcp_MailTools",
+      "url": "https://agent365.svc.cloud.microsoft/agents/servers/mcp_MailTools",
+      "scope": "Tools.ListInvoke.All",
+      "audience": "16b1878d-62c7-4009-aa25-68989d63bbad",
+      "publisher": "Microsoft"
     }
   ]
 }
 ```
 
-Start with an empty array `{ "mcpServers": [] }` if no WorkIQ tools are needed yet.
-Use `a365 develop add-mcp-servers` to add servers — never hand-edit this file.
+Use `a365 develop add-mcp-servers` to add more servers — never hand-edit this file.
 
 ---
 
@@ -493,7 +500,7 @@ connectionsMap__0__connection=service_connection
 |------|-----|
 | `configDotenv()` first line of `index.ts` and `client.ts` | Env vars must be set before any import that reads `process.env` at load time |
 | `/api/health` before `authorizeJWT` | Azure health probes don't carry JWT tokens |
-| `ToolingManifest.json` created empty | Populated later by the `add-workiq-tools` skill |
+| `ToolingManifest.json` created with Calendar + Mail servers | Add more servers with the `add-workiq-tools` skill |
 | `onAgentNotification` registered BEFORE `onActivity(Message)` | Notification routing must take priority |
 | `onAgentNotification` called with priority `1` and `[authHandlerName]` | Ensures agentic auth is required for notifications |
 | Side-effect import `import '@microsoft/agents-a365-notifications'` | Registers activity deserializers — omitting it silently breaks notification routing |

--- a/plugins/agent365/skills/make-ai-teammate/references/python-ai-teammate.md
+++ b/plugins/agent365/skills/make-ai-teammate/references/python-ai-teammate.md
@@ -396,6 +396,6 @@ LOG_LEVEL=INFO
 | `agent_notification.on_agent_notification(channel_id=ChannelId(channel="agents", sub_channel="*"))` | Subscribes to all agent notification subtypes including email and WPX_COMMENT |
 | Typing indicator loop at 4 s | Prevents Teams from clearing the typing indicator before the LLM responds |
 | `requires-python = ">=3.11"` | `str | None` union syntax requires 3.10+; `asyncio.TaskGroup` requires 3.11+ |
-| `ToolingManifest.json` created empty | Populated later by the `add-workiq-tools` skill |
+| `ToolingManifest.json` created with Calendar + Mail servers | Add more servers with the `add-workiq-tools` skill |
 | `/api/health` returns 200 without auth | Load balancers and A365 infrastructure require unauthenticated health probes |
 


### PR DESCRIPTION
## Summary

- **Terminology**: Adopt consistent paired phrase "AI Teammate (Digital Worker) or Standard Agent (Non Digital Worker)" across all skill files, evals, AGENTS.md, copilot-instructions.md, USER_FLOWS.md, and README.md — replacing inconsistent "System Agent / Non-DW / Non-Digital Worker" variants
- **CEA taxonomy**: Establish CEA ⊂ Non-DW (CEA is a specific subset of Standard Agent / Non Digital Worker, not synonymous); block CEA + AI Teammate path in a365-setup at GA with explicit error message
- **Auth mode constraints**: Document WorkIQ = OBO only (not S2S); Observability = both modes; AI Teammate modes = user-delegated or agentic-identity; Standard Agent modes = Assistive (OBO) or Autonomous (S2S)
- **ToolingManifest.json**: Pre-populate with Calendar + Mail WorkIQ servers (mcp_CalendarTools + mcp_MailTools) in make-ai-teammate instead of an empty array — updated SKILL.md Phase 7, all three language reference docs, and AGENTS.md
- **make-ai-teammate**: Add optional Observability (Phase 9.5) and WorkIQ (Phase 9.6) offer phases, matching make-a365-agent's post-setup flow; update stop hook to verify both were offered or skipped
- **README workflow**: Fix backwards prerequisite flow; add hierarchical tree (a365-setup → DW path: make-ai-teammate | Non-DW path: make-a365-agent); sync trigger phrase blocks; fix fake `copilot plugin` CLI commands
- **agent-detection.md**: Stage 1 question now uses "A — AI Teammate (Digital Worker) / B — Standard Agent (Non Digital Worker)"; compatibility table updated with DW/Non-DW auth mode + WorkIQ constraints

## Test plan

- [ ] Invoke `make-ai-teammate` on a .NET, Node.js, and Python agent project — verify ToolingManifest.json is created with Calendar + Mail servers pre-populated
- [ ] Invoke `a365-setup` on a CEA project and select AI Teammate (option 4) — verify the CEA guard fires and re-presents options 1–3
- [ ] Invoke `instrument-observability` — verify Stage 1 question shows "AI Teammate (Digital Worker) or Standard Agent (Non Digital Worker)"
- [ ] Invoke `add-workiq-tools` — verify same two-stage question phrasing
- [ ] Verify `make-ai-teammate` offers observability and WorkIQ after `a365 setup all` completes
- [ ] Run evals: `evals/agent365/a365-setup/evals.json`, `evals/agent365/instrument-observability/evals.json`, `evals/agent365/add-workiq-tools/evals.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)