### PR TITLE
feat: README fix, bump-version CI fix, runtime version check, and issue templates

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -35,11 +35,12 @@ jobs:
           fi
           echo "Bump type: $(cat $GITHUB_OUTPUT | grep type | cut -d= -f2)"
 
-      - name: Bump plugin.json and marketplace.json
+      - name: Bump all version manifest files
         id: version
         run: |
           PLUGIN="plugins/agent365/.claude-plugin/plugin.json"
           MARKET=".claude-plugin/marketplace.json"
+          GH_MARKET=".github/plugin/marketplace.json"
           CURRENT=$(node -e "process.stdout.write(require('./$PLUGIN').version)")
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
           BUMP="${{ steps.bump.outputs.type }}"
@@ -52,22 +53,40 @@ jobs:
 
           node -e "
             const fs = require('fs');
+            // plugin.json and .claude-plugin/marketplace.json use flat 'version'
             ['$PLUGIN', '$MARKET'].forEach(p => {
               const j = JSON.parse(fs.readFileSync(p, 'utf8'));
               j.version = '$NEW';
               fs.writeFileSync(p, JSON.stringify(j, null, 2) + '\n');
             });
+            // .github/plugin/marketplace.json uses metadata.version
+            const gh = JSON.parse(fs.readFileSync('$GH_MARKET', 'utf8'));
+            gh.metadata.version = '$NEW';
+            // also bump plugin-level version inside plugins array if present
+            (gh.plugins || []).forEach(p => { if (p.version) p.version = '$NEW'; });
+            fs.writeFileSync('$GH_MARKET', JSON.stringify(gh, null, 2) + '\n');
           "
 
           echo "new=$NEW" >> "$GITHUB_OUTPUT"
           echo "old=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "Bumped $CURRENT → $NEW ($BUMP)"
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Sync version field in SKILL.md files
+        run: node scripts/ensure-skill-version-check.js
+
       - name: Commit, tag, and push
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add plugins/agent365/.claude-plugin/plugin.json .claude-plugin/marketplace.json
+          git add plugins/agent365/.claude-plugin/plugin.json \
+                  .claude-plugin/marketplace.json \
+                  .github/plugin/marketplace.json \
+                  "plugins/agent365/skills/*/SKILL.md"
           git diff --cached --quiet || git commit -m "chore: bump version ${{ steps.version.outputs.old }} → ${{ steps.version.outputs.new }} [skip ci]"
           git tag "v${{ steps.version.outputs.new }}"
           git push

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -79,6 +79,10 @@ jobs:
       - name: Sync version field in SKILL.md files
         run: node scripts/ensure-skill-version-check.js
 
+      - name: Update README version badge
+        run: |
+          sed -i "s/img.shields.io\/badge\/version-[0-9]*\.[0-9]*\.[0-9]*/img.shields.io\/badge\/version-${{ steps.version.outputs.new }}/g" README.md
+
       - name: Commit, tag, and push
         run: |
           git config user.name "github-actions[bot]"
@@ -86,7 +90,8 @@ jobs:
           git add plugins/agent365/.claude-plugin/plugin.json \
                   .claude-plugin/marketplace.json \
                   .github/plugin/marketplace.json \
-                  "plugins/agent365/skills/*/SKILL.md"
+                  "plugins/agent365/skills/*/SKILL.md" \
+                  README.md
           git diff --cached --quiet || git commit -m "chore: bump version ${{ steps.version.outputs.old }} → ${{ steps.version.outputs.new }} [skip ci]"
           git tag "v${{ steps.version.outputs.new }}"
           git push

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -19,6 +19,11 @@ jobs:
           ref: main
           fetch-depth: 0
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - name: Determine bump type from PR commits
         id: bump
         run: |
@@ -70,11 +75,6 @@ jobs:
           echo "new=$NEW" >> "$GITHUB_OUTPUT"
           echo "old=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "Bumped $CURRENT → $NEW ($BUMP)"
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
 
       - name: Sync version field in SKILL.md files
         run: node scripts/ensure-skill-version-check.js

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ gh copilot suggest "Instrument observability for this agent"
 
 ### VS Code agent mode — `.agents/skills/` (open standard)
 
