### PR TITLE
feat: add VS Code workspace settings, CI improvements, and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,109 @@
+name: Bug Report
+description: Report a bug in an Agent 365 skill
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: skill
+    attributes:
+      label: Skill
+      description: Which skill is this bug related to?
+      options:
+        - make-ai-teammate
+        - a365-setup
+        - make-a365-agent
+        - add-workiq-tools
+        - instrument-observability
+        - test-local
+    validations:
+      required: true
+
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin Version
+      description: What version of the plugin are you using?
+      placeholder: e.g., 1.4.2
+    validations:
+      required: true
+
+  - type: dropdown
+    id: language
+    attributes:
+      label: Agent Language / Stack
+      description: Which language/framework is your agent using?
+      options:
+        - .NET AgentFramework
+        - .NET Semantic Kernel
+        - Node.js LangChain
+        - Node.js OpenAI Agents SDK
+        - Node.js Claude SDK
+        - Node.js Semantic Kernel
+        - Node.js Google ADK
+        - Python AgentFramework
+        - Python LangChain
+        - Python OpenAI
+        - Python Claude SDK
+        - Python Semantic Kernel
+        - Python Google ADK
+        - Not applicable
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of the bug.
+      placeholder: Describe what happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro-steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Run skill '...'
+        2. Provide input '...'
+        3. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs / Screenshots
+      description: Paste any relevant log output or screenshots.
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Any relevant environment details.
+      placeholder: |
+        - OS: Windows 11
+        - Claude Code version: x.x.x
+        - a365 CLI version: x.x.x
+        - Node.js / .NET / Python version: x.x.x
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,84 @@
+name: Feature Request
+description: Suggest a new feature or improvement for an Agent 365 skill
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: skill
+    attributes:
+      label: Skill
+      description: Which skill is this feature request for?
+      options:
+        - make-ai-teammate
+        - a365-setup
+        - make-a365-agent
+        - add-workiq-tools
+        - instrument-observability
+        - test-local
+        - new skill
+    validations:
+      required: true
+
+  - type: input
+    id: plugin-version
+    attributes:
+      label: Plugin Version
+      description: What version of the plugin are you using?
+      placeholder: e.g., 1.4.2
+    validations:
+      required: false
+
+  - type: dropdown
+    id: language
+    attributes:
+      label: Agent Language / Stack
+      description: Which language/framework is this related to? (Leave blank for general requests)
+      options:
+        - .NET AgentFramework
+        - .NET Semantic Kernel
+        - Node.js LangChain
+        - Node.js OpenAI Agents SDK
+        - Node.js Claude SDK
+        - Node.js Semantic Kernel
+        - Node.js Google ADK
+        - Python AgentFramework
+        - Python LangChain
+        - Python OpenAI
+        - Python Claude SDK
+        - Python Semantic Kernel
+        - Python Google ADK
+        - All / Not applicable
+    validations:
+      required: false
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve? What's the motivation?
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution or feature you'd like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or workarounds you've considered.
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or examples.
+    validations:
+      required: false

--- a/.github/workflows/ensure-skill-version-check.yml
+++ b/.github/workflows/ensure-skill-version-check.yml
@@ -1,0 +1,52 @@
+name: validate-skill-version-check
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "plugins/agent365/skills/**"
+      - "plugins/agent365/.claude-plugin/plugin.json"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  validate-skill-version-check:
+    name: validate-skill-version-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout (non-fork)
+        if: ${{ github.event.pull_request.head.repo.fork == false }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: checkout (fork)
+        if: ${{ github.event.pull_request.head.repo.fork == true }}
+        uses: actions/checkout@v4
+
+      - name: setup-node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: check-only (fork)
+        if: ${{ github.event.pull_request.head.repo.fork == true }}
+        run: node scripts/ensure-skill-version-check.js --check
+
+      - name: add missing version fields (non-fork)
+        if: ${{ github.event.pull_request.head.repo.fork == false }}
+        run: node scripts/ensure-skill-version-check.js
+
+      - name: commit and push if changed (non-fork)
+        if: ${{ github.event.pull_request.head.repo.fork == false }}
+        run: |
+          git diff --quiet && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "plugins/agent365/skills/*/SKILL.md"
+          git commit -m "ci: auto-add version field to SKILL.md files"
+          git push

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -156,3 +156,54 @@ jobs:
             fi
           done < <(find plugins/agent365/skills -mindepth 1 -maxdepth 1 -type d)
           exit $FAIL
+
+  # ── 9. Plugin names must be kebab-case ───────────────────────────────────
+  validate-plugin-names:
+    name: Plugin name format (kebab-case)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate kebab-case plugin names
+        run: |
+          python3 <<'PY'
+          import json
+          import re
+          from pathlib import Path
+
+          KEBAB_CASE_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+          def validate_name(name, source):
+              if KEBAB_CASE_PATTERN.fullmatch(name):
+                  return None
+              return f"{source}: '{name}' is not kebab-case"
+
+          errors = []
+
+          # Check .claude-plugin/marketplace.json
+          for mp in [Path(".claude-plugin/marketplace.json"), Path(".github/plugin/marketplace.json")]:
+              manifest = json.loads(mp.read_text())
+              top_name = manifest.get("name", "")
+              if top_name:
+                  err = validate_name(top_name, f"{mp} name")
+                  if err:
+                      errors.append(err)
+              for index, plugin in enumerate(manifest.get("plugins", [])):
+                  err = validate_name(plugin["name"], f"{mp} plugins[{index}].name")
+                  if err:
+                      errors.append(err)
+
+          # Check each plugin's own plugin.json
+          for plugin_manifest_path in sorted(Path("plugins").glob("*/.claude-plugin/plugin.json")):
+              plugin_manifest = json.loads(plugin_manifest_path.read_text())
+              err = validate_name(plugin_manifest["name"], f"{plugin_manifest_path} name")
+              if err:
+                  errors.append(err)
+
+          if errors:
+              print("Found plugin names that are not kebab-case:")
+              for error in errors:
+                  print(f"- {error}")
+              raise SystemExit(1)
+
+          print("All plugin names are kebab-case.")
+          PY

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "chat.agentSkillsLocations": ["plugins/agent365/skills"]
+}

