### PR TITLE
Make prod env-var requirements explicit (AUTH_HANDLER_NAME=AGENTIC, exporter=true)

### DIFF
--- a/plugins/agent365/skills/make-ai-teammate/SKILL.md
+++ b/plugins/agent365/skills/make-ai-teammate/SKILL.md
@@ -44,7 +44,14 @@ hooks:
         3. Phase 9.7.2d — required env vars present in .env / appsettings.json.
            For prod: completed=true AND resourceConsents non-empty (else GA
            handoff message shown), cloud-platform env vars set, platform state
-           Running/Ready.
+           Running/Ready. Prod-only env-var checklist must show:
+             - Python: AUTH_HANDLER_NAME=AGENTIC (must NOT be empty); .NET:
+               AgentApplication:AgenticAuthHandlerName="agentic"; Node.js:
+               MyAgent.authHandlerName='agentic' in code.
+             - ENABLE_A365_OBSERVABILITY_EXPORTER=true (Python / Node.js env;
+               .NET appsettings or app-service env). If this is false in prod
+               the agent runs but no spans reach the Agent 365 portal or
+               Microsoft Defender.
         4. Phase 9.5 — instrument-observability ran OR has_obs was true.
         5. Phase 9.6 — add-workiq-tools was offered (or has_workiq true).
         6. For runTarget = "prod": manifest.json reviewed (CLI owns it),

--- a/plugins/agent365/skills/make-ai-teammate/references/deploy-pipeline.md
+++ b/plugins/agent365/skills/make-ai-teammate/references/deploy-pipeline.md
@@ -187,14 +187,23 @@ Pull `<agentBlueprintId>`, `<agentBlueprintClientSecret>`, `<tenantId>` from `a3
    - **`resourceConsents` non-empty** — empty means consent hasn't been recorded; same GA handoff applies.
    - `agentBlueprintId`, `agentBlueprintClientSecret`, `tenantId`, `messagingEndpoint` all populated and non-empty.
 
-2. **Environment variables are set at the cloud platform, not just locally.** Local `.env` files do NOT propagate to the cloud — they must be configured in the platform's config:
+2. **Prod-only env-var checklist — these MUST be set (in addition to the common table above) and they differ from local-dev defaults.** Verify them in the cloud platform's effective config, not just the local `.env` (use the inspection command in step 3 below):
+
+   | Concern | Python `.env` | Node.js `.env` | .NET `appsettings.json` |
+   |---|---|---|---|
+   | Active auth handler — must point at agentic in prod | `AUTH_HANDLER_NAME=AGENTIC` (under `# A365 Authentication`). The Python code reads this env var to pick a handler at runtime; empty leaves the agent with no handler and every Teams message fails token exchange. | Not env-driven — `MyAgent.authHandlerName = 'agentic'` is set in code. Verify the constant matches the registered auth handler in `agentic_type=agentic`. | Not env-driven — `AgentApplication:AgenticAuthHandlerName=agentic` lives in `appsettings.json`. Verify the value is `agentic`. |
+   | A365 observability exporter — must be true in prod (false would mean console-only / no traces in Agent 365 portal or Defender) | `ENABLE_A365_OBSERVABILITY_EXPORTER=true` | `ENABLE_A365_OBSERVABILITY_EXPORTER=true` (or `a365.enableObservabilityExporter: true` in code) | `ENABLE_A365_OBSERVABILITY_EXPORTER=true` in app-service env vars (or `Logging.OpenTelemetry` config wiring) |
+
+   If any value is wrong or missing, fix it before continuing to Step 9.7.3.
+
+3. **Environment variables are set at the cloud platform, not just locally.** Local `.env` files do NOT propagate to the cloud — they must be configured in the platform's config:
    - **Azure App Service:** Azure portal → Web App → Settings → Environment Variables, or `az webapp config appsettings set --name <app> --resource-group <rg> --settings KEY=VALUE`. Use [Azure Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/general/overview) for sensitive secrets. Verify with `az webapp config appsettings list --name <app> --resource-group <rg>`. Full deployment guide: [Deploy agent to Azure](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/deploy-agent-azure).
    - **AWS Elastic Beanstalk:** `eb setenv KEY=VALUE`. Verify in EB console under Configuration → Software → Environment properties. Full deployment guide: [Deploy agent to AWS](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/deploy-agent-aws).
    - **Google Cloud Run:** `gcloud run services update <service> --region <region> --set-env-vars KEY=VALUE,KEY2=VALUE2`. Verify with `gcloud run services describe <service> --region <region>`. Full deployment guide: [Deploy agent to GCP](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/deploy-agent-gcp).
 
-3. **HTTPS is required.** Bot Framework rejects non-HTTPS messaging endpoints. Azure App Service serves HTTPS by default; AWS Elastic Beanstalk requires an SSL/TLS certificate; Google Cloud Run is HTTPS by default.
+4. **HTTPS is required.** Bot Framework rejects non-HTTPS messaging endpoints. Azure App Service serves HTTPS by default; AWS Elastic Beanstalk requires an SSL/TLS certificate; Google Cloud Run is HTTPS by default.
 
