### PR TITLE
Update skill files for CLI 1.1

### DIFF
--- a/plugins/agent365/skills/a365-setup/SKILL.md
+++ b/plugins/agent365/skills/a365-setup/SKILL.md
@@ -1,4 +1,4 @@
----
+﻿---
 name: a365-setup
 version: 1.5.0
 description: >

--- a/plugins/agent365/skills/instrument-observability/SKILL.md
+++ b/plugins/agent365/skills/instrument-observability/SKILL.md
@@ -1,4 +1,4 @@
----
+﻿---
 name: instrument-observability
 version: 1.5.0
 description: >
@@ -564,6 +564,7 @@ All new lines marked with the language-appropriate comment:
    A365_OBSERVABILITY_LOG_LEVEL=info|warn|error
    Use_Custom_Resolver=false
    ```
+   - **S2S path only:** Also add `AGENT365_USE_S2S_ENDPOINT=true` — this tells the distro to use the `/observabilityService/...` endpoint path instead of `/observability/...`.
 
 4. **If `.env` does not exist**, create it with the variables above.
 
@@ -580,6 +581,7 @@ All new lines marked with the language-appropriate comment:
    ```dotenv
    ENABLE_A365_OBSERVABILITY_EXPORTER=false
    ```
+   - **S2S path only:** Also add `AGENT365_USE_S2S_ENDPOINT=true` — this tells the distro to use the `/observabilityService/...` endpoint path instead of `/observability/...`.
 
 3. **If `.env` does not exist**, create it with the variable above.
 
@@ -726,9 +728,11 @@ This skill is safe to rerun. On subsequent runs:
 
 ### OtelWrite App Role Assignment
 
-As of CLI 1.1, `a365 setup all` automatically grants `Agent365.Observability.OtelWrite` to the Agent Identity SP as both a delegated and application permission. No manual assignment is needed for newly provisioned agents.
+`a365 setup all` **attempts** to grant `Agent365.Observability.OtelWrite` to the Agent Identity SP, but this requires **Global Administrator** privileges. If the logged-in user is not a Global Admin, the assignment silently fails with 403 and trace exports will return HTTP 403 from the observability service.
 
-For agents provisioned with an older CLI version, grant the permission via Entra portal:
+**The CLI prints a PowerShell admin consent script** in its output when the assignment fails. When running `a365 setup all`, **always scan the output for this script block** and display it to the user in a fenced code block so they can copy it and hand it to a Global Admin.
+
+If the script was not captured, grant the permission manually via Entra portal (requires Global Admin):
 1. [Entra portal](https://entra.microsoft.com) > App registrations > select Blueprint app > API permissions
 2. Add a permission > APIs my organization uses > search `9b975845-388f-4429-889e-eab1ef63949c`
 3. Add both **Delegated** and **Application** `Agent365.Observability.OtelWrite` > Grant admin consent
@@ -751,6 +755,44 @@ rm body.json
 The Node.js SDK (`@microsoft/agents-a365-observability@0.2.0-preview.5`) and .NET SDK (`0.3.4-beta`) include `/otlp/` in the S2S export URL path. The Power Platform PFAT gateway returns `401 MSAuth10AuthenticatorTypeUnknown` on this path. Python SDK `0.1.0` does NOT include `/otlp/` and works correctly.
 
 **Status:** Awaiting SDK fix. No workaround should be applied in generated code — this is an SDK-level issue.
+
+### S2S Endpoint Path — `useS2SEndpoint` Not Passed by Distro
+
+The `@microsoft/opentelemetry` distro creates `Agent365Exporter` internally but does NOT pass `useS2SEndpoint: true`. For S2S agents, the exporter defaults to the OBO path (`/observability/tenants/{tenantId}/otlp/agents/{agentId}/traces`), but S2S requires `/observabilityService/...`.
+
+**Fix (applied to distro source):**
+
+1. `A365Configuration` — add `useS2SEndpoint` property + `AGENT365_USE_S2S_ENDPOINT` env var support
+2. `distro.js` — pass `a365Config.useS2SEndpoint` when constructing `Agent365Exporter`
+
+**For generated agent code:** Set the env var in `.env`:
+```
+AGENT365_USE_S2S_ENDPOINT=true
+```
+
+This is a distro-level fix. The `useMicrosoftOpenTelemetry()` call does NOT need a custom `spanProcessors` array — the built-in exporter reads the env var via `A365Configuration` and passes it to `Agent365Exporter`.
+
+**URL paths:**
+- OBO: `observability/tenants/{tenantId}/otlp/agents/{agentId}/traces`
+- S2S: `observabilityService/tenants/{tenantId}/otlp/agents/{agentId}/traces`
+
+### Node.js MSAL `fmiPath` Not Supported (AADSTS82008)
+
+No published version of `@azure/msal-node` (v3.x or v5.x) serializes the `fmiPath` parameter to the token endpoint request body. Passing `fmiPath` in `acquireTokenByClientCredential()` options (even with `as any`) is silently ignored, resulting in:
+
+```
+AADSTS82008: All agentic applications requesting a token exchange token must include the fmipath parameter on the token request.
+```
+
+**Workaround (implemented in `nodejs-observability.md`):** For the client-secret local-dev path (`acquireT1ViaClientSecret`), use a direct HTTP POST to `https://login.microsoftonline.com/{tenantId}/oauth2/v2.0/token` with `fmi_path={agentId}` as a URL-encoded form parameter. The MSI path still uses MSAL + `ManagedIdentityCredential` which handles FMI via a different mechanism.
+
+**Status:** Awaiting `@azure/msal-node` to ship native `fmiPath` support. Remove the HTTP workaround once available.
+
+### Node.js LangChain Instrumentor Initialization Order
+
+`LangChainTraceInstrumentor.instrument(LangChainCallbacks)` requires `ObservabilityManager` to be fully initialized. Calling it as a standalone statement after `useMicrosoftOpenTelemetry()` throws `"ObservabilityManager is not configured yet"` when `a365.enabled: true`.
+
+**Workaround:** Use `instrumentationOptions: { langchain: {} }` inside the `useMicrosoftOpenTelemetry()` options object. This ensures the distro initializes the manager and the LangChain instrumentor in the correct order.
 
 ---
 

