### PR TITLE
Rename "Standard Agent" to "Agent (Non AI Teammate)" throughout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,7 +223,7 @@ Skills reference shared docs via `Read ${CLAUDE_PLUGIN_ROOT}/shared/<file>.md`.
 - **Stage 1 — Agent kind:** AI Teammate or Agent (Non AI Teammate) (pre-filled from `usesTeamsOrCopilot` cache if available).
 - **Stage 2 — Auth mode:** depends on agent kind:
   - AI Teammate → `obo` (signed-in user OBO) or `agentic-user` (agent's own Azure AD user — persistent M365 identity)
-  - Agent (Non AI Teammate) → `obo` (Assistive / OBO) or `s2s` (Autonomous / Service Principal, no user token)
+  - Agent (Non AI Teammate) → `obo` (On-Behalf-Of) or `s2s` (Service Principal, no user token)
 
 All three `authMode` values use an auth handler reference in SDK code — the difference is Azure AD provisioning. For OBO paths: .NET reads `authHandlerName` from config (`AgentApplication:AgenticAuthHandlerName`); Node.js passes `agentApplication.authorization` (the auth object) to `RefreshObservabilityToken`; Python uses `auth_handler_id=self.auth_handler_name` (from config) in `exchange_token()` — never hardcode `"AGENTIC"`. Agent IDs are always resolved dynamically from TurnContext — .NET: `turnContext.Activity.GetAgenticInstanceId()` (service principal object ID); Node.js/Python: `recipient.agenticAppId` / `agentic_app_id`. Results are cached in `.a365-workspace-detection.json` under `agentType` and `authMode` fields so subsequent skill invocations skip re-questioning. If `authMode = s2s` and the skill is `add-workiq-tools`, the skill exits immediately — WorkIQ is not available for s2s agents (requires a delegated OBO token).
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ a365-setup  (recommended entry point — handles CLI, Azure, Blueprint)
 │     agentic-user (agent's own M365 identity)      └─ add-workiq-tools          (optional, offered automatically)
 │
 └─ Agent (Non AI Teammate) → make-a365-agent  (Blueprint + Entra permissions)
-      obo (Assistive) or                       ├─ instrument-observability  (optional, offered automatically)
-      s2s (Autonomous)                         └─ add-workiq-tools          (optional, obo only)
+      obo (On-Behalf-Of) or                    ├─ instrument-observability  (optional, offered automatically)
+      s2s (Service Principal)                  └─ add-workiq-tools          (optional, obo only)
 
 test-local  ← standalone; run at any point to test your agent locally
 ```
@@ -159,8 +159,8 @@ Provisions an **Agent (Non AI Teammate)** with Agent 365. A Agent (Non AI Teamma
 >
 > CEA is the primary supported Agent (Non AI Teammate) path. CEA is **not** supported as an AI Teammate.
 
-- **Assistive (OBO)** — acts on behalf of the signed-in user via On-Behalf-Of flow
-- **Autonomous (S2S / Service Principal)** — runs independently, no user required
+- **`obo` (On-Behalf-Of)** — acts on behalf of the signed-in user via On-Behalf-Of flow
+- **`s2s` (Service Principal, no user token)** — runs independently with service principal credentials, no user required
 
 Normally invoked from `a365-setup` after CLI and Azure prerequisites are confirmed, but can also be called directly.
 
@@ -168,7 +168,7 @@ Normally invoked from `a365-setup` after CLI and Azure prerequisites are confirm
 |-----------|-------------|
 | **Register** | Blueprint + Entra permissions. Agent appears in the Agent 365 catalog. |
 | **Register + Observability** | Same, then invokes `instrument-observability`. |
-| **Observability** (Custom Engine Agent / Agent (Non AI Teammate)) | Blueprint + permissions, then invokes `instrument-observability`. Supports Assistive (OBO) and Autonomous (S2S). |
+| **Observability** (Custom Engine Agent / Agent (Non AI Teammate)) | Blueprint + permissions, then invokes `instrument-observability`. Supports both `obo` (On-Behalf-Of) and `s2s` (Service Principal). |
 | **Observability + WorkIQ** | Same, then also invokes `add-workiq-tools`. |
 
 Always shows a dry-run preview before applying anything. `a365 setup all` is idempotent — safe to re-run. WorkIQ MCP calls use OAuth On-Behalf-Of (OBO) tokens; users consent on first data access.
@@ -186,7 +186,7 @@ Always shows a dry-run preview before applying anything. `a365 setup all` is ide
 ### `add-workiq-tools` — Add WorkIQ MCP servers
 
 > **Prerequisite:** `a365-setup` must be run first.
-> **Auth requirement:** WorkIQ requires a user in the loop — supported for AI Teammates and Agent (Non AI Teammate) Assistive (OBO). Not available for Agent (Non AI Teammate) Autonomous (S2S).
+> **Auth requirement:** WorkIQ requires a user in the loop — supported for AI Teammates (`agentic-user`) and Agent (Non AI Teammate) with `obo` (On-Behalf-Of). Not available for Agent (Non AI Teammate) with `s2s` (Service Principal).
 
 Adds pre-built Microsoft 365 integration tools to your agent. Runs `a365 develop list-available`
 to show the MCP server catalog, adds selected servers via `a365 develop add-mcp-servers`
@@ -214,11 +214,11 @@ wiring any code, asks a two-stage question to determine **agent kind** and **aut
 
 **Stage 1 — Agent kind:**
 - **AI Teammate**: has Agentic User with UPN; then asks whether it uses `obo` (signed-in user) or `agentic-user` (agent's own M365 identity). **Both support Observability and WorkIQ.**
-- **Agent (Non AI Teammate)**: no Agentic User; then asks whether it is `obo` (Assistive OBO) or `s2s` (Autonomous / Service Principal). **Observability supports both; WorkIQ is obo only (Assistive mode).**
+- **Agent (Non AI Teammate)**: no Agentic User; then asks whether it is `obo` (On-Behalf-Of) or `s2s` (Service Principal, no user token). **Observability supports both; WorkIQ requires `obo` (delegated user token).**
 
 **Wiring by auth mode:**
-- **obo / agentic-user (Assistive OBO)**: `AddAgenticTracingExporter` + per-turn `RegisterObservability` with `AgenticTokenStruct`
-- **Autonomous S2S** (all languages): creates a scaffold token-service file per language (`Observability/ObservabilityTokenService.cs` for .NET, `observability/observability-token-service.ts` for Node.js, `observability/observability_token_service.py` for Python) that acquires the Observability API token (`api://9b975845-388f-4429-889e-eab1ef63949c/.default`) via MSAL client credentials and refreshes every 50 min — no per-turn token call
+- **`obo` / `agentic-user`** (OBO token exchange): `AddAgenticTracingExporter` + per-turn `RegisterObservability` with `AgenticTokenStruct`
+- **`s2s`** (Service Principal, all languages): creates a scaffold token-service file per language (`Observability/ObservabilityTokenService.cs` for .NET, `observability/observability-token-service.ts` for Node.js, `observability/observability_token_service.py` for Python) that acquires the Observability API token (`api://9b975845-388f-4429-889e-eab1ef63949c/.default`) via MSAL client credentials and refreshes every 50 min — no per-turn token call
 
 All new code is marked `// A365 Observability — best-effort instrumentation` and changes are non-destructive and idempotent.
 

--- a/README.md
+++ b/README.md
@@ -153,11 +153,11 @@ Handles Steps 1–2 for every path: installs/updates the a365 CLI, validates Azu
 
 ### `make-a365-agent` — Provision Agent (Non AI Teammate) Agents
 
-Provisions an **Agent (Non AI Teammate)** with Agent 365. A Standard Agent has no Agentic User identity (no UPN) — it is task-oriented, system-oriented, or assistive, and appears as a system or service agent rather than a virtual teammate. It authenticates via an Entra App ID or Agent Blueprint + Agent Identity, in one of two execution modes:
+Provisions an **Agent (Non AI Teammate)** with Agent 365. A Agent (Non AI Teammate) has no Agentic User identity (no UPN) — it is task-oriented, system-oriented, or assistive, and appears as a system or service agent rather than a virtual teammate. It authenticates via an Entra App ID or Agent Blueprint + Agent Identity, in one of two execution modes:
 
-> **Taxonomy:** Agent (Non AI Teammate) is a broad category. **CEA (Custom Engine Agent) is a specific subset** — built on a custom runtime, often with Teams/M365 integration. CEA ⊂ Agent (Non AI Teammate), but not all Standard Agents are CEAs. Other Standard Agent types include Agent Builder agents, SharePoint agents, background automation / import / sync agents, policy / classifier agents, and 3P system agents with no Teams surface.
+> **Taxonomy:** Agent (Non AI Teammate) is a broad category. **CEA (Custom Engine Agent) is a specific subset** — built on a custom runtime, often with Teams/M365 integration. CEA ⊂ Agent (Non AI Teammate), but not all Agent (Non AI Teammate)s are CEAs. Other Agent (Non AI Teammate) types include Agent Builder agents, SharePoint agents, background automation / import / sync agents, policy / classifier agents, and 3P system agents with no Teams surface.
 >
-> CEA is the primary supported Standard Agent path. CEA is **not** supported as an AI Teammate.
+> CEA is the primary supported Agent (Non AI Teammate) path. CEA is **not** supported as an AI Teammate.
 
 - **Assistive (OBO)** — acts on behalf of the signed-in user via On-Behalf-Of flow
 - **Autonomous (S2S / Service Principal)** — runs independently, no user required
@@ -168,7 +168,7 @@ Normally invoked from `a365-setup` after CLI and Azure prerequisites are confirm
 |-----------|-------------|
 | **Register** | Blueprint + Entra permissions. Agent appears in the Agent 365 catalog. |
 | **Register + Observability** | Same, then invokes `instrument-observability`. |
-| **Observability** (Custom Engine Agent / Standard Agent) | Blueprint + permissions, then invokes `instrument-observability`. Supports Assistive (OBO) and Autonomous (S2S). |
+| **Observability** (Custom Engine Agent / Agent (Non AI Teammate)) | Blueprint + permissions, then invokes `instrument-observability`. Supports Assistive (OBO) and Autonomous (S2S). |
 | **Observability + WorkIQ** | Same, then also invokes `add-workiq-tools`. |
 
 Always shows a dry-run preview before applying anything. `a365 setup all` is idempotent — safe to re-run. WorkIQ MCP calls use OAuth On-Behalf-Of (OBO) tokens; users consent on first data access.
@@ -186,7 +186,7 @@ Always shows a dry-run preview before applying anything. `a365 setup all` is ide
 ### `add-workiq-tools` — Add WorkIQ MCP servers
 
 > **Prerequisite:** `a365-setup` must be run first.
-> **Auth requirement:** WorkIQ requires a user in the loop — supported for AI Teammates and Agent (Non AI Teammate) Assistive (OBO). Not available for Standard Agent Autonomous (S2S).
+> **Auth requirement:** WorkIQ requires a user in the loop — supported for AI Teammates and Agent (Non AI Teammate) Assistive (OBO). Not available for Agent (Non AI Teammate) Autonomous (S2S).
 
 Adds pre-built Microsoft 365 integration tools to your agent. Runs `a365 develop list-available`
 to show the MCP server catalog, adds selected servers via `a365 develop add-mcp-servers`

--- a/evals/agent365/a365-setup/evals.json
+++ b/evals/agent365/a365-setup/evals.json
@@ -254,11 +254,11 @@
       "id": 13,
       "prompt": "Make this agent an AI Teammate",
       "description": "Non-CEA agent selecting AI Teammate from capabilities menu — agentic-user authMode set automatically (not user-selectable in auth mode question)",
-      "expected_output": "Skill outputs intro message. Phase 1A detects a standard non-CEA agent (usesTeamsOrCopilot=0, hasAITeammateChanges=0). Phase 1B shows capabilities menu first (all 4 options). User selects option 4 (AI Teammate). Auth mode question is NOT shown — authMode is auto-set to agentic-user (agent's own M365 identity). isAITeammate=true stored in cache. Delegates to make-ai-teammate.",
+      "expected_output": "Skill outputs intro message. Phase 1A detects a non-CEA agent (usesTeamsOrCopilot=0, hasAITeammateChanges=0). Phase 1B shows capabilities menu first (all 4 options). User selects option 4 (AI Teammate). Auth mode question is NOT shown — authMode is auto-set to agentic-user (agent's own M365 identity). isAITeammate=true stored in cache. Delegates to make-ai-teammate.",
       "files": [],
       "expectations": [
         "Skill outputs mandatory intro message before any tool calls",
-        "Phase 1A: usesTeamsOrCopilot=0 and hasAITeammateChanges=0 detected (standard non-CEA agent)",
+        "Phase 1A: usesTeamsOrCopilot=0 and hasAITeammateChanges=0 detected (non-CEA agent)",
         "Phase 1B: Capabilities menu shown FIRST with all four options: Register, Observability, WorkIQ, AI Teammate",
         "Phase 1B: User selects option 4 (AI Teammate)",
         "Phase 1B: Auth mode question NOT shown — AI Teammate always uses agentic-user (agent's own M365 identity, not the caller's token)",
@@ -288,7 +288,7 @@
       "id": 15,
       "prompt": "Set up A365 for this autonomous agent",
       "description": "s2s auth mode — non-AI Teammate agent; user selects s2s after capabilities; WorkIQ is dropped with warning",
-      "expected_output": "Skill outputs intro message. Phase 1A detects standard non-CEA agent. Phase 1B shows capabilities menu first (all 4 options including WorkIQ). User selects Register. Auth mode question shown after capabilities; user selects s2s. If WorkIQ had been selected, skill warns and drops it. authMode=s2s stored in .a365-workspace-detection.json. Delegates to make-a365-agent.",
+      "expected_output": "Skill outputs intro message. Phase 1A detects non-CEA agent. Phase 1B shows capabilities menu first (all 4 options including WorkIQ). User selects Register. Auth mode question shown after capabilities; user selects s2s. If WorkIQ had been selected, skill warns and drops it. authMode=s2s stored in .a365-workspace-detection.json. Delegates to make-a365-agent.",
       "files": [],
       "expectations": [
         "Skill outputs mandatory intro message before any tool calls",

--- a/evals/agent365/add-workiq-tools/evals.json
+++ b/evals/agent365/add-workiq-tools/evals.json
@@ -159,7 +159,7 @@
         "Phase 0B: Auth mode question presented — user selects S2S",
         "Phase 0B: Skill exits immediately with ❌ message — WorkIQ is not available for S2S agents",
         "Phase 0B: No option to proceed is offered — hard block, not a warning",
-        "Phase 0B: Message explains WorkIQ requires a delegated OBO token at runtime and instructs user to switch to Assistive (obo) mode",
+        "Phase 0B: Message explains WorkIQ requires a delegated OBO token at runtime and instructs user to switch to `obo` (On-Behalf-Of) mode",
         "Phase 0C and all subsequent phases: NOT reached — session ends after the block message",
         "No a365 develop list-available is run",
         "No code changes are made to the agent"

--- a/evals/agent365/make-a365-agent/evals.json
+++ b/evals/agent365/make-a365-agent/evals.json
@@ -5,7 +5,7 @@
     {
       "id": 1,
       "prompt": "Run a365 setup for this agent",
-      "description": "Register path (Standard Agent) — .NET AgentFramework, delegated from a365-setup",
+      "description": "Register path (Agent (Non AI Teammate)) — .NET AgentFramework, delegated from a365-setup",
       "expected_output": "Skill reads context (capabilities=Register, usesTeamsOrCopilot=0) from session. Creates 3 todos (Register, Add Observability optional, Add WorkIQ optional). Runs a365 setup all --dry-run, confirms, runs setup. Shows Setup Summary verbatim. Then always offers observability (Phase 3) and WorkIQ (Phase 4) as optional add-ons.",
       "files": [],
       "expectations": [
@@ -27,7 +27,7 @@
     {
       "id": 2,
       "prompt": "Set up observability for this agent",
-      "description": "Standard Agent (Node.js LangChain) — user accepts observability offer in Phase 3",
+      "description": "Agent (Non AI Teammate) (Node.js LangChain) — user accepts observability offer in Phase 3",
       "expected_output": "Skill runs a365 setup all, then in Phase 3 user says yes to observability — instrument-observability SKILL.md is read and followed. Phase 4 WorkIQ offer shown regardless.",
       "files": [],
       "expectations": [

--- a/plugins/agent365/shared/agent-detection.md
+++ b/plugins/agent365/shared/agent-detection.md
@@ -317,7 +317,7 @@ The agent has both an Entra app registration AND an existing A365 Blueprint. You
 
 ### registrationType 3 — All other agents
 
-Standard A365 agent with no M365 custom engine configuration. Fresh setup or Register-only registration.
+Agent (Non AI Teammate) with no M365 custom engine configuration. Fresh setup or Register-only registration.
 
 | Signal | Detection |
 |--------|-----------|
@@ -336,7 +336,7 @@ Agents needing Register capability (registrationType 3, non-AI Teammate) typical
 | No `a365.config.json` | Agent has never been registered |
 | No `ToolingManifest.json` | No WorkIQ tools configured |
 | No `manifest/manifest.json` | Agent has never been published |
-| Agent has observable business logic | Standard LLM agent with no Teams/M365 channel config |
+| Agent has observable business logic | Agent (Non AI Teammate) LLM agent with no Teams/M365 channel config |
 
 If all four signals are true and the user hasn't specified AI Teammate intent, suggest: **"Would you like to register this agent for registration only, or deploy it as an AI Teammate?"**
 

--- a/plugins/agent365/shared/agent-detection.md
+++ b/plugins/agent365/shared/agent-detection.md
@@ -323,7 +323,7 @@ Agent (Non AI Teammate) with no M365 custom engine configuration. Fresh setup or
 |--------|-----------|
 | No M365 signals | Step 1 greps return nothing |
 | No existing a365 config | `a365.config.json` absent |
-| Standard agent framework | dotnet-agentframework or nodejs-langchain detected |
+| Common agent framework detected | dotnet-agentframework or nodejs-langchain |
 
 **Pre-fill:** `registrationType = 3`, `usesTeamsOrCopilot = 0`. Capabilities menu: all 4 options apply; options can be combined.
 

--- a/plugins/agent365/shared/agent-detection.md
+++ b/plugins/agent365/shared/agent-detection.md
@@ -498,26 +498,26 @@ AskUserQuestion:
   question: |
     How does this Agent (Non AI Teammate) execute?
 
-    1 — Autonomous (S2S / Service Principal)
+    1 — Service Principal (s2s, no user token)
         Agent runs independently as itself — no signed-in user required.
         Authenticates with Entra App ID or Agent Blueprint credentials.
         → Docs: https://learn.microsoft.com/en-us/microsoft-agent-365/developer/authentication-flow
 
-    2 — Assistive (OBO)
-        Agent acts on behalf of the signed-in user via On-Behalf-Of flow.
+    2 — On-Behalf-Of (obo)
+        Agent acts on behalf of the signed-in user via the OBO token exchange.
         → Docs: https://learn.microsoft.com/en-us/entra/agent-id/agent-on-behalf-of-oauth-flow
 
     ✅ Both modes work with Observability
-    ❌  Autonomous (S2S) cannot use WorkIQ tools — WorkIQ requires a delegated user token (OBO)
+    ❌  s2s (Service Principal) cannot use WorkIQ tools — WorkIQ requires a delegated user token (obo)
   options:
-    - "1 — Autonomous (S2S / Service Principal)"
-    - "2 — Assistive (OBO)"
+    - "1 — Service Principal (s2s, no user token)"
+    - "2 — On-Behalf-Of (obo)"
 ```
 
 | Choice | `authMode` |
 |--------|-----------|
-| Autonomous (S2S / Service Principal) | `s2s` |
-| Assistive (OBO) | `obo` |
+| Service Principal (s2s, no user token) | `s2s` |
+| On-Behalf-Of (obo) | `obo` |
 
 ---
 
@@ -581,7 +581,7 @@ Add this inline comment wherever the auth handler is wired:
     WorkIQ requires a delegated user token (OBO) at runtime — S2S client credentials
     cannot be used for WorkIQ API calls.
 
-    To use WorkIQ, switch your agent to Assistive mode (obo) and re-run this skill.
+    To use WorkIQ, switch your agent to On-Behalf-Of mode (`obo`) and re-run this skill.
 ```
 
 Do **not** proceed. Do **not** show a server list. End the session.

--- a/plugins/agent365/skills/a365-setup/SKILL.md
+++ b/plugins/agent365/skills/a365-setup/SKILL.md
@@ -264,7 +264,7 @@ Then create all todos for the path and mark Todo 1 in-progress:
 - Todo 2: `Step 2: Ensure Prerequisites and Environment Configuration`
 - Todo 3: `Step 3: Run the make-ai-teammate skill`
 
-**Standard path** — `registrationType = 3, isAITeammate = false` (3 todos total):
+**Agent (Non AI Teammate) path** — `registrationType = 3, isAITeammate = false` (3 todos total):
 - Todo 1: `Step 1: Install and Verify All Prerequisites`
 - Todo 2: `Step 2: Ensure Prerequisites and Environment Configuration`
 - Todo 3: `Step 3: Run the make-a365-agent skill`
@@ -286,7 +286,7 @@ Then create all todos for the path and mark Todo 1 in-progress:
 
 **RULE 7 — SKILL DELEGATION.** After Steps 1 and 2, all paths delegate to a specialized skill at Step 3 — do not run setup or publish inline here:
 - **AI Teammate path** (`isAITeammate = true`): delegate to `make-ai-teammate` (code generation, a365.config.json, setup all, publish, Teams Dev Portal).
-- **Standard paths** (`isAITeammate = false`): delegate to `make-a365-agent` (setup all + optional observability/WorkIQ).
+- **Agent (Non AI Teammate) paths** (`isAITeammate = false`): delegate to `make-a365-agent` (setup all + optional observability/WorkIQ).
 
 ---
 
@@ -714,7 +714,7 @@ The `make-ai-teammate` skill handles everything: code generation, a365.config.js
 
 ---
 
-**Standard paths** (`isAITeammate = false` — Register, Observability, WorkIQ):
+**Agent (Non AI Teammate) paths** (`isAITeammate = false` — Register, Observability, WorkIQ):
 
 **Read** `${CLAUDE_PLUGIN_ROOT}/skills/make-a365-agent/SKILL.md` and follow it from the beginning.
 

--- a/plugins/agent365/skills/add-workiq-tools/SKILL.md
+++ b/plugins/agent365/skills/add-workiq-tools/SKILL.md
@@ -121,7 +121,7 @@ Store `agentType` (`ai-teammate` or `system-agent`) and `authMode` (`obo`, `s2s`
     WorkIQ requires a delegated user token (OBO) at runtime — S2S client credentials
     cannot be used for WorkIQ API calls.
 
-    To use WorkIQ, switch your agent to Assistive mode (obo)
+    To use WorkIQ, switch your agent to On-Behalf-Of mode (`obo`)
     and re-run this skill.
 ```
 

--- a/plugins/agent365/skills/instrument-observability/SKILL.md
+++ b/plugins/agent365/skills/instrument-observability/SKILL.md
@@ -7,7 +7,7 @@ description: >
   instrumentation scopes (InvokeAgentScope, InferenceScope, ExecuteToolScope — required for
   store publishing), and updates configuration files. Asks a two-stage question — agent kind
   (AI Teammate or Agent (Non AI Teammate)) and auth mode — to determine
-  the correct token path: OBO (obo / agentic-user) or Autonomous (s2s)
+  the correct token path: OBO (`obo` / `agentic-user`) or Service Principal (`s2s`)
   (FMI 3-hop token chain with Power Platform scope supported for .NET, Node.js, and Python — each language
   gets a scaffold token-service file that acquires and refreshes the Observability API token via the FMI chain). Non-destructive and idempotent.
 compatibility:
@@ -120,7 +120,7 @@ If `agentType` and `authMode` are already present in the detection cache (from a
 
 Store `agentType` (`ai-teammate` = AI Teammate, or `system-agent` = Agent (Non AI Teammate)) and `authMode`:
 - **AI Teammate:** `agentic-user` (agent's own M365 identity — not the caller's token; auto-set, no question needed)
-- **Agent (Non AI Teammate):** `obo` (Assistive / signed-in user token) or `s2s` (Autonomous / Service Principal)
+- **Agent (Non AI Teammate):** `obo` (On-Behalf-Of — signed-in user token) or `s2s` (Service Principal, no user token)
 
 **Update `.a365-workspace-detection.json`** — merge `agentType` and `authMode` into the existing cache file, preserving all other fields (`agentStack`, `programmingLanguage`, `usesTeamsOrCopilot`, `detectedAt`). Use the **Write** tool to write the merged object back.
 

--- a/plugins/agent365/skills/instrument-observability/references/dotnet-observability.md
+++ b/plugins/agent365/skills/instrument-observability/references/dotnet-observability.md
@@ -54,7 +54,7 @@ dotnet add package Microsoft.Agents.A365.Observability.Hosting
 
 ## Program.cs — S2S Path (`authMode: s2s`)
 
-Use this pattern for Agent (Non AI Teammate) agents that run without a signed-in user (Autonomous / S2S).
+Use this pattern for Agent (Non AI Teammate) agents that run without a signed-in user (`s2s` — Service Principal).
 Requires two scaffold files in `Observability/` — create these before wiring Program.cs.
 
 > **⚠️ Expected configuration (1.0.x GA):**

--- a/plugins/agent365/skills/make-ai-teammate/SKILL.md
+++ b/plugins/agent365/skills/make-ai-teammate/SKILL.md
@@ -716,7 +716,7 @@ Show the full dry-run output and ask:
 **If yes**, ask: "Will this agent be accessible directly from Microsoft Teams or Microsoft Copilot (M365-integrated)?" Store as `isM365 = true/false`. Then apply:
 
 ```bash
-# Standard AI Teammate (no Teams/Copilot catalog integration)
+# Default AI Teammate (no Teams/Copilot catalog integration)
 a365 setup all --agent-name <name> --aiteammate
 
 # M365-registered AI Teammate (Teams / Microsoft Copilot integration)


### PR DESCRIPTION
## Summary

- The repo's canonical taxonomy uses **Agent (Non AI Teammate)** as the non-AI-Teammate category label. The string "Standard Agent" still appeared in two places — replaced with the canonical form.
- No behavior change — terminology alignment only.

## Files changed

| File | Change |
|------|--------|
| `README.md` | 5 occurrences across the taxonomy callout, capability table, and WorkIQ auth requirement note |
| `evals/agent365/make-a365-agent/evals.json` | 2 occurrences in eval descriptions for the Register and Observability paths |

## Test plan

- [x] `grep -rn "Standard Agent"` — no remaining matches
- [x] Verified the `README.md` taxonomy paragraph still reads coherently with the substitution