### PR TITLE
Fix stale install.js comment; add .agents/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ obj/
 .DS_Store
 Thumbs.db
 
+# Agent Skills open-standard copy (created by install.js in user projects; not needed in source repo)
+.agents/
+
 # Editor
 .vscode/settings.json
 .idea/

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -321,7 +321,8 @@ if (!hasClaude && !hasVSCode && !hasCopilot && !hasGhSkill) {
   else installCopilotInstructions(); // covers VS Code, gh copilot, and unknown hosts
 }
 
-// Always install to .agents/skills/ — works for VS Code agent mode, Copilot CLI, and cloud agent
+// Install to .agents/skills/ for user projects; when running from the source repo, registers
+// plugins/agent365/skills directly instead (see installAgentsSkills for self-repo detection).
 installAgentsSkills();
 
 checkA365();


### PR DESCRIPTION
## Follow-up to #30

Two remaining files that referenced the now-removed `.agents/` pattern:

### `scripts/install.js`
Updated the comment on the `installAgentsSkills()` call (was "Always install to `.agents/skills/`") to accurately reflect that the function now detects the self-repo case and registers `plugins/agent365/skills` directly instead of copying.

### `.gitignore`
Added `.agents/` to the ignore list. If someone runs an older version of `install.js` from inside this repo (before the self-repo detection fix landed), it would recreate `.agents/skills/` and those files could get accidentally committed. The gitignore entry prevents that.