### PR TITLE
Land Phase 0A fix on main (release/v1.0.0 → main)

### DIFF
--- a/plugins/agent365/skills/add-workiq-tools/SKILL.md
+++ b/plugins/agent365/skills/add-workiq-tools/SKILL.md
@@ -77,15 +77,24 @@ All changes are **additive** and **idempotent** — rerunning is safe.
 
 ---
 
-## Phase 0A — Load Detection Cache
+## Phase 0A — Workspace Triage and Detection Cache
 
-**Read** `.a365-workspace-detection.local.json`.
+### Step 1 — Triage the workspace
 
-If the file is missing or `detectedAt` is older than 60 minutes:
-> "`a365-setup` must be run before this skill — it registers your agent with Agent 365 and writes
-> the project detection cache this skill depends on. Run `a365-setup` now, then return here."
+Run in parallel:
 
-Stop until the user confirms `a365-setup` has been run.
+- **Glob** `**/*.csproj`, `package.json`, `requirements.txt`, `pyproject.toml`, `src/**/*.ts`, `**/*.cs`, `**/*.py` → `hasProjectFiles`.
+- **Read** `.a365-workspace-detection.local.json` → `cacheState` (`fresh` if `detectedAt` < 60 min, `stale` if older, `missing` if absent).
+
+Decide:
+
+| `cacheState` | `hasProjectFiles` | Action |
+|--------------|-------------------|--------|
+| `fresh`      | —                 | Continue to Step 2 below. |
+| `missing` / `stale` | false       | **Hard stop with a useful message:** *"WorkIQ tools wire MCP servers into an existing agent — there's no agent code in this workspace yet. Run `/agent365:make-ai-teammate` (recommended — WorkIQ requires an AI Teammate or OBO agent) first to scaffold and register the agent, then come back here."* Do not proceed. |
+| `missing` / `stale` | true        | Tell the user: *"Found existing agent code but no fresh Agent 365 registration. I'll run `a365-setup` now to register it and write the detection cache, then continue here automatically."* **Read** `${CLAUDE_PLUGIN_ROOT}/skills/a365-setup/SKILL.md` and follow it to completion, then continue to Step 2. |
+
+### Step 2 — Load from cache
 
 Load from cache: `agentStack`, `programmingLanguage`, `usesTeamsOrCopilot`, `agentType`, `authMode` (if previously stored).
 

--- a/plugins/agent365/skills/instrument-observability/SKILL.md
+++ b/plugins/agent365/skills/instrument-observability/SKILL.md
@@ -93,13 +93,22 @@ All changes are **additive** and **idempotent** — rerunning the skill is safe.
 
 **TaskCreate** — "Load detection cache and validate with user"
 
-**Read** `.a365-workspace-detection.local.json`.
+### Step 0.1 — Triage the workspace
 
-If the file is missing or `detectedAt` is older than 60 minutes:
-> "`a365-setup` must be run before this skill — it registers your agent with Agent 365 and writes
-> the project detection cache this skill depends on. Run `a365-setup` now, then return here."
+Run in parallel:
 
-Stop until the user confirms `a365-setup` has been run.
+- **Glob** `**/*.csproj`, `package.json`, `requirements.txt`, `pyproject.toml`, `src/**/*.ts`, `**/*.cs`, `**/*.py` → `hasProjectFiles`.
+- **Read** `.a365-workspace-detection.local.json` → `cacheState` (`fresh` if `detectedAt` < 60 min, `stale` if older, `missing` if absent).
+
+Decide:
+
+| `cacheState` | `hasProjectFiles` | Action |
+|--------------|-------------------|--------|
+| `fresh`      | —                 | Continue to Step 0.2 below. |
+| `missing` / `stale` | false       | **Hard stop with a useful message:** *"This skill instruments an existing agent for observability — there's no agent code in this workspace yet. Run `/agent365:make-ai-teammate` (if this will be a Teams/Copilot agent) or `/agent365:make-a365-agent` first to scaffold and register the agent, then come back here."* Do not proceed. |
+| `missing` / `stale` | true        | Tell the user: *"Found existing agent code but no fresh Agent 365 registration. I'll run `a365-setup` now to register it and write the detection cache, then continue here automatically."* **Read** `${CLAUDE_PLUGIN_ROOT}/skills/a365-setup/SKILL.md` and follow it through completion, then continue to Step 0.2. |
+
+### Step 0.2 — Load from cache
 
 Load from cache: `agentStack`, `programmingLanguage`, `usesTeamsOrCopilot`, `agentType`, `authMode` (if previously stored).
 

--- a/plugins/agent365/skills/make-ai-teammate/SKILL.md
+++ b/plugins/agent365/skills/make-ai-teammate/SKILL.md
@@ -89,15 +89,30 @@ hooks:
 
 ---
 
-## Phase 0A — Load Detection Cache
+## Phase 0A — Workspace Triage and Detection Cache
 
-**Read** `.a365-workspace-detection.local.json`.
+### Step 1 — Triage the workspace
 
-If the file is missing or `detectedAt` is older than 60 minutes:
-> "`a365-setup` must be run before this skill — it registers your agent with Agent 365 and writes
-> the project detection cache this skill depends on. Run `a365-setup` now, then return here."
+Run in parallel and combine results:
 