--- a/plugins/agent365/skills/a365-setup/SKILL.md
+++ b/plugins/agent365/skills/a365-setup/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: a365-setup
+version: 1.4.2
 description: >
   Entry point for general Agent 365 (A365) registration and CLI setup — use this skill whenever
   the user wants to "set up A365", "register agent", "create blueprint", or general A365 onboarding

--- a/plugins/agent365/skills/add-workiq-tools/SKILL.md
+++ b/plugins/agent365/skills/add-workiq-tools/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: add-workiq-tools
+version: 1.4.2
 description: >
   Adds WorkIQ MCP tool servers to an existing .NET AgentFramework, Node.js, or Python agent
   using the A365 CLI. Runs a365 develop list-available to show the catalog, adds selected servers

--- a/plugins/agent365/skills/instrument-observability/SKILL.md
+++ b/plugins/agent365/skills/instrument-observability/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: instrument-observability
+version: 1.4.2
 description: >
   Instruments Microsoft Agent 365 observability into existing .NET AgentFramework, Node.js, or
   Python agents. Adds OTel-based tracing, context propagation, A365 exporter, manual

--- a/plugins/agent365/skills/make-a365-agent/SKILL.md
+++ b/plugins/agent365/skills/make-a365-agent/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: make-a365-agent
+version: 1.4.2
 description: >
   Provisions a non-AI Teammate agent with Agent 365 — use this skill for Discoverability
   and Observability paths. Runs a365 setup all to create the Blueprint and Entra ID permissions.

