### PR TITLE
docs: add dynamic version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Agent 365 Skills
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Fagent365-skills%2Fmain%2Fplugins%2Fagent365%2F.claude-plugin%2Fplugin.json&query=%24.version&label=Agent%20365%20Skills&color=blue)](https://github.com/microsoft/agent365-skills/blob/main/plugins/agent365/.claude-plugin/plugin.json)
 
 Agent skills and MCP configuration for [Microsoft Agent 365](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/) — works with Claude Code and GitHub Copilot. Six skills cover the full A365 lifecycle: transforming agents into AI Teammates, registering Blueprints for Discoverability or Observability paths, wiring WorkIQ MCP tools, instrumenting observability, and local testing with AgentsPlayground.
 


### PR DESCRIPTION
## Summary

- Adds a shields.io dynamic JSON badge next to the License badge on line 3 of README.md
- Badge reads `$.version` directly from `plugins/agent365/.claude-plugin/plugin.json` via the raw GitHub URL — no workflow or manual update needed
- Badge label is "Agent 365 Skills" and links to the plugin.json file for transparency

## How it works

`shields.io/badge/dynamic/json` fetches the raw file at build time, extracts the `version` field with JSONPath `$.version`, and renders it as a blue badge. When `plugin.json` is bumped (e.g., `1.4.1` → `1.5.0`), the badge updates automatically on next render — nothing else to change.

## Test plan

- [ ] Verify badge renders correctly in the GitHub README preview after merge
- [ ] Bump version in `plugin.json` and confirm badge reflects new version (shields.io CDN cache ~5 min)