--- a/plugins/agent365/skills/instrument-observability/references/nodejs-observability.md
+++ b/plugins/agent365/skills/instrument-observability/references/nodejs-observability.md
@@ -1,4 +1,4 @@
-# Node.js — A365 Observability Reference
+﻿# Node.js — A365 Observability Reference
 
 Authoritative package versions and code patterns for instrumenting A365 observability
 into a Node.js agent. All samples mirror the official Microsoft Learn docs (updated 2026-04-30).
@@ -94,7 +94,16 @@ No OBO user token is required.
 >   - `true` (production) — MSI → Blueprint FIC → Agent Identity → API
 >   - `false` (local dev) — Client Secret → Blueprint FIC → Agent Identity → API
 
-> **Note:** As of CLI 1.1, `a365 setup all` automatically grants `Agent365.Observability.OtelWrite` to the Agent Identity SP (both delegated and application). No manual role assignment is needed for newly provisioned agents.
+> **IMPORTANT — MSAL `fmiPath` limitation (as of 2026-04-30):** No published version of
+> `@azure/msal-node` (v3.x or v5.x) serializes the `fmiPath` parameter to the token endpoint.
+> Passing `fmiPath` via `acquireTokenByClientCredential()` with `as any` results in
+> `AADSTS82008: All agentic applications requesting a token exchange token must include the
+> fmipath parameter`. **Workaround:** For the client-secret path (`acquireT1ViaClientSecret`),
+> use a direct HTTP POST to the `/oauth2/v2.0/token` endpoint with `fmi_path` as a form
+> parameter. The MSI path (`acquireT1ViaMsi`) still uses MSAL since `ManagedIdentityCredential`
+> handles FMI differently. This workaround will be removed once MSAL ships native `fmiPath` support.
+
+> **Note:** `a365 setup all` attempts to grant `Agent365.Observability.OtelWrite` to the Agent Identity SP, but this requires **Global Administrator** privileges. If the assignment fails (403), a Global Admin must manually grant the role via Entra portal — otherwise trace exports will return HTTP 403.
 
 #### Step 1 — Create `observability/token-cache.ts`
 