-Stop until the user confirms `a365-setup` has been run.
+- **Glob** `**/*.csproj`, `package.json`, `requirements.txt`, `pyproject.toml`, `src/**/*.ts`, `**/*.cs`, `**/*.py` → does any agent code or project file exist? Call this `hasProjectFiles`.
+- **Read** `.a365-workspace-detection.local.json` → does the cache exist, and is `detectedAt` within 60 minutes? Call this `cacheState` (`fresh`, `stale`, or `missing`).
+- **Parse `$ARGUMENTS`** for an explicit framework hint (e.g. `dotnet`, `dotnet-sk`, `langchain`, `openai`, `claude`, `semantickernel`, `googleadk`, `python`) and the word `create`. Store as `argFramework` and `argCreateIntent`.
+
+Decide what to do next from this table — do not fall through to Step 2 until one of these branches has run:
+
+| `cacheState` | `hasProjectFiles` | Action |
+|--------------|-------------------|--------|
+| `fresh`      | —                 | Continue to Step 2 below (load cache). |
+| `missing`    | false             | **Empty workspace, new-agent path.** Tell the user: *"This is a fresh workspace — I'll scaffold a starter agent from Agent365-Samples first, then run `a365-setup` to register it."* Jump directly to **Phase 0A.5**. If `argFramework` is set, pre-select the matching sample (e.g. `dotnet` → option 1, `dotnet-sk` → option 2, `langchain` → option 3, etc.) and skip the menu. After scaffolding completes, **Read** `${CLAUDE_PLUGIN_ROOT}/skills/a365-setup/SKILL.md` and follow it to register the new agent — then return to Step 2 below. |
+| `missing`    | true              | Tell the user: *"I found existing agent code but no Agent 365 registration. I'll run `a365-setup` now to register it and detect its framework, then continue here automatically."* **Read** `${CLAUDE_PLUGIN_ROOT}/skills/a365-setup/SKILL.md` and follow it to completion, then return to Step 2 below. |
+| `stale`      | —                 | Tell the user the detection cache is stale (>60 min) and re-run `a365-setup` the same way as the `missing + true` row, then return to Step 2. |
+
+> **Why this triage exists:** Phase 0A.5 was designed for the empty-workspace new-agent path, but is only reachable after Step 2 succeeds. Without this triage, a user running `/make-ai-teammate create a dotnet agentframework agent` in an empty directory gets a "run a365-setup first" wall instead of the scaffold flow they asked for.
+
+### Step 2 — Load Detection Cache
+
+(Only reached once the cache is fresh — either it already was, or `a365-setup` just wrote it.)
 
 Load from cache:
 - `programmingLanguage` → use as `language`
@@ -117,7 +132,24 @@ Store the main source file(s) as `existingFiles`.
 
 ## Phase 0A.5 — New Agent Path (no source files found)
 
-**Check for empty directory:** If `existingFiles` is empty AND no `.csproj`, `package.json`, or `requirements.txt` exists anywhere in the working directory, the user is starting fresh with no existing agent code.
+This phase is normally entered directly from the **Phase 0A Step 1** triage when `cacheState = missing` and `hasProjectFiles = false`. It can also be entered as a fallback when Phase 0A Step 2 runs but finds no LLM entry point.
+
+**Argument pre-selection:** If `$ARGUMENTS` contained `argFramework` from Phase 0A, map it to the option below and skip the menu — only show the menu when the user gave no framework hint:
+
+| `argFramework` keyword | Auto-selected option |
+|------------------------|----------------------|
+| `dotnet` (alone) or `dotnet agentframework` | 1 — .NET Agent Framework |
+| `dotnet-sk` or `dotnet semantickernel` | 2 — .NET Semantic Kernel |
+| `langchain` (Node.js context implied) | 3 — Node.js LangChain |
+| `openai` (Node.js context implied) | 4 — Node.js OpenAI Agents SDK |
+| `python` (alone) or `python agentframework` | 5 — Python Agent Framework |
+| `claude` (Python context implied) | 6 — Python Claude SDK |
+| `googleadk` or `google-adk` | 7 — Python Google ADK |
+| `semantickernel` (no language given) | Ask the user: ".NET (option 2) or Python? Python Semantic Kernel sample isn't published yet — defaulting to .NET." |
+
+When pre-selected, tell the user the inference: *"Picked option {N} ({sample name}) based on your request. Proceeding to clone…"* and jump straight to **Step 1 (Verify git)** below.
+
+**Empty-directory fallback check** (only when not entered from Phase 0A triage): If `existingFiles` is empty AND no `.csproj`, `package.json`, or `requirements.txt` exists anywhere in the working directory, the user is starting fresh — show the menu below.
 
 In this case, **do NOT fail** — offer to scaffold from an official sample:
 


### PR DESCRIPTION
## Summary

Brings the Phase 0A workspace-triage fix (PR #45) from `release/v1.0.0` to `main` so installed plugins — which pull from `main` via `scripts/install.js` — actually see the new behavior.

## What's in this PR

Two commits from `release/v1.0.0`:

- `cdc1884` — Fix Phase 0A hard-stop blocking new-agent and auto-setup paths
- `f074f5f` — Merge pull request #45

See [PR #45](https://github.com/microsoft/agent365-skills/pull/45) for full context on the fix.

## Why this is needed

PR #45 merged into `release/v1.0.0`, but users running `/make-ai-teammate create a python+googleadk agent365 AI teammate` still hit the old "Detection cache check" hard-stop because their installed plugin loads `make-ai-teammate/SKILL.md` from `main`, where the fix isn't present yet.

## Test plan

- [ ] After merge, re-install the plugin (or wait for auto-update) and re-run `/make-ai-teammate create a python googleadk agent` in an empty workspace — should jump to Phase 0A.5, auto-pick option 7 (Python Google ADK), clone the sample, then chain `a365-setup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)