### PR TITLE
add-workiq-tools: Word @mention handling for LangChain + task-execution discipline (v1.0.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "agent365-skills",
   "description": "Production-ready skills for Microsoft Agent 365 — AI Teammate transformation, Blueprint provisioning, WorkIQ MCP servers, OTel observability, and local testing. Supports .NET, Node.js, and Python. Works with Claude Code and GitHub Copilot Chat.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "owner": {
     "name": "Microsoft",
     "url": "https://github.com/microsoft"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -5,6 +5,27 @@ When a user asks for any of the trigger phrases below, follow the corresponding 
 
 ---
 
+## Task Execution Discipline
+
+When a skill creates a task list, run every task to completion in one turn — do not pause
+between phases. Mark each task complete the moment its phase finishes (`TaskUpdate` in
+Claude Code, `- [ ]` → `- [x]` in Copilot Chat / CLI). Surface a one-line status update
+between phases instead of asking permission.
+
+**Only pause at these explicit interaction points:**
+- `a365-setup`: capabilities menu; authMode (non-AI-Teammate only); install confirmations for missing tools; Azure login.
+- `make-a365-agent`: agent name + directory; reuse-blueprint; hosted vs local; observability/WorkIQ offers.
+- `make-ai-teammate`: Phase 0B confirm; 0C row-8 sub-question; 9.6 WorkIQ offer; 9.7.1a Reuse/Re-run/Fresh; 9.7.2 Run Target + 9.7.2b hosting.
+- `add-workiq-tools`: MCP server selection; Word @mention offer (only when `mcp_WordServer` is selected and stack is Node.js LangChain).
+- `instrument-observability`: agent kind + auth mode (only if not in cache).
+- `test-local`: confirm before launching.
+
+CLI `Allow / Skip` prompts are the chat client's permission flow — not stopping conditions.
+Manual browser steps (Teams Dev Portal, M365 Admin Center, GA consent) are surfaced with
+URL + action, then you continue to the next non-blocking phase.
+
+---
+
 ## Skill: make-ai-teammate
 
 **Full instructions:** [plugins/agent365/skills/make-ai-teammate/SKILL.md](../plugins/agent365/skills/make-ai-teammate/SKILL.md)
@@ -121,7 +142,8 @@ When a user asks for any of the trigger phrases below, follow the corresponding 
 3. Runs `a365 develop list-available` to show the MCP server catalog.
 4. Adds selected servers via `a365 develop add-mcp-servers` (updates `ToolingManifest.json`).
 5. **Phase 4 is framework-aware** — branches on the cached `agentStack` into 11 sub-sections (§4.1 .NET Agent Framework, §4.2 .NET Semantic Kernel, §4.3 .NET Azure AI Foundry best-effort, §4.4 Node.js LangChain, §4.5 Node.js OpenAI, §4.6 Node.js Claude SDK, §4.7 Python Agent Framework, §4.8 Python OpenAI, §4.9 Python Google ADK, §4.10 Python Semantic Kernel best-effort, §4.11 Python Azure AI Foundry best-effort). The wiring symbol differs per stack: .NET AF uses `GetMcpToolsAsync`; .NET SK uses `AddToolServersToAgentAsync` (different namespace, mutates `Kernel`, void return); Node.js LangChain captures the returned new agent; Node.js OpenAI/Claude mutate in place; Python all use `add_tool_servers_to_agent` but with different kwargs (`turn_context=` for AF, `context=` for OpenAI/SK/ADK). **Do not cross-paste between sections** — kwarg name and parameter shape vary.
-6. Guides the permissions handoff to the Global Administrator (`a365 setup permissions mcp`; supports V1/V2 mixed manifests, use `--remove-legacy-scopes` for V2 migration).
+6. **Optional Word @mention handling** (only when `mcp_WordServer` is in the selected servers AND `programmingLanguage = NodeJS && agentStack = LangChain`): asks via `AskUserQuestion` whether the AI Teammate should notify and reply when someone `@mentions` it on a Word comment. If yes, wires `proactive: {}` on the `AgentApplication`, a per-user conversation index, and a `NotificationType.WpxComment` handler that reads the document, posts a reply on the same comment thread, and DMs the user in Teams. Pattern is best-effort (no Microsoft Node.js sample published yet) — see [nodejs-workiq.md](../plugins/agent365/skills/add-workiq-tools/references/nodejs-workiq.md) "Word @mention notification handling (BEST-EFFORT)".
+7. Guides the permissions handoff to the Global Administrator (`a365 setup permissions mcp`; supports V1/V2 mixed manifests, use `--remove-legacy-scopes` for V2 migration).
 
 **Verified support matrix:**
 

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "agent365-skills",
   "metadata": {
     "description": "Skills for Microsoft Agent 365 — transform agents into AI Teammates, register blueprints, add WorkIQ MCP servers, instrument observability, and test locally. Supports .NET, Node.js, and Python.",
-    "version": "1.0.0"
+    "version": "1.0.1"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "agent365",
       "source": "./plugins/agent365",
       "description": "Six skills covering the full Agent 365 lifecycle: AI Teammate transformation, Blueprint provisioning (Registration / Observability paths), WorkIQ MCP servers (M365 data access), OTel observability instrumentation, and local testing with AgentsPlayground. Supports .NET AgentFramework, Node.js (LangChain, OpenAI, Claude SDK, Semantic Kernel, Google ADK), and Python.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "skills": [
         "./skills/make-ai-teammate",
         "./skills/a365-setup",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,6 +271,22 @@ node /path/to/agent365-skills/plugins/agent365/hooks/stop/validate-make-ai-teamm
 
 ---
 
+## Task Execution Discipline
+
+Skills with task lists must run every task to completion in one turn. Mark each task
+complete (`TaskUpdate` in Claude Code, `- [ ]` → `- [x]` in Copilot) the moment its
+phase finishes — never leave a finished phase as ⭕.
+
+Only pause at the explicit interaction points each SKILL.md documents (capabilities menu,
+run-target, Reuse/Re-run/Fresh, WorkIQ offer, MCP server selection, Word @mention offer
+when `mcp_WordServer` is selected on a Node.js LangChain stack, launch confirmation).
+CLI `Allow / Skip` prompts and manual browser steps (Teams Dev Portal, M365 Admin Center,
+GA consent) are not stopping conditions — surface them with URL + action and continue.
+When adding a new interaction point to a SKILL.md, mirror it in [CLAUDE.md](CLAUDE.md)
+and [.github/copilot-instructions.md](.github/copilot-instructions.md) so all three stay in sync.
+
+---
+
 ## Code Style
 
 - All validator scripts: plain Node.js (no dependencies, no TypeScript).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,15 @@ agent365-skills/
    for S2S agents. The guard exists at three layers: `a365-setup`, `make-a365-agent` Phase 4,
    and `add-workiq-tools` Phase 0B.
 
+8. **Run task lists to completion in one turn.** When a skill creates a task list, execute
+   every task and mark each complete (`TaskUpdate` or `- [ ]` → `- [x]`) the moment its phase
+   finishes. Only pause at the explicit interaction points each SKILL.md documents
+   (capabilities menu, run-target, blueprint Reuse/Re-run/Fresh, WorkIQ offer, MCP server
+   selection, Word @mention offer when `mcp_WordServer` is selected on Node.js LangChain,
+   launch confirmation). CLI permission prompts and manual browser steps
+   (Teams Dev Portal, M365 Admin Center, GA consent) are not stopping conditions — surface
+   them with URL + action and continue.
+
 ---
 
 ## Testing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent365-skills",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "description": "Skills for Microsoft Agent 365 — transform agents into AI Teammates, register blueprints, add WorkIQ MCP servers, instrument observability, and test locally. Supports .NET (AgentFramework, Semantic Kernel) and Node.js (LangChain, OpenAI Agents SDK, Claude SDK, Semantic Kernel, Google ADK) and Python (AgentFramework, LangChain, OpenAI, Claude, Semantic Kernel, Google ADK).",
   "license": "MIT",

--- a/plugins/agent365/.claude-plugin/plugin.json
+++ b/plugins/agent365/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent365",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Skills for Microsoft Agent 365 — transform agents into AI Teammates, register blueprints, add WorkIQ MCP servers, instrument observability, and test locally. Supports .NET (AgentFramework, Semantic Kernel) and Node.js (LangChain, OpenAI Agents SDK, Claude SDK, Semantic Kernel, Google ADK) and Python (AgentFramework, LangChain, OpenAI, Claude, Semantic Kernel, Google ADK).",
   "author": {
     "name": "Microsoft",

--- a/plugins/agent365/skills/add-workiq-tools/SKILL.md
+++ b/plugins/agent365/skills/add-workiq-tools/SKILL.md
@@ -388,6 +388,12 @@ Tell the user verbatim: *"Microsoft publishes the `Microsoft.Agents.A365.Tooling
    ```
 2. **Read** `nodejs-workiq.md` — section "LangChain — Wiring (VERIFIED)".
 3. **Edit** `src/client.ts` (or wherever the `getClient` factory lives). Add module-level `toolService = new McpToolRegistrationService()` singleton and the per-turn call inside `getClient`. **Capture the return value** — LangChain rebuilds the agent because `createAgent`'s tools are immutable.
+4. **Offer Word @mention notification handling** — only if `mcp_WordServer` is in the user's selected servers. Ask via `AskUserQuestion`:
+   > *"You added `mcp_WordServer`. Do you want this AI Teammate to also notify and reply when someone `@mentions` it on a Word comment? It will read the document, post a reply on the same comment thread, and DM the user in Teams with the reply text."*
+   >
+   > Options: **Yes — wire @mention handling** / **No — Word read/write only**
+   - If Yes: **Read** the "Optional: Word @mention notification handling (BEST-EFFORT)" section in `nodejs-workiq.md` and apply it to `src/agent.ts` + `src/client.ts`. Pre-check `proactive` is configured on the `AgentApplication` constructor; add `proactive: {}` if missing. Mark new lines with `// A365 WorkIQ — best-effort wiring (verify against SDK source before production)`.
+   - If No: skip — Word tools still work for direct user prompts; only the proactive @mention path is omitted.
 
 ### §4.5 Node.js OpenAI
 

--- a/plugins/agent365/skills/add-workiq-tools/references/nodejs-workiq.md
+++ b/plugins/agent365/skills/add-workiq-tools/references/nodejs-workiq.md
@@ -122,6 +122,110 @@ export async function getClient(
 
 ---
 
+## Optional: Word @mention notification handling (LangChain — BEST-EFFORT)
+
+> **Status:** Public APIs (`NotificationType.WpxComment`, `wpxCommentNotification`, `AgentApplicationOptions.proactive`, `Proactive.storeConversation` / `sendActivity`) are verified in `@microsoft/agents-a365-notifications` and `@microsoft/agents-hosting`. No Microsoft Node.js sample published yet — mark generated lines with `// A365 WorkIQ — best-effort wiring (verify against SDK source before production)`.
+
+When a user `@mentions` the agent on a Word comment, the runtime delivers an `AgentNotificationActivity` with `notificationType === NotificationType.WpxComment`. The document URL is **not** on `wpxCommentNotification` — read it from `activity.attachments[*].contentUrl`. The Node.js `WpxComment` shape exposes `documentId`, `initiatingCommentId`, `subjectCommentId` (note: no `parentCommentId` — that's the .NET shape). Delegate comment-ID resolution to the LLM via prompt so the agent doesn't depend on the typed shape.
+
+### 1. Enable proactive on the `AgentApplication`
+
+```typescript
+super({
+  storage: new MemoryStorage(),
+  proactive: {},                       // required for proactive Teams DMs
+  authorization: { agentic: { type: 'agentic', /* ... */ } },
+});
+```
+
+### 2. Index Teams conversations by user identifiers
+
+```typescript
+const userKeyToConversationId = new Map<string, string>();
+
+function userKeysFor(from: any): string[] {
+  if (!from) return [];
+  const keys = new Set<string>();
+  if (from.aadObjectId) keys.add(`aad:${String(from.aadObjectId).toLowerCase()}`);
+  if (from.id)          keys.add(`id:${String(from.id).toLowerCase()}`);
+  if (from.name)        keys.add(`name:${String(from.name).toLowerCase()}`);
+  return [...keys];
+}
+
+// A365 WorkIQ — best-effort wiring (verify against SDK source before production)
+private async trackConversationForProactive(context: TurnContext): Promise<void> {
+  const convId = await this.proactive.storeConversation(context);
+  for (const k of userKeysFor(context.activity.from)) {
+    userKeyToConversationId.set(k, convId);
+  }
+}
+```
+
+Call `trackConversationForProactive` from both the message handler **and** the `installationUpdate(add)` handler — proactive DMs require a previously stored conversation reference.
+
+### 3. Handle the `WpxComment` notification
+
+```typescript
+// A365 WorkIQ — best-effort wiring (verify against SDK source before production)
+case NotificationType.WpxComment:
+  await this.handleWpxCommentNotification(context, state, agentNotificationActivity);
+  break;
+
+private async handleWpxCommentNotification(context, state, activity) {
+  const wpx = activity.wpxCommentNotification;
+  if (!wpx) return;
+
+  // URL is not on wpxCommentNotification — pull from raw attachments.
+  const attachments  = (context.activity as any)?.attachments ?? [];
+  const fileAttachment = attachments.find((a: any) =>
+    typeof a?.contentUrl === 'string' && /\.(docx?|doc)(\?|$)/i.test(a.contentUrl),
+  ) ?? attachments[0];
+  const documentUrl  = fileAttachment?.contentUrl;
+  const documentName = fileAttachment?.name ?? 'the document';
+  const commentText  = (context.activity as any)?.text ?? '';
+  const senderName   = context.activity.from?.name ?? 'a user';
+
+  const client = await getClient(this.authorization, A365Agent.authHandlerName, context);
+
+  // Tell the LLM to use the REPLY tool — default behaviour is AddComment (new thread).
+  const prompt =
+    `${senderName} @mentioned you on a comment in "${documentName}".\n` +
+    `Comment: ${commentText}\nDocument URL: ${documentUrl}\n` +
+    `Steps:\n` +
+    `1. Call mcp_WordServer.GetDocumentContent with the URL.\n` +
+    `2. Find the comment matching the text above; capture driveId, documentId, commentId.\n` +
+    `3. Use the Word REPLY tool (name contains "reply") — NOT AddComment.\n` +
+    `4. Reply concisely. Finish with: "Replied to commentId=<id> with: <text>".`;
+
+  const response = await client.invokeInferenceScope(prompt);
+
+  // Proactively notify the user in Teams (needs prior tracked conversation).
+  const convId = userKeysFor(context.activity.from)
+    .map(k => userKeyToConversationId.get(k))
+    .find(Boolean);
+  if (convId) {
+    const replyText = response?.match(/Replied to commentId=\S+ with:\s*([\s\S]+)/)?.[1] ?? response;
+    await this.proactive.sendActivity(this.adapter, convId, {
+      text: `I replied to your comment on **${documentName}**:\n\n${replyText?.substring(0, 1500)}`,
+    });
+  }
+}
+```
+
+### 4. (Optional) Keep multi-turn @mention threads coherent
+
+Wire a LangGraph `MemorySaver` into `createAgent({ checkpointer })` and invoke with `{ configurable: { thread_id: conversation.id } }` so repeated @mentions on the same document retain tool-call history.
+
+### Gotchas
+
+- `wpxCommentNotification` does **not** carry the document URL — always pull from `activity.attachments`.
+- `proactive.sendActivity` requires the recipient to have previously spoken to (or installed) the bot. If `userKeyToConversationId.get(...)` returns `undefined`, surface a friendly *"DM me once to enable Word notifications"* message instead of failing silently.
+- Tell the LLM explicitly to use the **reply** tool. Without that instruction, models default to `AddComment` and create a new top-level thread.
+- The Node.js `WpxComment` shape has `initiatingCommentId` / `subjectCommentId`, **not** `parentCommentId` (which is .NET-only). The prompt above delegates ID resolution to the LLM, avoiding the typing gap.
+- Word MCP server's `audience` GUID in `ToolingManifest.json` is written by `a365 develop add-mcp-servers` — never hand-edit.
+
+---
+
 ## OpenAI Agents SDK — Wiring (VERIFIED)
 
 Sample: https://github.com/microsoft/Agent365-Samples/blob/main/nodejs/openai/sample-agent/src/client.ts

--- a/tests/validate-workiq.test.js
+++ b/tests/validate-workiq.test.js
@@ -58,9 +58,16 @@ describe('validate-workiq — ToolingManifest', () => {
 describe('validate-workiq — Node.js', () => {
   test('valid wiring → ok', () => {
     const dir = createFixture({
+      '.a365-workspace-detection.local.json': JSON.stringify({ programmingLanguage: 'NodeJS', agentStack: 'LangChain' }),
       'ToolingManifest.json': MANIFEST_VALID,
-      'package.json': JSON.stringify({ name: 'my-agent', dependencies: { '@microsoft/agents-a365-tooling': '^1.0.0' } }),
-      'index.ts': `import { McpToolRegistrationService } from '@microsoft/agents-a365-tooling';`,
+      'package.json': JSON.stringify({
+        name: 'my-agent',
+        dependencies: {
+          '@microsoft/agents-a365-tooling': '^1.0.0',
+          '@microsoft/agents-a365-tooling-extensions-langchain': '^1.0.0',
+        },
+      }),
+      'index.ts': `import { McpToolRegistrationService } from '@microsoft/agents-a365-tooling-extensions-langchain';`,
     });
     try {
       const r = runValidator(VALIDATOR, dir);
@@ -70,14 +77,15 @@ describe('validate-workiq — Node.js', () => {
 
   test('missing tooling package in package.json → reports package', () => {
     const dir = createFixture({
+      '.a365-workspace-detection.local.json': JSON.stringify({ programmingLanguage: 'NodeJS', agentStack: 'LangChain' }),
       'ToolingManifest.json': MANIFEST_VALID,
       'package.json': JSON.stringify({ name: 'my-agent', dependencies: {} }),
-      'index.ts': `import { McpToolRegistrationService } from '@microsoft/agents-a365-tooling';`,
+      'index.ts': `import { McpToolRegistrationService } from '@microsoft/agents-a365-tooling-extensions-langchain';`,
     });
     try {
       const r = runValidator(VALIDATOR, dir);
       assert.equal(r.ok, false);
-      assert.match(r.reason, /agents-a365-tooling is not in package\.json/);
+      assert.match(r.reason, /agents-a365-tooling.*not in package\.json/);
     } finally { cleanup(dir); }
   });
 


### PR DESCRIPTION
## Summary

- **Word @mention handling for Node.js LangChain.** `add-workiq-tools` §4.4 now offers proactive Word-comment @mention handling when `mcp_WordServer` is selected. Wires `proactive: {}` on `AgentApplication`, a per-user conversation index, and a `NotificationType.WpxComment` handler that reads the document, posts a reply on the same comment thread, and DMs the user in Teams with the reply text.
- **New `nodejs-workiq.md` section** — "Word @mention notification handling (BEST-EFFORT)". Marked best-effort because no Microsoft Node.js sample is published yet, though the four load-bearing APIs (`NotificationType.WpxComment`, `wpxCommentNotification`, `AgentApplicationOptions.proactive`, `Proactive.storeConversation` / `sendActivity`) are verified against `microsoft/Agent365-nodejs` and `microsoft/Agents-for-js` source.
- **Task Execution Discipline.** Added a short block to `CLAUDE.md`, `AGENTS.md`, and `.github/copilot-instructions.md` so the agent runs to-do lists to completion in one turn and only pauses at explicit interaction points (capabilities menu, run-target, blueprint Reuse/Re-run/Fresh, WorkIQ offer, MCP server selection, Word @mention offer, launch confirmation). Addresses the setup-UX issue where the agent stopped mid-flow after observability/WorkIQ wiring.
- **Version bumped to 1.0.1** across `package.json`, `.claude-plugin/marketplace.json`, `.github/plugin/marketplace.json` (both `metadata.version` and `plugins[0].version`), and `plugins/agent365/.claude-plugin/plugin.json`.

## Sync verified across all install surfaces

| Surface | Reads | @mention | Discipline |
|---|---|---|---|
| Claude Code (CLI / desktop / VS Code ext) | `plugin.json` + SKILL.md + reference docs | SKILL.md §4.4 + `nodejs-workiq.md` | `CLAUDE.md` rule #8 |
| VS Code Copilot Chat (traditional) | `.github/copilot-instructions.md` | add-workiq-tools step 6 | Task Execution Discipline section |
| VS Code Copilot Chat (agent mode) | `.agents/skills/*` after `install.js` | same SKILL.md | same |
| GitHub Copilot CLI | `.agents/skills/*` + `.github/copilot-instructions.md` | both paths | both paths |
| GitHub CLI marketplace (`gh skill`) | `marketplace.json` | metadata only | n/a |

## SDK verification

Per [feedback_verify_against_sdk_source]:

| API | Source |
|---|---|
| `NotificationType.WpxComment` | [Agent365-nodejs/packages/agents-a365-notifications/src/models/notification-type.ts](https://github.com/microsoft/Agent365-nodejs/blob/main/packages/agents-a365-notifications/src/models/notification-type.ts) |
| `wpxCommentNotification` field | [Agent365-nodejs/packages/agents-a365-notifications/src/models/agent-notification-activity.ts](https://github.com/microsoft/Agent365-nodejs/blob/main/packages/agents-a365-notifications/src/models/agent-notification-activity.ts) — note `initiatingCommentId` / `subjectCommentId`, no `parentCommentId` |
| `AgentApplicationOptions.proactive` | [Agents-for-js/packages/agents-hosting/src/app/agentApplicationOptions.ts](https://github.com/microsoft/Agents-for-js/blob/main/packages/agents-hosting/src/app/agentApplicationOptions.ts) |
| `Proactive.storeConversation` / `sendActivity` | [Agents-for-js/packages/agents-hosting/src/app/proactive/proactive.ts](https://github.com/microsoft/Agents-for-js/blob/main/packages/agents-hosting/src/app/proactive/proactive.ts) |

## Test plan

- [ ] In a Node.js LangChain agent: run `/agent365:add-workiq-tools`, select `mcp_WordServer`, confirm the @mention prompt appears
- [ ] Answer **Yes** → confirm `proactive: {}`, `trackConversationForProactive`, and `handleWpxCommentNotification` are wired into `src/agent.ts`; confirm `tsc --noEmit` passes
- [ ] Answer **No** → confirm Word tools still wire up normally; no @mention scaffolding written
- [ ] In a .NET / Python project: confirm the @mention prompt does NOT appear (LangChain-only branch)
- [ ] In an OpenAI / Claude SDK Node.js project: confirm the @mention prompt does NOT appear (LangChain-only branch)
- [ ] Run `make-ai-teammate` end-to-end and verify the agent moves through observability → WorkIQ → publish without pausing for "continue" between phases (discipline rule)
- [ ] Confirm `node --check` and `JSON.parse` succeed for all 4 JSON files