### PR TITLE
a365-setup: 3-option Azure CLI login menu (explicit same-tenant re-login)

### DIFF
--- a/plugins/agent365/skills/a365-setup/SKILL.md
+++ b/plugins/agent365/skills/a365-setup/SKILL.md
@@ -632,20 +632,32 @@ Found an existing Azure CLI session:
   Tenant ID:    <tenantId>
   Subscription: <name>  (may be empty if no Azure subscription)
 
-Would you like to:
-  1. Use this tenant  (recommended if this is your A365 tenant)
-  2. Switch to a different tenant  (provide a tenant ID or domain)
-  3. Log in fresh  (clears the current session)
+How would you like to proceed?
+
+  1. Use existing session as-is  (recommended — no new login, fastest)
+     I'll use the cached token. Pick this if you've used `a365` or `az`
+     successfully in the last hour.
+
+  2. Same tenant — new login  (different user, different subscription,
+     or refresh expired credentials)
+     Stay on tenant <tenantId> but log in again. Pick this to switch
+     to a different user account in the same tenant, pick a different
+     subscription, or refresh an expired token.
+
+  3. Connect to a new tenant  (cross-tenant work)
+     I'll ask for the new tenant ID or domain. Pick this if your A365
+     workspace is in a tenant other than the one you're currently
+     signed into.
 ```
 
-- **Option 1 — use existing:** confirm `az account show` returns the correct account and proceed.
-- **Option 2 — switch tenant:** ask "What is your tenant ID or domain?" then run:
+- **Option 1 — use existing:** confirm `az account show` returns the correct account and proceed. No new CLI command runs.
+- **Option 2 — same tenant, new login:** run with the **existing** tenant ID so Azure CLI keeps the user on the same tenant but starts a fresh interactive login (different user, different subscription, or just refresh):
   ```bash
-  az login --allow-no-subscriptions --tenant <tenantId>
+  az login --allow-no-subscriptions --tenant <existingTenantId>
   ```
-- **Option 3 — fresh login:** run:
+- **Option 3 — connect to new tenant:** ask "What is the new tenant ID or domain?" then run with the **new** tenant ID:
   ```bash
-  az login --allow-no-subscriptions
+  az login --allow-no-subscriptions --tenant <newTenantId>
   ```
 
 **If no session exists (NO_SESSION)**, ask: "Would you like to log in to a specific tenant or to your default tenant?" then run the appropriate command:


### PR DESCRIPTION
## Summary

The existing-Azure-CLI-session menu had three options but one was ambiguous (`Log in fresh`) and silently omitted `--tenant`, so the resulting login could land on any tenant Azure CLI happened to default to. Replaces it with three **explicit** choices that pin `--tenant` correctly.

## Before

```
Would you like to:
  1. Use this tenant  (recommended if this is your A365 tenant)
  2. Switch to a different tenant  (provide a tenant ID or domain)
  3. Log in fresh  (clears the current session)
```

Problem: Option 3 ran `az login --allow-no-subscriptions` with no `--tenant` flag — the tenant was whatever Azure CLI's default was, which could differ from the one shown above. Users couldn't explicitly say "same tenant, refresh my login."

## After

```
How would you like to proceed?

  1. Use existing session as-is  (recommended — no new login, fastest)
     I'll use the cached token. Pick this if you've used `a365` or `az`
     successfully in the last hour.

  2. Same tenant — new login  (different user, different subscription,
     or refresh expired credentials)
     Stay on tenant <tenantId> but log in again. Pick this to switch
     to a different user account in the same tenant, pick a different
     subscription, or refresh an expired token.

  3. Connect to a new tenant  (cross-tenant work)
     I'll ask for the new tenant ID or domain. Pick this if your A365
     workspace is in a tenant other than the one you're currently
     signed into.
```

## Branch logic

| Choice | What runs |
|--------|-----------|
| 1 | nothing — proceed |
| 2 | `az login --allow-no-subscriptions --tenant <existingTenantId>` |
| 3 | ask for tenant, then `az login --allow-no-subscriptions --tenant <newTenantId>` |

Both options that re-login now pass `--tenant` explicitly so the user always lands on the tenant they picked. The no-session default path (`az login --allow-no-subscriptions` with no tenant) is unchanged.

## Files changed

- [a365-setup/SKILL.md:628-660](plugins/agent365/skills/a365-setup/SKILL.md#L628-L660) — menu + per-option commands.

## Test plan

- [ ] Existing session, pick **1** → skill proceeds, no `az login` runs.
- [ ] Existing session, pick **2** → `az login --allow-no-subscriptions --tenant <currentTenantId>` runs (interactive prompt allows different user / subscription).
- [ ] Existing session, pick **3** → skill asks for a tenant, then runs login with the new tenant ID.
- [ ] No existing session → unchanged: asks "specific or default tenant?" and proceeds.