-To install into your project for VS Code agent mode, Copilot cloud agent, and any [agentskills.io](https://agentskills.io)-compatible tool, run the installer from your agent project directory:
+To install into your project for VS Code agent mode, Copilot cloud agent, and any agentskills.io-compatible tool, run the installer from your agent project directory:
 
 ```bash
 cd my-agent-project

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Agent 365 Skills
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmicrosoft%2Fagent365-skills%2Fmain%2Fplugins%2Fagent365%2F.claude-plugin%2Fplugin.json&query=%24.version&label=Agent%20365%20Skills&color=blue)](https://github.com/microsoft/agent365-skills/blob/main/plugins/agent365/.claude-plugin/plugin.json)
+[![Version](https://img.shields.io/badge/version-1.4.2-blue)](https://github.com/microsoft/agent365-skills/blob/main/plugins/agent365/.claude-plugin/plugin.json)
 
 Agent skills and MCP configuration for [Microsoft Agent 365](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/) — works with Claude Code and GitHub Copilot. Six skills cover the full A365 lifecycle: transforming agents into AI Teammates, registering Blueprints for Discoverability or Observability paths, wiring WorkIQ MCP tools, instrumenting observability, and local testing with AgentsPlayground.
 

--- a/plugins/agent365/skills/a365-setup/SKILL.md
+++ b/plugins/agent365/skills/a365-setup/SKILL.md
@@ -38,6 +38,8 @@ hooks:
       timeout: 30000
 ---
 
+> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+
 # Agent 365 CLI Setup
 
 > **Trigger phrases** — any of these will activate this skill automatically:

--- a/plugins/agent365/skills/add-workiq-tools/SKILL.md
+++ b/plugins/agent365/skills/add-workiq-tools/SKILL.md
@@ -38,6 +38,8 @@ hooks:
       timeout: 30000
 ---
 
+> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+
 # Add WorkIQ Tools (A365 CLI + SDK)
 
 > **Trigger phrases** — any of these will activate this skill automatically:

--- a/plugins/agent365/skills/instrument-observability/SKILL.md
+++ b/plugins/agent365/skills/instrument-observability/SKILL.md
@@ -43,6 +43,8 @@ hooks:
       timeout: 30000
 ---
 
+> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+
 # Instrument A365 Observability
 
 > **Trigger phrases** — any of these will activate this skill automatically:

--- a/plugins/agent365/skills/make-a365-agent/SKILL.md
+++ b/plugins/agent365/skills/make-a365-agent/SKILL.md
@@ -37,6 +37,8 @@ hooks:
       timeout: 30000
 ---
 
+> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+
 # Make A365 Agent
 
 > **Trigger phrases** — any of these will activate this skill:

--- a/plugins/agent365/skills/make-ai-teammate/SKILL.md
+++ b/plugins/agent365/skills/make-ai-teammate/SKILL.md
@@ -64,6 +64,8 @@ hooks:
       timeout: 45000
 ---
 
+> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+
 # Make AI Teammate
 
 > **Trigger phrases** — any of these will activate this skill:

--- a/plugins/agent365/skills/test-local/SKILL.md
+++ b/plugins/agent365/skills/test-local/SKILL.md
@@ -37,6 +37,8 @@ hooks:
       timeout: 30000
 ---
 
+> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.
+
 # Test Agent Locally (AgentsPlayground)
 
 > **Trigger phrases** — any of these will activate this skill automatically:

--- a/scripts/check-version.js
+++ b/scripts/check-version.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// scripts/check-version.js
+// Checks if the installed plugin version is up to date.
+//
+// Invoked automatically at skill start via:
+//   node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"
+//
+// Outputs a warning if behind the latest release; silent if up to date or check unavailable.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const pluginJson = path.join(__dirname, '..', 'plugins', 'agent365', '.claude-plugin', 'plugin.json');
+
+let installedVersion;
+try {
+  installedVersion = JSON.parse(fs.readFileSync(pluginJson, 'utf8')).version;
+} catch {
+  process.exit(0); // can't read local version — skip silently
+}
+
+let latestVersion = null;
+try {
+  const raw = execSync(
+    'gh release view --repo microsoft/agent365-skills --json tagName -q .tagName',
+    { timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }
+  ).toString().trim();
+  latestVersion = raw.replace(/^v/, '');
+} catch {
+  // gh CLI unavailable, no auth, or no releases yet — skip silently
+  process.exit(0);
+}
+
+if (latestVersion && latestVersion !== installedVersion) {
+  console.log(`> [!WARNING]`);
+  console.log(`> **Agent 365 Skills update available**: installed v${installedVersion}, latest v${latestVersion}.`);
+  console.log(`> Update with: \`gh skill add microsoft/agent365-skills\``);
+  console.log(`> Or re-run: \`node /path/to/agent365-skills/scripts/install.js\``);
+}
+// Up to date or check unavailable → exit 0, no output

