### PR TITLE
refactor(a365-setup): rename isAITeammate → isOwnIdentity + sync deprecated CLI commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ This plugin instruments and configures A365 agents. It contains six skills:
 make-ai-teammate  ─────────────────────────────────→  add-workiq-tools
       │                                            →  instrument-observability
       └→  a365-setup (CLI install + Azure prereqs
-            when isAITeammate = true, delegates back to make-ai-teammate)
+            when isOwnIdentity = true, delegates back to make-ai-teammate)
 
 a365-setup  →  make-ai-teammate    (AI Teammate path)
             →  make-a365-agent     (Discoverability / Observability / WorkIQ paths)

--- a/evals/agent365/a365-setup/evals.json
+++ b/evals/agent365/a365-setup/evals.json
@@ -1,6 +1,6 @@
 {
   "skill_name": "a365-setup",
-  "eval_instructions": "Test against real agent projects in clean state. a365-setup detects agentStack (Agent Framework/LangChain/OpenAI), programmingLanguage, and usesTeamsOrCopilot (CEA=1, Non-DW=0), asks the final capabilities question, then verifies CLI (Step 1) and Azure prerequisites (Step 2), and delegates to the right skill at Step 3. For the AI Teammate path (isAITeammate=true), Step 3 reads make-ai-teammate/SKILL.md. For all other paths, Step 3 reads make-a365-agent/SKILL.md. a365-setup does NOT run a365 setup all, does NOT create a365.config.json, and does NOT run a365 publish. Capabilities menu: Discoverability, Observability, Tools (WorkIQ), AI Teammate — combinable. Phase 1B shows agent type as 'Custom Engine Agent (CEA)' or 'Non-DW agent — no Teams/Copilot markers detected'. CEA detection uses multi-signal check: strong standalone signals (teamsapp.yml, Teams app manifests, teams-ai SDK packages, existing a365 configs) or paired signals (generic botbuilder packages + structural marker, env vars + structural marker). Phase 1C derives registrationType from usesTeamsOrCopilot: usesTeamsOrCopilot=1 → registrationType=1 (CEA/Entra app ID path); usesTeamsOrCopilot=0 → registrationType=3 (Standard path). registrationType is derived, never asked.",
+  "eval_instructions": "Test against real agent projects in clean state. a365-setup detects agentStack (Agent Framework/LangChain/OpenAI), programmingLanguage, and usesTeamsOrCopilot (CEA=1, Non-DW=0), asks the final capabilities question, then verifies CLI (Step 1) and Azure prerequisites (Step 2), and delegates to the right skill at Step 3. For the AI Teammate path (isOwnIdentity=true), Step 3 reads make-ai-teammate/SKILL.md. For all other paths, Step 3 reads make-a365-agent/SKILL.md. a365-setup does NOT run a365 setup all, does NOT create a365.config.json, and does NOT run a365 publish. Capabilities menu: Discoverability, Observability, Tools (WorkIQ), AI Teammate — combinable. Phase 1B shows agent type as 'Custom Engine Agent (CEA)' or 'Non-DW agent — no Teams/Copilot markers detected'. CEA detection uses multi-signal check: strong standalone signals (teamsapp.yml, Teams app manifests, teams-ai SDK packages, existing a365 configs) or paired signals (generic botbuilder packages + structural marker, env vars + structural marker). Phase 1C derives registrationType from usesTeamsOrCopilot: usesTeamsOrCopilot=1 → registrationType=1 (CEA/Entra app ID path); usesTeamsOrCopilot=0 → registrationType=3 (Standard path). registrationType is derived, never asked.",
   "evals": [
     {
       "id": 1,
@@ -13,7 +13,7 @@
         "Phase 1B: Detection summary shows Stack, Language, and Agent type (human-readable CEA or Standard Agent (Non Digital Worker) label)",
         "Phase 1B: Capabilities menu shows all 4 options: Discoverability, Observability, Tools (WorkIQ), AI Teammate",
         "Phase 1B: User is told options can be combined",
-        "Phase 1C: isAITeammate = false (Discoverability path selected)",
+        "Phase 1C: isOwnIdentity = false (Discoverability path selected)",
         "Phase 1C: registrationType = 3 (derived from usesTeamsOrCopilot=0 — Standard path)",
         "Phase 1C: 3 todos created: Step 1 (CLI), Step 2 (Prerequisites), Step 3 (Run the make-a365-agent skill)",
         "Step 1: dotnet --version is checked",
@@ -115,17 +115,17 @@
       "id": 7,
       "prompt": "Make this an AI Teammate agent",
       "description": "AI Teammate path — verifies CLI + prerequisites then delegates to make-ai-teammate",
-      "expected_output": "The skill selects AI Teammate path, creates 3 todos (CLI, Prerequisites, invoke make-ai-teammate), validates CLI and Azure prerequisites (Steps 1-2), then reads make-ai-teammate/SKILL.md and follows it from the beginning. Does NOT run a365 setup all, a365 config init, or a365 publish inline.",
+      "expected_output": "The skill selects AI Teammate path, creates 3 todos (CLI, Prerequisites, invoke make-ai-teammate), validates CLI and Azure prerequisites (Steps 1-2), then reads make-ai-teammate/SKILL.md and follows it from the beginning. Does NOT run a365 setup all or a365 publish inline.",
       "files": [],
       "expectations": [
         "Phase 1B: 4-option capabilities menu shown: Discoverability, Observability, Tools (WorkIQ), AI Teammate",
         "Phase 1B: User selects option 4 (AI Teammate)",
-        "Phase 1C: isAITeammate = true",
+        "Phase 1C: isOwnIdentity = true",
         "Phase 1C: 3 todos created: Step 1, Step 2, Step 3 = invoke make-ai-teammate",
         "Step 1: a365 CLI is verified and installed if needed",
         "Step 2: Azure CLI login confirmed, custom client app validated, build tools verified",
         "Step 3: make-ai-teammate SKILL.md is read and followed",
-        "a365 config init is done by make-ai-teammate Phase 9, not by a365-setup",
+        "Setup and configuration (code generation, a365 setup all) is handled by make-ai-teammate, not by a365-setup",
         "a365 setup all is run by make-ai-teammate Phase 9, not by a365-setup",
         "a365 publish is run by make-ai-teammate Phase 10, not by a365-setup"
       ]
@@ -134,14 +134,14 @@
       "id": 8,
       "prompt": "Make this agent an AI Teammate",
       "description": "CEA guard — CEA detected (usesTeamsOrCopilot=1) and user selects AI Teammate (option 4); skill must block and re-present options 1-3",
-      "expected_output": "The skill detects CEA (usesTeamsOrCopilot=1) from Phase 1A. User selects option 4 (AI Teammate). The CEA guard fires: skill responds with the blocking message, sets isAITeammate=false, and re-presents options 1-3. User selects a valid option (e.g. Discoverability). Skill proceeds with the Standard Agent path.",
+      "expected_output": "The skill detects CEA (usesTeamsOrCopilot=1) from Phase 1A. User selects option 4 (AI Teammate). The CEA guard fires: skill responds with the blocking message, sets isOwnIdentity=false, and re-presents options 1-3. User selects a valid option (e.g. Discoverability). Skill proceeds with the Standard Agent path.",
       "files": [],
       "expectations": [
         "Phase 1A: usesTeamsOrCopilot detected as 1 (CEA)",
         "Phase 1B: Capabilities menu shown — option 4 includes ⚠️ note about CEA not supported as AI Teammate at GA",
         "Phase 1B: User selects option 4 (AI Teammate)",
         "Phase 1C: CEA guard fires — skill responds: 'Custom Engine Agents are supported as Standard Agent (Non Digital Worker) agents at GA. AI Teammate (Digital Worker) is not available for CEA at GA.'",
-        "Phase 1C: isAITeammate is forced to false",
+        "Phase 1C: isOwnIdentity is forced to false",
         "Phase 1C: Options 1-3 are re-presented to the user",
         "Phase 1C: User selects a valid option — skill continues with Standard Agent (Non Digital Worker) path",
         "make-ai-teammate is NOT invoked",

--- a/evals/agent365/add-workiq-tools/evals.json
+++ b/evals/agent365/add-workiq-tools/evals.json
@@ -59,7 +59,7 @@
         "Phase 4: WorkIQ tools are spread into the existing tools array",
         "Phase 4: All new code is marked: // A365 WorkIQ — added by add-workiq-tools skill",
         "Phase 5: Blueprint exists — user is told Global Administrator must run a365 setup permissions mcp",
-        "Phase 5: User is told admin must first verify deploymentProjectPath via a365 config display",
+        "Phase 5: User is told admin must verify the deploymentProjectPath (run a365 status to confirm project config)",
         "Phase 5: Updated ToolingManifest.json must be shared with the GA",
         "Phase 6: a365 develop get-token is shown",
         "Phase 6: BEARER_TOKEN and SKIP_TOOLING_ON_ERRORS added to .env",

--- a/plugins/agent365/skills/a365-setup/SKILL.md
+++ b/plugins/agent365/skills/a365-setup/SKILL.md
@@ -142,10 +142,10 @@ Wait for the answer. Store as `capabilities`.
 
 After the capabilities question is answered (and the detection/confirmation above is complete):
 
-1. Set `isAITeammate = true` if the user selected **AI Teammate (Digital Worker)**, else `isAITeammate = false`.
-   - **If `usesTeamsOrCopilot = 1` (CEA) AND `isAITeammate = true`:** This combination is not supported at GA.
+1. Set `isOwnIdentity = true` if the user selected **AI Teammate (Digital Worker)**, else `isOwnIdentity = false`.
+   - **If `usesTeamsOrCopilot = 1` (CEA) AND `isOwnIdentity = true`:** This combination is not supported at GA.
      Tell the user: "CEA is supported as a Standard Agent (Non Digital Worker) at GA — AI Teammate (Digital Worker) is not available for CEA."
-     Set `isAITeammate = false` and route to the Standard/CEA path.
+     Set `isOwnIdentity = false` and route to the Standard/CEA path.
 2. Derive `registrationType` from Phase 1A signals (do not ask the user):
    - `registrationType = 1` if `usesTeamsOrCopilot = 1` (CEA — Entra app ID path)
    - `registrationType = 3` if `usesTeamsOrCopilot = 0` (Standard Agent (Non Digital Worker) / no M365 integration path)
@@ -153,22 +153,22 @@ After the capabilities question is answered (and the detection/confirmation abov
 
 Then create all todos for the path and mark Todo 1 in-progress:
 
-**AI Teammate path** — `isAITeammate = true` (3 todos total):
+**AI Teammate path** — `isOwnIdentity = true` (3 todos total):
 - Todo 1: `Step 1: Verify and Install/Update the Agent 365 CLI`
 - Todo 2: `Step 2: Ensure Prerequisites and Environment Configuration`
 - Todo 3: `Step 3: Run the make-ai-teammate skill`
 
-**Standard path** — `registrationType = 3, isAITeammate = false` (3 todos total):
+**Standard path** — `registrationType = 3, isOwnIdentity = false` (3 todos total):
 - Todo 1: `Step 1: Verify and Install/Update the Agent 365 CLI`
 - Todo 2: `Step 2: Ensure Prerequisites and Environment Configuration`
 - Todo 3: `Step 3: Run the make-a365-agent skill`
 
-**Entra app ID path** — `registrationType = 1, isAITeammate = false` (3 todos total):
+**Entra app ID path** — `registrationType = 1, isOwnIdentity = false` (3 todos total):
 - Todo 1: `Step 1: Verify and Install/Update the Agent 365 CLI`
 - Todo 2: `Step 2: Ensure Prerequisites and Environment Configuration`
 - Todo 3: `Step 3: Run the make-a365-agent skill`
 
-**RULE 2 — ALWAYS BEGIN FROM STEP 1.** No step is optional within your path. Even if the CLI appears installed or Azure appears logged in, you MUST run the validation commands in each step. Step 3 is always the final step — it delegates to the appropriate skill based on `isAITeammate`.
+**RULE 2 — ALWAYS BEGIN FROM STEP 1.** No step is optional within your path. Even if the CLI appears installed or Azure appears logged in, you MUST run the validation commands in each step. Step 3 is always the final step — it delegates to the appropriate skill based on `isOwnIdentity`.
 
 **RULE 3 — SUB-SECTIONS ARE NOT SEPARATE TODOS.** Each `## Step` has internal sub-sections — these are tasks WITHIN that step, NOT separate todos.
 
@@ -177,8 +177,8 @@ Then create all todos for the path and mark Todo 1 in-progress:
 **RULE 5 — SILENT EXECUTION.** Work silently. Do NOT narrate what you are about to do, announce step transitions ("Proceeding to Step 2", "CLI installed, moving on"), print todo state, emoji checklists, or step completion summaries. Only speak to the user when you need input, have an error to report, or need confirmation before a destructive action.
 
 **RULE 6 — SKILL DELEGATION.** After Steps 1 and 2, all paths delegate to a specialized skill at Step 3 — do not run setup or publish inline here:
-- **AI Teammate path** (`isAITeammate = true`): delegate to `make-ai-teammate` (code generation, a365.config.json, setup all, publish, Teams Dev Portal).
-- **Standard paths** (`isAITeammate = false`): delegate to `make-a365-agent` (setup all + optional observability/WorkIQ).
+- **AI Teammate path** (`isOwnIdentity = true`): delegate to `make-ai-teammate` (code generation, a365.config.json, setup all, publish, Teams Dev Portal).
+- **Standard paths** (`isOwnIdentity = false`): delegate to `make-a365-agent` (setup all + optional observability/WorkIQ).
 
 ---
 
@@ -186,7 +186,7 @@ Then create all todos for the path and mark Todo 1 in-progress:
 
 You are an AI coding agent with access to execute shell commands, read the Agent365-devTools repository (code and docs), and browse the web for documentation or GitHub issues. Your task is to set up, configure, and deploy all prerequisite components for a Microsoft Agent 365–compliant agent using the Agent 365 CLI. You must handle this end-to-end: from installation and configuration to deployment. Work step-by-step, and adapt to any issues or differences in CLI versions along the way.
 
-> **CRITICAL BLOCKING PREREQUISITE:** Before running ANY `a365` CLI commands (including `config init`, `setup`, `publish`, or `deploy`), you MUST validate that the custom client app registration exists in Entra ID with all required permissions and admin consent. This is validated in Step 2. Failure to validate this will cause all CLI commands to fail. Do NOT skip this validation step.
+> **CRITICAL BLOCKING PREREQUISITE:** Before running ANY `a365` CLI commands (including `setup all`, `publish`, or `deploy`), you MUST validate that the custom client app registration exists in Entra ID with all required permissions and admin consent. This is validated in Step 2. Failure to validate this will cause all CLI commands to fail. Do NOT skip this validation step.
 
 ---
 
@@ -310,7 +310,7 @@ Confirm Python 3.10 or later and pip are available.
 
 The CLI is verified and Azure prerequisites are confirmed. All remaining work is handled by a specialized skill.
 
-**AI Teammate path** (`isAITeammate = true`):
+**AI Teammate path** (`isOwnIdentity = true`):
 
 **Read** `${CLAUDE_PLUGIN_ROOT}/skills/make-ai-teammate/SKILL.md` and follow it from the beginning.
 
@@ -320,7 +320,7 @@ The `make-ai-teammate` skill handles everything: code generation, a365.config.js
 
 ---
 
-**Standard paths** (`isAITeammate = false` — Discoverability, Observability, WorkIQ):
+**Standard paths** (`isOwnIdentity = false` — Discoverability, Observability, WorkIQ):
 
 **Read** `${CLAUDE_PLUGIN_ROOT}/skills/make-a365-agent/SKILL.md` and follow it from the beginning.
 
@@ -356,7 +356,7 @@ a365 setup all --agent-name <agent_name>              # apply
 If you need to re-publish or re-register an existing AI Teammate agent without re-running the full `make-ai-teammate` flow, the steps are in `make-ai-teammate` Phase 10:
 - Manifest review (`manifest/manifest.json`)
 - `a365 publish`
-- Teams Developer Portal configuration (`a365 config display -g --field agentBlueprintId`)
+- Teams Developer Portal configuration (run `a365 status --field agentBlueprintId` to retrieve the blueprint ID)
 - Create agent instance via Teams > Apps > Request Instance
 - Admin approval at [admin.cloud.microsoft/#/agents/all/requested](https://admin.cloud.microsoft/#/agents/all/requested)
 


### PR DESCRIPTION
## Summary

- **`isAITeammate` → `isOwnIdentity`** across `a365-setup/SKILL.md`, `evals/a365-setup/evals.json`, and `AGENTS.md` — aligns with the Agent365-devTools PR #385 internal variable rename
- **Deprecated `a365 config` commands removed:**
  - `a365 config init` removed from critical prerequisite list in SKILL.md (replaced by `a365 setup all`)
  - `a365 config display` → `a365 status` in `evals/add-workiq-tools/evals.json` Phase 5 description and `a365-setup/SKILL.md`
- **Eval assertions updated** to use `isOwnIdentity` in all Phase 1C checks

## Context

Agent365-devTools PR #385 renamed the internal session variable from `isAITeammate` to `isOwnIdentity`. The rename was previously applied to our branch but was accidentally reverted by a remote push (`edbdd5a`). This PR cleanly re-applies it from `origin/main`.

The `a365 config` command family was also removed in PR #385 (`config init` → `a365 setup all --agent-name`, `config display` → `a365 status`). This PR removes the remaining references.

## Test plan

- [ ] Run a365-setup evals — confirm `isOwnIdentity` appears in Phase 1C assertions
- [ ] Confirm CEA guard eval (#5) still fires and forces `isOwnIdentity=false`
- [ ] Verify no remaining `isAITeammate` occurrences: `grep -r "isAITeammate" plugins/ evals/ AGENTS.md`
- [ ] Verify no remaining `a365 config display` or `a365 config init` references in changed files