@@ -246,24 +255,33 @@ async function acquireT1ViaMsi(authority: string, blueprintClientId: string, age
 }
 
 async function acquireT1ViaClientSecret(authority: string, blueprintClientId: string, blueprintClientSecret: string, agentId: string): Promise<string> {
-  const blueprintApp = new ConfidentialClientApplication({
-    auth: {
-      clientId: blueprintClientId,
-      authority,
-      clientSecret: blueprintClientSecret,
-    },
+  // Direct HTTP request — @azure/msal-node does not yet serialize fmiPath to the token endpoint.
+  // Use native fetch to POST with fmi_path form parameter until MSAL ships support.
+  const tokenUrl = `${authority}/oauth2/v2.0/token`;
+  const params = new URLSearchParams({
+    client_id: blueprintClientId,
+    client_secret: blueprintClientSecret,
+    scope: FMI_SCOPES[0],
+    grant_type: 'client_credentials',
+    fmi_path: agentId,
   });
 
-  const result = await blueprintApp.acquireTokenByClientCredential({
-    scopes: FMI_SCOPES,
-    azureRegion: undefined,
-    fmiPath: agentId,
-  } as any); // fmiPath is available in MSAL Node but not yet in stable types
+  const response = await fetch(tokenUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params.toString(),
+  });
 
-  if (!result?.accessToken) {
-    throw new Error('FMI T1 via client secret failed: no access token returned');
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(`FMI T1 via client secret failed (${response.status}): ${errorBody}`);
   }
-  return result.accessToken;
+
+  const data = await response.json() as { access_token?: string };
+  if (!data.access_token) {
+    throw new Error('FMI T1 via client secret failed: no access_token in response');
+  }
+  return data.access_token;
 }
 ```
 
@@ -312,6 +330,7 @@ const agentDetails: AgentDetails = {
 // ── Observability ────────────────────────────────────────────────────────────
 // Microsoft OpenTelemetry distro with A365 exporter.
 // Token resolver reads from in-memory cache populated by the background token service.
+// AGENT365_USE_S2S_ENDPOINT=true env var routes exports to /observabilityService/... path.
 useMicrosoftOpenTelemetry({
   a365: A365_ENABLED
     ? {
@@ -319,6 +338,9 @@ useMicrosoftOpenTelemetry({
         tokenResolver: (agentId, tenantId) => tokenResolver(agentId, tenantId) ?? '',
       }
     : undefined,
+  instrumentationOptions: {
+    langchain: {},   // replace with your framework's instrumentation or omit entirely
+  },
 });
 
 // Start background token service (skipped when credentials not configured)
@@ -357,6 +379,7 @@ AGENT365_CLIENT_SECRET=
 AGENT365_AGENT_NAME=my-agent
 AGENT365_AGENT_DESCRIPTION=
 AGENT365_USE_MANAGED_IDENTITY=true
+AGENT365_USE_S2S_ENDPOINT=true
 ```
 
 Message handler baggage setup is **identical** to `user-delegated` / `agentic-identity` — only the token resolver and credential source differ. Do **not** call `AgenticTokenCacheInstance.RefreshObservabilityToken` for S2S agents.
@@ -782,6 +805,29 @@ instrumentor.enable();
 ```
 
 ### LangChain
+
+> **IMPORTANT:** `LangChainTraceInstrumentor.instrument()` requires `ObservabilityManager` to be
+> fully initialized first. Calling it **after** `useMicrosoftOpenTelemetry()` as a separate
+> statement will throw `"ObservabilityManager is not configured yet"` if `a365.enabled` is `true`.
+>
+> **Preferred approach:** Use `instrumentationOptions: { langchain: {} }` inside the
+> `useMicrosoftOpenTelemetry()` call. This ensures correct initialization order:
+>
+> ```typescript
+> useMicrosoftOpenTelemetry({
+>   a365: { enabled: true, tokenResolver: ... },
+>   instrumentationOptions: {
+>     langchain: {},
+>   },
+> });
+> ```
+>
+> **Alternative (conditional):** If you must call `instrument()` separately, guard it:
+> ```typescript
+> if (process.env.ENABLE_A365_OBSERVABILITY_EXPORTER === 'true') {
+>   LangChainTraceInstrumentor.instrument(LangChainCallbacks);
+> }
+> ```
 
 ```typescript
 import { LangChainTraceInstrumentor } from '@microsoft/agents-a365-observability-extensions-langchain';

--- a/plugins/agent365/skills/make-a365-agent/SKILL.md
+++ b/plugins/agent365/skills/make-a365-agent/SKILL.md
@@ -1,4 +1,4 @@
----
+﻿---
 name: make-a365-agent
 version: 1.5.0
 description: >
@@ -241,12 +241,12 @@ Monitor output carefully:
 After `a365 setup all` completes, show the user:
 
 1. **The Setup Summary table** from CLI output — verbatim.
-2. **If the CLI printed an admin consent action item (Permission Grants):** Show all options:
-   - Option A — **Entra portal** (no CLI needed): [Entra portal](https://entra.microsoft.com) > App registrations > select Blueprint app > API permissions > Add a permission > APIs my organization uses > search `9b975845-388f-4429-889e-eab1ef63949c` > add both Delegated and Application `Agent365.Observability.OtelWrite` > Grant admin consent
-   - Option B — **PowerShell script** printed in the `a365 setup all` summary output (copy and run as GA)
-
-   Tell the user:
-   > "If admin consent is required, have a Global Administrator use Option A (Entra portal) or the PowerShell script shown in the setup output above."
+2. **If the CLI printed an admin consent action item (Permission Grants) or any role assignment failed (403):**
+   - **Extract the PowerShell admin consent script** from the CLI output and display it in a fenced code block so the user can copy it easily. The CLI typically prints a `Connect-AzAccount` / `New-AzADServicePrincipalAppRoleAssignment` script block — find and display it verbatim.
+   - If no PowerShell script was printed, provide the manual Entra portal steps:
+     [Entra portal](https://entra.microsoft.com) > App registrations > select Blueprint app > API permissions > Add a permission > APIs my organization uses > search `9b975845-388f-4429-889e-eab1ef63949c` > add both Delegated and Application `Agent365.Observability.OtelWrite` > Grant admin consent
+   - Tell the user:
+     > "⚠️ The OtelWrite app role assignment requires **Global Administrator**. Copy the PowerShell script above and have a Global Admin run it — without this, trace exports will fail with HTTP 403."
 3. **Skip the client secret action item entirely.** Do not show or mention it.
 
 Mark Todo 1 as completed.


### PR DESCRIPTION
Updates to four skill files for CLI 1.1:\n\n- `plugins/agent365/skills/a365-setup/SKILL.md`\n- `plugins/agent365/skills/instrument-observability/SKILL.md`\n- `plugins/agent365/skills/instrument-observability/references/nodejs-observability.md`\n- `plugins/agent365/skills/make-a365-agent/SKILL.md`