--- a/scripts/ensure-skill-version-check.js
+++ b/scripts/ensure-skill-version-check.js
@@ -1,11 +1,15 @@
 #!/usr/bin/env node
 // scripts/ensure-skill-version-check.js
-// Ensures each SKILL.md in plugins/agent365/skills/ has a `version:` field
-// in its YAML frontmatter that matches the version in plugins/agent365/.claude-plugin/plugin.json.
+// Ensures each SKILL.md in plugins/agent365/skills/:
+//   1. Has a `version:` field in YAML frontmatter matching plugin.json
+//   2. Has the runtime version-check prompt line immediately after the frontmatter closing ---
 //
 // Usage:
 //   node scripts/ensure-skill-version-check.js          # auto-add / auto-fix (default)
 //   node scripts/ensure-skill-version-check.js --check  # check-only; exit 1 if any are missing or wrong
+
+const VERSION_CHECK_LINE =
+  '> **Plugin check**: Run `node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"` — if it outputs a message, show it to the user before proceeding.';
 
 'use strict';
 
@@ -73,6 +77,30 @@ for (const skill of fs.readdirSync(SKILLS_DIR).sort()) {
     fs.writeFileSync(skillMdPath, updated + afterFrontmatter);
     console.log(`Added version: ${pluginVersion} to ${skillMdPath}`);
     fixed++;
+  }
+
+  // ── 2. Ensure runtime check line exists immediately after closing --- ──────
+  const currentContent = fs.readFileSync(skillMdPath, 'utf8');
+  const hasCheckLine = currentContent.includes(VERSION_CHECK_LINE);
+
+  if (!hasCheckLine) {
+    if (checkOnly) {
+      console.error(`FAIL: ${skillMdPath} — missing runtime version-check line`);
+      missing++;
+    } else {
+      // Find closing --- and insert the line right after it
+      const match = currentContent.match(/^---[ \t]*\r?\n[\s\S]*?\r?\n---[ \t]*\r?\n/);
+      if (match) {
+        const insertPos = match[0].length;
+        const updated =
+          currentContent.slice(0, insertPos) +
+          '\n' + VERSION_CHECK_LINE + '\n' +
+          currentContent.slice(insertPos);
+        fs.writeFileSync(skillMdPath, updated, 'utf8');
+        console.log(`Added runtime check line to ${skillMdPath}`);
+        fixed++;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

### README fixes
- Removed `agentskills.io` hyperlink from `.agents/skills/` install section (plain text only)
- Switched version badge from dynamic JSON (broken on private repos) to static `![Version](https://img.shields.io/badge/version-1.4.2-blue)`

### `bump-version.yml` CI fix
- Previously only bumped 2 of 3 manifest files — now bumps all three: `plugins/agent365/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `.github/plugin/marketplace.json` (using `metadata.version` schema)
- Added `ensure-skill-version-check.js` step to sync `version:` in all SKILL.md files on every version bump
- Added `sed` step to update the static version badge in `README.md`
- Stages `README.md` alongside manifests in the version bump commit

### Runtime version staleness check
- **`scripts/check-version.js`** (new): runs at skill invocation time via the injected SKILL.md line; uses `gh release view` to compare installed vs latest released version; outputs a Markdown warning callout if behind; silent if up to date or `gh` unavailable
- **`scripts/ensure-skill-version-check.js`** (updated): now also injects the runtime prompt line `> **Plugin check**: Run \`node "${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js"\`...` immediately after the frontmatter closing `---` in each SKILL.md
- All 6 SKILL.md files updated with the runtime check line

### Issue templates (carried from branch base)
- `bug_report.yml`, `feature_request.yml`, `config.yml` — based on `microsoft/power-platform-skills` pattern, adapted for agent365 skill/language dropdowns