--- a/plugins/agent365/skills/make-ai-teammate/SKILL.md
+++ b/plugins/agent365/skills/make-ai-teammate/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: make-ai-teammate
+version: 1.4.2
 description: >
   Transforms a non-M365 agent into a Microsoft Agent 365 AI Teammate. Supports all major
   frameworks across .NET (AgentFramework, Semantic Kernel), Node.js (LangChain, OpenAI Agents

--- a/plugins/agent365/skills/test-local/SKILL.md
+++ b/plugins/agent365/skills/test-local/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: test-local
+version: 1.4.2
 description: >
   Runs an Agent 365 AI Teammate agent locally and opens AgentsPlayground for interactive
   local testing. Works with any AI Teammate stack — .NET (AgentFramework, Semantic Kernel),

--- a/scripts/ensure-skill-version-check.js
+++ b/scripts/ensure-skill-version-check.js
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+// scripts/ensure-skill-version-check.js
+// Ensures each SKILL.md in plugins/agent365/skills/ has a `version:` field
+// in its YAML frontmatter that matches the version in plugins/agent365/.claude-plugin/plugin.json.
+//
+// Usage:
+//   node scripts/ensure-skill-version-check.js          # auto-add / auto-fix (default)
+//   node scripts/ensure-skill-version-check.js --check  # check-only; exit 1 if any are missing or wrong
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const checkOnly = process.argv.includes('--check');
+const PLUGIN_JSON = path.join('plugins', 'agent365', '.claude-plugin', 'plugin.json');
+const SKILLS_DIR = path.join('plugins', 'agent365', 'skills');
+
+const pluginVersion = JSON.parse(fs.readFileSync(PLUGIN_JSON, 'utf8')).version;
+if (!pluginVersion) {
+  console.error('ERROR: could not read version from', PLUGIN_JSON);
+  process.exit(1);
+}
+
+let missing = 0;
+let fixed = 0;
+
+for (const skill of fs.readdirSync(SKILLS_DIR).sort()) {
+  const skillMdPath = path.join(SKILLS_DIR, skill, 'SKILL.md');
+  if (!fs.existsSync(skillMdPath)) continue;
+
+  const content = fs.readFileSync(skillMdPath, 'utf8');
+
+  // Frontmatter must start at line 0 with ---
+  if (!content.startsWith('---')) {
+    console.error(`ERROR: ${skillMdPath} has no YAML frontmatter`);
+    missing++;
+    continue;
+  }
+
+  // Find closing ---
+  const closingIdx = content.indexOf('\n---', 3);
+  if (closingIdx === -1) {
+    console.error(`ERROR: ${skillMdPath} frontmatter is not closed`);
+    missing++;
+    continue;
+  }
+
+  const frontmatter = content.slice(0, closingIdx);
+  const afterFrontmatter = content.slice(closingIdx);
+
+  const versionMatch = frontmatter.match(/^version:\s*(.+)$/m);
+
+  if (versionMatch) {
+    const currentVersion = versionMatch[1].trim();
+    if (currentVersion === pluginVersion) {
+      console.log(`OK: ${skillMdPath} (version: ${pluginVersion})`);
+    } else if (checkOnly) {
+      console.error(`FAIL: ${skillMdPath} — version '${currentVersion}' != plugin version '${pluginVersion}'`);
+      missing++;
+    } else {
+      const updated = frontmatter.replace(/^version:\s*.+$/m, `version: ${pluginVersion}`);
+      fs.writeFileSync(skillMdPath, updated + afterFrontmatter);
+      console.log(`Updated ${skillMdPath}: ${currentVersion} → ${pluginVersion}`);
+      fixed++;
+    }
+  } else if (checkOnly) {
+    console.error(`FAIL: ${skillMdPath} — missing 'version:' field in frontmatter`);
+    missing++;
+  } else {
+    // Insert version: after the name: line
+    const updated = frontmatter.replace(/^(name:.+)$/m, `$1\nversion: ${pluginVersion}`);
+    fs.writeFileSync(skillMdPath, updated + afterFrontmatter);
+    console.log(`Added version: ${pluginVersion} to ${skillMdPath}`);
+    fixed++;
+  }
+}
+
+if (missing > 0) {
+  console.error(`\n${missing} skill(s) need attention. Run without --check to auto-fix.`);
+  process.exit(1);
+} else if (fixed > 0) {
+  console.log(`\nFixed ${fixed} skill(s) — set version: ${pluginVersion}`);
+} else {
+  console.log(`\nAll skills have version: ${pluginVersion}`);
+}


### PR DESCRIPTION
## Summary

This PR adds three quality improvements to the repository:

### 1. VS Code workspace settings (`.vscode/settings.json`)
Configures `chat.agentSkillsLocations` to point VS Code at the canonical skill sources in `plugins/agent365/skills/`. Contributors who open this repo in VS Code agent mode get all six skills surfaced automatically — no file duplication or manual copying needed.

### 2. CI improvements
- **Job 9 — validate-plugin-names** (added to `validate.yml`): Validates that all plugin `name` fields in `.claude-plugin/marketplace.json`, `.github/plugin/marketplace.json`, and each `plugin.json` are kebab-case. Based on the pattern from [`microsoft/power-platform-skills`](https://github.com/microsoft/power-platform-skills/blob/main/.github/workflows/validate-plugin-names.yml).
- **New workflow — `ensure-skill-version-check.yml`**: On every PR touching `plugins/agent365/skills/**`, ensures each `SKILL.md` has a `version:` field matching `plugin.json`. Auto-adds missing fields for non-fork PRs; runs in check-only mode for forks. Companion script: `scripts/ensure-skill-version-check.js`.
- **SKILL.md version fields**: All 6 `SKILL.md` files updated with `version: 1.4.2` by the new script.

### 3. GitHub Issue Templates
Added `.github/ISSUE_TEMPLATE/` with:
- `bug_report.yml` — skill dropdown, agent language/stack dropdown, repro steps, logs, environment
- `feature_request.yml` — skill dropdown, language/stack, problem statement, proposed solution
- `config.yml` — disables blank issues

Based on the pattern from [`microsoft/power-platform-skills`](https://github.com/microsoft/power-platform-skills/tree/main/.github/ISSUE_TEMPLATE), adapted for the agent365 skill set.

## Files changed
- `.vscode/settings.json` (new)
- `.github/workflows/validate.yml` — added job 9 (validate-plugin-names)
- `.github/workflows/ensure-skill-version-check.yml` (new)
- `scripts/ensure-skill-version-check.js` (new)
- `.github/ISSUE_TEMPLATE/bug_report.yml` (new)
- `.github/ISSUE_TEMPLATE/feature_request.yml` (new)
- `.github/ISSUE_TEMPLATE/config.yml` (new)
- `plugins/agent365/skills/*/SKILL.md` — added `version: 1.4.2` to all 6
