### PR TITLE
docs: update observability and a365-setup skills with production patterns

### DIFF
--- a/evals/agent365/a365-setup/evals.json
+++ b/evals/agent365/a365-setup/evals.json
@@ -1,6 +1,6 @@
 {
   "skill_name": "a365-setup",
-  "eval_instructions": "Test against real agent projects in clean state. Step 1 now covers ALL system prerequisites (dotnet, a365 CLI, PowerShell 7+, Azure CLI, Az PowerShell module, Git, GitHub CLI, and language-specific tools). Step 2 covers only Azure login and Entra ID roles. Step 3 delegates. a365-setup detects agentStack, programmingLanguage, and usesTeamsOrCopilot, THEN asks authMode (OBO/S2S/Both) BEFORE showing capabilities — WorkIQ is omitted from capabilities menu when authMode=s2s. After authMode, asks capabilities, then runs Steps 1–3. Azure login MUST use 'az login --allow-no-subscriptions' — plain 'az login' fails for accounts with no subscription. For the AI Teammate path (isAITeammate=true), Step 3 reads make-ai-teammate/SKILL.md. For all other paths, Step 3 reads make-a365-agent/SKILL.md. a365-setup does NOT run a365 setup all, does NOT create a365.config.json, and does NOT run a365 publish. Capabilities menu: Register, Observability, WorkIQ, AI Teammate — combinable. CEA detection uses multi-signal check. Phase 1C derives registrationType from usesTeamsOrCopilot. registrationType is derived, never asked.",
+  "eval_instructions": "Test against real agent projects in clean state. Step 1 now covers ALL system prerequisites (dotnet, a365 CLI, PowerShell 7+, Azure CLI, Az PowerShell module, Git, GitHub CLI, and language-specific tools). Step 2 covers only Azure login and Entra ID roles. Step 3 delegates. a365-setup detects agentStack, programmingLanguage, usesTeamsOrCopilot, and hasAITeammateChanges. CEA rule: if usesTeamsOrCopilot=1 (CEA), authMode is auto-set to 'agentic-user' and capabilities auto-set to [Register, Observability, WorkIQ, AI Teammate] — no questions asked. hasAITeammateChanges rule: if hasAITeammateChanges=1, authMode auto-set to 'agentic-user' and capabilities menu shows only Register and WorkIQ. For non-CEA/non-AI-Teammate agents: authMode question (OBO/S2S/agentic-user) asked before capabilities — WorkIQ omitted when authMode=s2s. If user selects AI Teammate (option 4), Register+Observability+WorkIQ are auto-included. Azure login MUST use 'az login --allow-no-subscriptions'. For the AI Teammate path (isAITeammate=true), Step 3 reads make-ai-teammate/SKILL.md. For all other paths, Step 3 reads make-a365-agent/SKILL.md. a365-setup does NOT run a365 setup all, does NOT create a365.config.json, and does NOT run a365 publish. Phase 1C derives registrationType from usesTeamsOrCopilot. registrationType is derived, never asked.",
   "evals": [
     {
       "id": 1,
@@ -61,18 +61,20 @@
       "id": 3,
       "prompt": "Set up A365 for this agent",
       "description": "CEA detection — Node.js project with teamsapp.yml and @microsoft/teams-ai present, no a365.config.json yet",
-      "expected_output": "Skill detects Node.js project. Phase 1A finds teamsapp.yml (or @microsoft/teams-ai in package.json) and classifies as CEA (usesTeamsOrCopilot=1) without requiring a365.config.json to exist. Phase 1B shows 'Custom Engine Agent (CEA)' as agent type. User confirms. Capabilities menu shown. Skill proceeds normally.",
+      "expected_output": "Skill detects Node.js project. Phase 1A finds teamsapp.yml (or @microsoft/teams-ai in package.json) and classifies as CEA (usesTeamsOrCopilot=1). Phase 1B shows 'Custom Engine Agent (CEA)' as agent type. User confirms. Because CEA can only be an AI Teammate, authMode is auto-set to 'agentic-user' and capabilities auto-set to [Register, Observability, WorkIQ, AI Teammate] — no auth mode question or capabilities menu is shown. Skill proceeds to Steps 1-3 and delegates to make-ai-teammate.",
       "files": [],
       "expectations": [
         "Phase 1A: usesTeamsOrCopilot detected as 1 (CEA) from teamsapp.yml or @microsoft/teams-ai — NOT from a365.config.json alone",
         "Phase 1A: Detection does NOT require a365.config.json to exist for CEA classification",
         "Phase 1B: Agent type shown as 'Custom Engine Agent (CEA) — has Teams/Copilot integration'",
-        "Phase 1B: User can correct to Agent (Non AI Teammate) if detection is wrong",
-        "Phase 1B: 4-option capabilities menu shown: Register, Observability, WorkIQ, AI Teammate",
+        "Phase 1B: Auth mode question is NOT shown — authMode auto-set to 'agentic-user' with message explaining CEA only supports Agent User Account",
+        "Phase 1B: Capabilities menu is NOT shown — capabilities auto-set to [Register, Observability, WorkIQ, AI Teammate] with message explaining CEAs can only be AI Teammates",
+        "Phase 1C: isAITeammate = true",
         "Phase 1C: registrationType = 1 (derived from usesTeamsOrCopilot=1 — CEA/Entra app ID path)",
-        "Phase 1C: 3 todos created",
+        "Phase 1C: 3 todos created with Step 3 = Run the make-ai-teammate skill",
         "Step 1: a365 CLI validated",
-        "Step 2: Azure prerequisites confirmed"
+        "Step 2: Azure prerequisites confirmed",
+        "Step 3: Delegates to make-ai-teammate"
       ]
     },
     {
@@ -141,19 +143,20 @@
     {
       "id": 8,
       "prompt": "Make this agent an AI Teammate",
-      "description": "CEA guard — CEA detected (usesTeamsOrCopilot=1) and user selects AI Teammate (option 4); skill must block and re-present options 1-3",
-      "expected_output": "The skill detects CEA (usesTeamsOrCopilot=1) from Phase 1A. User selects option 4 (AI Teammate). The CEA guard fires: skill responds with the blocking message, sets isAITeammate=false, and re-presents options 1-3. User selects a valid option (e.g. Register). Skill proceeds with the Standard Agent path.",
+      "description": "CEA auto-routes to AI Teammate — CEA detected (usesTeamsOrCopilot=1); skill must auto-select AI Teammate path without asking",
+      "expected_output": "The skill detects CEA (usesTeamsOrCopilot=1) from Phase 1A. No auth mode or capabilities question is shown. authMode is auto-set to 'agentic-user' and capabilities auto-set to [Register, Observability, WorkIQ, AI Teammate] with a message explaining CEAs can only be AI Teammates. isAITeammate = true. Skill proceeds to Steps 1-3 and delegates to make-ai-teammate.",
       "files": [],
       "expectations": [
         "Phase 1A: usesTeamsOrCopilot detected as 1 (CEA)",
-        "Phase 1B: Capabilities menu shown — option 4 includes ⚠️ note about CEA not supported as AI Teammate",
-        "Phase 1B: User selects option 4 (AI Teammate)",
-        "Phase 1C: CEA guard fires — skill responds: 'Custom Engine Agents are supported as Agent (Non AI Teammate) agents. AI Teammate is not supported for CEA.'",
-        "Phase 1C: isAITeammate is forced to false",
-        "Phase 1C: Options 1-3 are re-presented to the user",
-        "Phase 1C: User selects a valid option — skill continues with Agent (Non AI Teammate) path",
-        "make-ai-teammate is NOT invoked",
-        "make-a365-agent SKILL.md is read and followed for the re-selected capability"
+        "Phase 1B: Auth mode question NOT shown — authMode auto-set to 'agentic-user'",
+        "Phase 1B: Capabilities menu NOT shown — capabilities auto-set to [Register, Observability, WorkIQ, AI Teammate]",
+        "Phase 1B: User informed that CEAs can only be configured as AI Teammates",
+        "Phase 1C: isAITeammate = true",
+        "Phase 1C: 3 todos created with Step 3 = Run the make-ai-teammate skill",
+        "Step 1: a365 CLI validated",
+        "Step 2: Azure prerequisites confirmed",
+        "Step 3: make-ai-teammate SKILL.md is read and followed",
+        "make-a365-agent is NOT invoked for CEA agents"
       ]
     },
     {

--- a/plugins/agent365/skills/a365-setup/SKILL.md
+++ b/plugins/agent365/skills/a365-setup/SKILL.md
@@ -100,17 +100,40 @@ Check the following signals **in parallel** (Glob + Grep).
 
 If no strong standalone signal and no valid pairing → `0` (Agent (Non AI Teammate), no M365 integration detected — may be a non-M365 CEA or other Agent (Non AI Teammate) type)
 
+**Step 4: Detect AI Teammate Changes** → Store as `hasAITeammateChanges`
+
+Run all checks **in parallel** (Glob + Grep):
+
+*AI Teammate structure signals (from `make-ai-teammate`) — any one counts:*
+- `AgentApplication` in `src/**/*.ts`, `**/*.cs`, or `**/*.py`
+- `CloudAdapter` in `src/**/*.ts` or `CloudAdapterAiohttp` in `**/*.py`
+- `@microsoft/agents-a365-notifications` in `package.json`
+- `Microsoft.Agents.A365.Notifications` in `**/*.csproj`
+- `ToolingManifest.json` exists
+
+*Observability signals (from `instrument-observability`) — any one counts:*
+- `Microsoft.Agents.A365.Observability.Runtime` or `Microsoft.Agents.A365.Observability.Hosting` or `Microsoft.OpenTelemetry` in `**/*.csproj` (.NET)
+- `@microsoft/agents-a365-observability` or `@microsoft/opentelemetry` in `package.json` (Node.js)
+- `microsoft-agents-a365-observability-core` in `requirements.txt` or `pyproject.toml` (Python)
+- `A365 Observability` comment in any `src/**/*.ts`, `**/*.cs`, or `**/*.py` file
+
+If at least one signal from **each** category is found → `hasAITeammateChanges = 1`
+Otherwise → `hasAITeammateChanges = 0`
+
 ### Phase 1B: User Validation Questions
 
 Present **all three detections in a single message** and wait for ONE response:
 
 ```
 Here's what we detected about your agent:
-  • Stack:         {agentStack}
-  • Language:      {programmingLanguage}
-  • Agent type:    {usesTeamsOrCopilot == 1
-                     ? "M365 Custom Engine Agent (CEA) — Agent (Non AI Teammate) with Teams/Copilot integration"
-                     : "Agent (Non AI Teammate) — no Teams/Copilot markers detected (may be a non-M365 CEA, background agent, or other Agent (Non AI Teammate) type)"}
+  • Stack:            {agentStack}
+  • Language:         {programmingLanguage}
+  • Agent type:       {usesTeamsOrCopilot == 1
+                        ? "uses Teams/Copilot integration"
+                        : "no Teams/Copilot markers detected"}
+  • AI Teammate setup: {hasAITeammateChanges == 1
+                        ? "already configured (make-ai-teammate + observability detected)"
+                        : "not yet configured"}
 
 Reply **yes** to confirm, or describe any corrections.
 Examples: "language is NodeJS", "it's a Custom Engine Agent", "it's not Teams".
@@ -123,6 +146,13 @@ Examples: "language is NodeJS", "it's a Custom Engine Agent", "it's not Teams".
 
 **Auth mode question (ask before capabilities):**
 
+If `hasAITeammateChanges = 1` or `usesTeamsOrCopilot = 1` (CEA), **do not ask** — automatically set `authMode = "agentic-user"` and tell the user:
+
+- If `usesTeamsOrCopilot = 1`: "This is a Custom Engine Agent (CEA) — the only supported auth mode is **Agent User Account (agentic-user)**."
+- If `hasAITeammateChanges = 1`: "Since this agent already has AI Teammate changes configured, **Agent User Account (agentic-user)** is the only supported auth mode. Your agent authenticates using its own Entra identity provisioned via the Agent 365 Blueprint."
+
+Otherwise, ask:
+
 ```
 How will your agent authenticate when calling downstream APIs?
 
@@ -133,11 +163,14 @@ How will your agent authenticate when calling downstream APIs?
   2. Service-to-service (S2S) — the agent acts as its own identity (application permissions)
      Choose this when the agent runs unattended or needs tenant-wide access without a signed-in user
      (e.g. reading all mailboxes, managing SharePoint sites).
+
+  3. Agent User Account  - The agent has it own Entra User Account based on an Entra Blueprint and authenticates with its own credentials. This is a special mode for AI Teammate agents that interact with workflows using their own user identity. https://learn.microsoft.com/en-us/entra/agent-id/agent-users
 ```
 
 Wait for the answer. Store as `authMode`:
 - If 1 → `authMode = "obo"`
 - If 2 → `authMode = "s2s"`
+- If 3 → `authMode = "agentic-user"`
 
 > **Note:** WorkIQ MCP servers require delegated (OBO) permissions — they are not available for S2S-only agents.
 
@@ -145,40 +178,41 @@ Wait for the answer. Store as `authMode`:
 
 **Final question: What capabilities do you want to enable?**
 
-Present only the options that apply — **omit WorkIQ when `authMode = "s2s"`** and omit or note option 4 if CEA was detected:
+If `usesTeamsOrCopilot = 1` (CEA), **do not ask** — automatically set `capabilities = [Register, Observability, WorkIQ, AI Teammate]` and tell the user:
+
+> "Custom Engine Agents can only be configured as AI Teammates. **Register**, **Observability**, **WorkIQ**, and **AI Teammate** have been selected automatically."
+
+Otherwise, if `hasAITeammateChanges = 1`, only present these options (Observability and AI Teammate are already configured):
 
   1. Register — make the agent findable in the Agent 365 catalog
-  2. Observability — end-to-end activity tracing for every message, LLM call, and tool use, visible in the Agent 365 portal and Microsoft Defender
+  3. WorkIQ — add WorkIQ MCP servers (M365 data: email, calendar, Teams, SharePoint, OneDrive)
+
+Otherwise, present only the options that apply — **omit WorkIQ when `authMode = "s2s"`**:
+
+  1. Register — make the agent findable in the Agent 365 catalog
+  2. Observability — end-to-end activity tracing for every message, LLM call, and tool use, visible in the Agent 365 portal and Microsoft Defender. Will register your agent with the A365 catalog if not already registered.
   3. WorkIQ — add WorkIQ MCP servers (M365 data: email, calendar, Teams, SharePoint, OneDrive)
      _(omit this option when `authMode = "s2s"` — WorkIQ requires a user token)_
-  4. AI Teammate  — agent gets a first-class M365 identity (Agentic User with UPN)
-     ⚠️  NOT available for Custom Engine Agents — CEA is supported as Agent (Non AI Teammate) only
-
-> **CEA guard:** If `usesTeamsOrCopilot = 1` (CEA detected) and the user selects option 4, respond:
-> "Custom Engine Agents are supported as Agent (Non AI Teammate) agents.
->  AI Teammate is not supported for CEA.
->  Please choose from options 1–3."
-> Then re-present options 1–3 (minus WorkIQ if S2S) and wait for a new answer.
+  4. AI Teammate  — agent gets a first-class M365 identity (Agentic User with UPN). AI Teammates interact with productivity workflows using their own identity.
+       _(only show this option when `authMode = "agentic-user"`- AI Teammate needs an auth type of `agentic-user`)_
 
 Wait for the answer. Store as `capabilities`.
 
 > **Note:** Options can be combined — e.g. a user can say "1 and 2" for Register + Observability.
 
+> **AI Teammate auto-select:** If the user selects option 4 (AI Teammate), automatically include options 1 (Register), 2 (Observability), and 3 (WorkIQ) — set `capabilities = [Register, Observability, WorkIQ, AI Teammate]` and inform the user: "AI Teammate includes Register, Observability, and WorkIQ automatically."
+
 ### Phase 1C: Determine Path and Create Todos
 
 After the capabilities question is answered (and the detection/confirmation above is complete):
 
-1. Set `isAITeammate = true` if the user selected **AI Teammate**, else `isAITeammate = false`.
-   - **If `usesTeamsOrCopilot = 1` (CEA) AND `isAITeammate = true`:** This combination is not supported.
-     Tell the user: "CEA is supported as an Agent (Non AI Teammate) — AI Teammate is not supported for CEA."
-     Set `isAITeammate = false` and route to the Standard/CEA path.
-
-2. **Write `.a365-workspace-detection.json`** now (see `agent-detection.md` cache format). Include `agentType` derived from `isAITeammate` and `authMode` collected above:
+1. **Write `.a365-workspace-detection.json`** now (see `agent-detection.md` cache format). Include `agentType` derived from `isAITeammate` and `authMode` collected above:
    - `isAITeammate = true` → `agentType: "ai-teammate"`
    - `isAITeammate = false` → `agentType: "system-agent"`
    - Write `authMode` as collected (`"obo"` or `"s2s"`) — downstream skills (`instrument-observability`, `add-workiq-tools`) read this to skip re-asking.
+   - Write `hasAITeammateChanges` as detected in Phase 1A Step 4 (`1` or `0`).
 
-3. Derive `registrationType` from Phase 1A signals (do not ask the user):
+2. Derive `registrationType` from Phase 1A signals (do not ask the user):
    - `registrationType = 1` if `usesTeamsOrCopilot = 1` (CEA — Entra app ID path)
    - `registrationType = 3` if `usesTeamsOrCopilot = 0` (Agent (Non AI Teammate) / no M365 integration path)
    - (`registrationType = 2` — Blueprint already exists — is set by make-ai-teammate, not here)

--- a/plugins/agent365/skills/instrument-observability/SKILL.md
+++ b/plugins/agent365/skills/instrument-observability/SKILL.md
@@ -283,7 +283,7 @@ The `authMode` value drives Phases 3–5: OBO and S2S paths differ in entry poin
 
 2. **Edit** — Add observability wiring following the reference pattern in `dotnet-observability.md`:
    - Add using directives for the observability namespaces
-   - **OBO path** (`user-delegated` or `agentic-identity`): call `builder.Services.AddAgenticTracingExporter();` then `builder.AddA365Tracing();`
+   - **OBO path** (`user-delegated` or `agentic-identity`): call `builder.Services.AddAgenticTracingExporter(clusterCategory: "production");` then `builder.AddA365Tracing(config => { config.WithAgentFramework(); });` — requires `using Microsoft.Agents.A365.Observability.Extensions.AgentFramework;` and the NuGet package `Microsoft.Agents.A365.Observability.Extensions.AgentFramework`. Also set `"EnableAgent365Exporter": true` in `appsettings.json` to activate the backend exporter (when `false`, traces are only emitted to console).
    - **S2S path**: First **Write** the two scaffold files from the reference doc — `Observability/ObservabilityServiceExtensions.cs` (DI extension with `AddAgent365Observability()` using `ServiceTokenCache` and conditional `ObservabilityTokenService`) and `Observability/ObservabilityTokenService.cs` (background service that acquires the Observability API token via the MSAL FMI 3-hop chain with `.WithFmiPath()` targeting scope `api://9b975845-388f-4429-889e-eab1ef63949c/.default`, supports MSI with client-secret fallback). Then call `builder.Services.AddAgent365Observability();` and `builder.UseMicrosoftOpenTelemetry(...)` with token resolver reading from the `ServiceTokenCache`. **Critical:** Set `o.Agent365.Exporter.UseS2SEndpoint = true` in the options callback — without this, the exporter posts to the wrong path (`/observability/` instead of `/observabilityService/`) and gets HTTP 401. See "Known Issues" section.
    - Optionally register `adapter.Use(new BaggageTurnMiddleware())` (OBO path only) to auto-populate baggage on every request
    - Mark all new lines with: `// A365 Observability — best-effort instrumentation (verify against official sample)`
@@ -335,26 +335,43 @@ The `authMode` value drives Phases 3–5: OBO and S2S paths differ in entry poin
 
 1. **Read** the detected message handler file.
 
-2. **Edit** — Follow the reference pattern in `dotnet-observability.md` based on `authMode`:
+2. **Edit** — Follow the reference pattern (see `Agent365-samples/dotnet/agent-framework/sample-agent/telemetry/A365OtelWrapper.cs`):
 
    **OBO path** (`user-delegated` or `agentic-identity`):
    - Inject `IExporterTokenCache<AgenticTokenStruct>` in the constructor
-   - Use `new BaggageBuilder().FromTurnContext(turnContext).Build()` — requires `using Microsoft.Agents.A365.Observability.Hosting.Extensions;`; `Build()` returns `IDisposable`, use `using var`
+   - **Resolve agent ID and tenant ID from the agentic request** — add a helper method:
+     ```csharp
+     private static (string agentId, string tenantId) ResolveTenantAndAgentId(ITurnContext turnContext)
+     {
+         string agentId = turnContext.Activity.IsAgenticRequest()
+             ? turnContext.Activity.GetAgenticInstanceId()
+             : Guid.Empty.ToString();
+
+         string tenantId = turnContext.Activity.Conversation?.TenantId
+             ?? turnContext.Activity.Recipient?.TenantId
+             ?? Guid.Empty.ToString();
+
+         return (agentId, tenantId);
+     }
+     ```
+     `GetAgenticInstanceId()` returns the agent's **service principal object ID** (the instance ID assigned by A365). This is the correct ID for observability export — it maps to the agent in the MAC portal.
+   - Use `new BaggageBuilder().TenantId(tenantId).AgentId(agentId).Build()` to set baggage context.
    - Call `RegisterObservability` with all four arguments per turn (wrap in try/catch — non-fatal):
      ```csharp
      _agentTokenCache.RegisterObservability(
-         turnContext.Activity.Recipient.AgenticAppId,
-         turnContext.Activity.Recipient.TenantId,
+         agentId,
+         tenantId,
          new AgenticTokenStruct(
              userAuthorization: UserAuthorization,
              turnContext: turnContext,
-             authHandlerName: "AGENTIC"),
+             authHandlerName: authHandlerName),
          EnvironmentUtils.GetObservabilityAuthenticationScope()
      );
      ```
-     - `user-delegated`: token exchange resolves to the **signed-in user's** identity → traces attributed to the user
-     - `agentic-identity`: token exchange resolves to the **agentic user** provisioned in Azure AD → traces attributed to the agent
-   - Add inline comment: `// A365 auth mode: {authMode} — see: https://learn.microsoft.com/en-us/entra/agent-id/agent-on-behalf-of-oauth-flow`
+     Note: Some SDK versions support object-initializer syntax instead. If the constructor form fails to compile, try property-initializer: `new AgenticTokenStruct { UserAuthorization = ..., TurnContext = ..., AuthHandlerName = ... }`.
+   - The `authHandlerName` should be the agentic auth handler name (from config `AgentApplication:AgenticAuthHandlerName`) when `IsAgenticRequest()` is true, empty string otherwise.
+   - **No `Agent365Observability` config section needed** — all values are resolved from the agentic request at runtime.
+   - **Recommended pattern:** Create a reusable static wrapper method (e.g. `A365OtelWrapper.InvokeObservedAgentOperation(...)`) that encapsulates agent ID resolution, baggage building, token registration, and the operation invocation. See the reference sample's `telemetry/A365OtelWrapper.cs`.
 
    **S2S path**:
    - Inject `Agent365ObservabilityContext` (singleton registered by `AddAgent365Observability()`) in the constructor — **not** `IExporterTokenCache<AgenticTokenStruct>`


### PR DESCRIPTION
## Summary

Updates the **instrument-observability** and **a365-setup** skills based on learnings from building and testing a real .NET AI Teammate agent with A365 observability + exporter.

### Observability SKILL.md
- Add `clusterCategory: "production"` to `AddAgenticTracingExporter` call
- Add `WithAgentFramework()` config and `EnableAgent365Exporter` appsettings flag
- Add `ResolveTenantAndAgentId` helper pattern using `GetAgenticInstanceId()`
- Update `RegisterObservability` to use resolved agentId/tenantId instead of hardcoded values
- Add note about `AgenticTokenStruct` constructor vs property-initializer syntax
- Reference `A365OtelWrapper.cs` pattern from official sample agent

### a365-setup SKILL.md
- Add `hasAITeammateChanges` detection (Step 4) for agents already configured by make-ai-teammate
- Add `agentic-user` auth mode (option 3) for AI Teammate agents
- Auto-select `agentic-user` when CEA or `hasAITeammateChanges` is detected
- Auto-select all capabilities for CEA agents
- AI Teammate selection auto-includes Register + Observability + WorkIQ

### a365-setup evals
- Update eval test cases to match new detection and auth mode flows

---

**Testing:** Changes tested against a live .NET AgentFramework AI Teammate agent with traces successfully exporting to A365 backend and visible in Microsoft Defender portal.