### PR TITLE
chore: add Microsoft copyright headers to JS files

### DIFF
--- a/plugins/agent365/hooks/preToolUse/path-guard.js
+++ b/plugins/agent365/hooks/preToolUse/path-guard.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * path-guard.js — PreToolUse hook
  *

--- a/plugins/agent365/hooks/stop/validate-add-workiq-tools.js
+++ b/plugins/agent365/hooks/stop/validate-add-workiq-tools.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * validate-add-workiq-tools.js
  *

--- a/plugins/agent365/hooks/stop/validate-make-a365-agent.js
+++ b/plugins/agent365/hooks/stop/validate-make-a365-agent.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * validate-make-a365-agent.js
  *

--- a/plugins/agent365/hooks/stop/validate-make-ai-teammate.js
+++ b/plugins/agent365/hooks/stop/validate-make-ai-teammate.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * validate-make-ai-teammate.js
  *

--- a/plugins/agent365/hooks/stop/validate-observability.js
+++ b/plugins/agent365/hooks/stop/validate-observability.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * validate-observability.js
  *

--- a/plugins/agent365/hooks/stop/validate-setup.js
+++ b/plugins/agent365/hooks/stop/validate-setup.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * validate-setup.js
  *

--- a/plugins/agent365/hooks/stop/validate-test-local.js
+++ b/plugins/agent365/hooks/stop/validate-test-local.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * validate-test-local.js
  *

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 /**
  * install.js — Agent 365 Skills Installer
  *


### PR DESCRIPTION
## Summary
- Added `// Copyright (c) Microsoft Corporation.` and `// Licensed under the MIT License.` headers to all 8 JavaScript files
- Headers are placed immediately after the shebang line (`#!/usr/bin/env node`) in each file

## Files updated
- `plugins/agent365/hooks/preToolUse/path-guard.js`
- `plugins/agent365/hooks/stop/validate-add-workiq-tools.js`
- `plugins/agent365/hooks/stop/validate-make-a365-agent.js`
- `plugins/agent365/hooks/stop/validate-make-ai-teammate.js`
- `plugins/agent365/hooks/stop/validate-observability.js`
- `plugins/agent365/hooks/stop/validate-setup.js`
- `plugins/agent365/hooks/stop/validate-test-local.js`
- `scripts/install.js`

## Test plan
- [ ] Verify hook scripts still execute correctly (`node plugins/agent365/hooks/stop/validate-setup.js`)
- [ ] Confirm copyright headers are present in all modified files