### PR TITLE
fix(install): VS Code skill discovery fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
-  "chat.agentSkillsLocations": ["plugins/agent365/skills"]
+  "chat.agentSkillsLocations": {
+    "plugins/agent365/skills": true,
+    ".agents/skills": true
+  }
 }

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -234,6 +234,30 @@ function installAgentsSkills() {
     log('Add .agents/skills/ to .gitignore if you do not want to commit them.');
   }
   if (skipped > 0) log(`${skipped} skill(s) already present — skipped.`);
+
+  // VS Code Copilot Chat only scans .github/skills/ and .claude/skills/ by default.
+  // Write chat.agentSkillsLocations to .vscode/settings.json so it also scans .agents/skills/.
+  // The setting requires an object { "path": true } format — arrays are silently ignored.
+  writeVSCodeSkillsLocation('.agents/skills');
+}
+
+function writeVSCodeSkillsLocation(relPath) {
+  const settingsDir  = path.join(TARGET_DIR, '.vscode');
+  const settingsFile = path.join(settingsDir, 'settings.json');
+  const key = 'chat.agentSkillsLocations';
+
+  let settings = readJson(settingsFile) || {};
+  if (typeof settings[key] !== 'object' || Array.isArray(settings[key])) {
+    settings[key] = {};
+  }
+  if (settings[key][relPath] === true) {
+    log('chat.agentSkillsLocations already set — skipping');
+    return;
+  }
+  settings[key][relPath] = true;
+  writeJson(settingsFile, settings);
+  ok(`Updated .vscode/settings.json — chat.agentSkillsLocations includes "${relPath}"`);
+  log('Reload VS Code (Ctrl+Shift+P → Developer: Reload Window) for skills to appear.');
 }
 
 // ── Manual fallback ──────────────────────────────────────────────────────────

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -80,7 +80,16 @@ function detectGhSkill() {
 }
 
 function detectVSCode() {
-  return run('code --version') !== null;
+  // Avoid spawning `code --version` — on Windows it can open VS Code.
+  // Instead check well-known install paths and environment markers.
+  if (process.env.VSCODE_PID || process.env.TERM_PROGRAM === 'vscode') return true;
+  const locations = [
+    path.join(os.homedir(), '.vscode', 'extensions'),
+    path.join(os.homedir(), 'AppData', 'Local', 'Programs', 'Microsoft VS Code'),
+    '/usr/share/code',
+    '/Applications/Visual Studio Code.app',
+  ];
+  return locations.some(p => fs.existsSync(p));
 }
 
 function detectA365() {
@@ -273,9 +282,9 @@ if (!hasClaude && !hasVSCode && !hasCopilot && !hasGhSkill) {
   warn('Neither Claude Code, VS Code, gh copilot, nor gh skill detected.');
   showManualInstructions();
 } else {
-  if (hasClaude)                    installClaudeCode();
-  if (hasGhSkill)                   installGhSkill();
-  else if (hasVSCode || hasCopilot) installCopilotInstructions();
+  if (hasClaude) installClaudeCode();
+  if (hasGhSkill) installGhSkill();
+  else installCopilotInstructions(); // covers VS Code, gh copilot, and unknown hosts
 }
 
 // Always install to .agents/skills/ — works for VS Code agent mode, Copilot CLI, and cloud agent


### PR DESCRIPTION
## Summary

Three bugs in scripts/install.js and .vscode/settings.json that prevented skills from appearing in VS Code Copilot Chat agent mode.

## Fixes

**1. Redirect install output to repo root when run from scripts/ dir**
Running node install.js from inside scripts/ created .agents/skills/ inside scripts/ instead of the workspace root. Fixed by detecting when process.cwd() equals __dirname and redirecting to repo root.

**2. Detect VS Code via filesystem, not code --version**
code --version on Windows opens VS Code instead of printing a version. Fixed by checking well-known install paths and environment variables (VSCODE_PID, TERM_PROGRAM).

**3. Write chat.agentSkillsLocations as object, register .agents/skills/**
VS Code only scans .github/skills/ and .claude/skills/ by default. The setting also requires {"path": true} object format - arrays are silently ignored. Fixed settings.json and updated installer to write the correct format.