-4. **Messaging endpoint is reachable:** quick smoke test with `curl <chosenEndpoint>` — anything but a 404 is acceptable (a GET on `/api/messages` typically returns method-not-allowed, which is fine; the POST handler is what Teams uses). Verify the web app is in `"Running"` state:
+5. **Messaging endpoint is reachable:** quick smoke test with `curl <chosenEndpoint>` — anything but a 404 is acceptable (a GET on `/api/messages` typically returns method-not-allowed, which is fine; the POST handler is what Teams uses). Verify the web app is in `"Running"` state:
    - Azure: `az webapp show --name <app> --resource-group <rg> --query state` → expect `"Running"`.
    - AWS: `eb health --refresh` → expect green.
    - GCP: `gcloud run services describe <service> --region <region>` → expect `"Ready"` condition.

--- a/plugins/agent365/skills/make-ai-teammate/references/python-ai-teammate.md
+++ b/plugins/agent365/skills/make-ai-teammate/references/python-ai-teammate.md
@@ -461,8 +461,13 @@ def extract_turn_context_details(
 ## .env template
 
 ```dotenv
-# Authentication
-AUTH_HANDLER_NAME=
+# A365 Authentication
+# AUTH_HANDLER_NAME picks the auth handler at runtime. For prod (Teams /
+# Copilot reachable) this MUST be AGENTIC — leaving it empty causes every
+# incoming Teams message to fail token exchange.
+AUTH_HANDLER_NAME=AGENTIC
+# BEARER_TOKEN is local-dev only (acquired via `a365 develop get-token`).
+# Do NOT carry this into prod cloud config.
 BEARER_TOKEN=
 
 # Azure OpenAI
@@ -484,6 +489,12 @@ CONNECTIONSMAP_0_CONNECTION=SERVICE_CONNECTION
 USE_AGENTIC_AUTH=true
 AGENTAPPLICATION__USERAUTHORIZATION__HANDLERS__AGENTIC__SETTINGS__TYPE=AgenticUserAuthorization
 AGENTAPPLICATION__USERAUTHORIZATION__HANDLERS__AGENTIC__SETTINGS__SCOPES=https://graph.microsoft.com/.default
+
+# A365 Observability
+# Required for prod — sends spans to Agent 365 portal + Microsoft Defender.
+# Set to `false` for local dev (console-only). The full set of observability
+# vars (sponsor identity etc.) is wired by `instrument-observability`.
+ENABLE_A365_OBSERVABILITY_EXPORTER=true
 
 # Server
 PORT=3978


### PR DESCRIPTION
## Summary

Two prod-run failure modes that local-dev defaults silently caused:

1. **`AUTH_HANDLER_NAME` empty** (Python) → agent had no auth handler in prod, every Teams message failed token exchange.
2. **`ENABLE_A365_OBSERVABILITY_EXPORTER=false`** (console-only, the local-dev default) → agent ran fine but no spans reached the Agent 365 portal or Microsoft Defender. The agent was invisible to admins.

This PR makes both prod requirements explicit in the deploy pipeline, the Python env template, and the skill's stop-hook check.

## Files changed

| File | Change |
|------|--------|
| [deploy-pipeline.md Step 9.7.2d](plugins/agent365/skills/make-ai-teammate/references/deploy-pipeline.md#L192) | New prod-only env-var checklist table covering both vars across Python / Node.js / .NET (with language-specific equivalents — Python env var, Node.js code constant, .NET `appsettings.json`). Subsequent steps renumbered. |
| [python-ai-teammate.md .env template](plugins/agent365/skills/make-ai-teammate/references/python-ai-teammate.md#L463) | Renames `# Authentication` to `# A365 Authentication`. Sets `AUTH_HANDLER_NAME=AGENTIC` (was empty). Adds `# A365 Observability` block with `ENABLE_A365_OBSERVABILITY_EXPORTER=true`. |
| [make-ai-teammate/SKILL.md stop-hook prompt](plugins/agent365/skills/make-ai-teammate/SKILL.md#L44) | Phase 9.7.2d check extended to verify the two prod-required values per language. |

## Cross-language notes

- `AUTH_HANDLER_NAME` is **Python-only** — it's an env var read by the Python host_agent_server.py. Node.js sets the equivalent as `MyAgent.authHandlerName = 'agentic'` in code; .NET sets `AgentApplication:AgenticAuthHandlerName` in `appsettings.json`.
- `ENABLE_A365_OBSERVABILITY_EXPORTER` is **universal** (Python / Node.js / .NET app-service env).

## Test plan

- [ ] Deploy a Python AI Teammate to Azure App Service with `AUTH_HANDLER_NAME` unset → confirm the skill flags it during Phase 9.7.2d.
- [ ] Same agent with `ENABLE_A365_OBSERVABILITY_EXPORTER=false` in app-service env → confirm the skill flags it.
- [ ] Re-run a happy-path prod deploy where both vars are correctly set → skill proceeds to Step 9.7.3 without complaint.
- [ ] Local-dev path (`runTarget = "local"`) is unaffected — the prod checklist only applies to `runTarget = "prod"`.