### PR TITLE
README: bump version badge to 1.0.2; align tenant prereq guidance

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -2,7 +2,7 @@
   "name": "agent365-skills",
   "metadata": {
     "description": "Skills for Microsoft Agent 365 — transform agents into AI Teammates, register blueprints, add WorkIQ MCP servers, instrument observability, and test locally. Supports .NET, Node.js, and Python.",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "owner": {
     "name": "Microsoft",
@@ -13,7 +13,7 @@
       "name": "agent365",
       "source": "./plugins/agent365",
       "description": "Skills covering the full Agent 365 lifecycle: AI Teammate transformation, Blueprint provisioning (Registration / Observability paths), WorkIQ MCP servers (M365 data access), OTel observability instrumentation, and local testing with AgentsPlayground. Supports .NET (AgentFramework, Semantic Kernel), Node.js (LangChain, OpenAI Agents SDK, Claude SDK, Semantic Kernel, Google ADK), and Python (AgentFramework, LangChain, OpenAI, Claude, Semantic Kernel, Google ADK). Note: WorkIQ tooling narrows the supported set — see add-workiq-tools SKILL.md for the verified matrix.",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "skills": [
         "./skills/make-ai-teammate",
         "./skills/a365-setup",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Agent 365 Skills
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/version-1.0.1-blue)](https://github.com/microsoft/agent365-skills/blob/main/plugins/agent365/.claude-plugin/plugin.json)
+[![Version](https://img.shields.io/badge/version-1.0.2-blue)](https://github.com/microsoft/agent365-skills/blob/main/plugins/agent365/.claude-plugin/plugin.json)
 
 Agent skills and MCP configuration for [Microsoft Agent 365](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/) — works with Claude Code and GitHub Copilot. Skills cover the full A365 lifecycle: transforming agents into AI Teammates, registering Blueprints for registration or Observability paths, wiring WorkIQ MCP servers, instrumenting observability, and local testing with AgentsPlayground.
 
@@ -22,7 +22,7 @@ The Agent 365 CLI requires a custom Entra ID app registration in your tenant. Th
 
 Required admin role: **Application Administrator** *(recommended — lightest)*, **Cloud Application Administrator**, or **Global Administrator**. GA is not required. See [custom client app registration](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/custom-client-app-registration) for full details.
 
-If you're a developer without admin access, the skills detect this and surface a clean handoff message for your admin — no need to track down a Global Admin yourself.
+If you're a developer without admin access and the CLI reports the tenant prerequisites are missing (e.g. `403` or "tenant not ready" from `a365 setup all`), share the `a365 setup requirements` command above with your tenant admin — once they run it, you'll inherit the ready state automatically.
 
 ---
 

--- a/plugins/agent365/skills/add-workiq-tools/SKILL.md
+++ b/plugins/agent365/skills/add-workiq-tools/SKILL.md
@@ -393,7 +393,7 @@ Tell the user verbatim: *"Microsoft publishes the `Microsoft.Agents.A365.Tooling
    ```
 2. **Read** `nodejs-workiq.md` — section "LangChain — Wiring (VERIFIED)".
 3. **Edit** `src/client.ts` (or wherever the `getClient` factory lives). Add module-level `toolService = new McpToolRegistrationService()` singleton and the per-turn call inside `getClient`. **Capture the return value** — LangChain rebuilds the agent because `createAgent`'s tools are immutable.
-4. **`mcp_WordServer` was added?** → continue to **Phase 4.5** below for the gated Word @mention handler offer. This is a required check, not a soft suggestion — Phase 4.5's gates handle the actual decision.
+4. After this branch finishes, **fall through to Phase 4.5** — its two gates decide whether the Word `@mention` offer fires or no-ops. Phase 4.5 is not optional; do not jump to Phase 5 from here.
 
 ### §4.5 Node.js OpenAI
 
@@ -485,7 +485,9 @@ Tell the user verbatim: *"No Microsoft sample exists for Python Azure AI Foundry
 
 **Mark task in progress: "Offer Word @mention handler (if applicable)"**
 
-This phase is **gated** — most flows skip it. **Always run the gates explicitly** — the @mention handler should be offered every time `mcp_WordServer` is added on a Node.js LangChain stack. **Do not skip this phase without running both gates.**
+**Always enter this phase after Phase 4 completes — regardless of which §4.x branch ran.** The two gates below decide whether the offer fires or the phase no-ops; the decision belongs to the gates, not to the LLM's intuition. Do not skip ahead to Phase 5 without running BOTH gates — the gate tables below each specify the exact task-completion note to write when they fail.
+
+Read `programmingLanguage` and `agentStack` from `.a365-workspace-detection.local.json` **case-insensitively** — accept `nodejs` / `NodeJS` / `Node.js` and `langchain` / `LangChain` as equivalent. If `agentStack` is the combined string `"Node.js LangChain"`, treat it as LangChain.
 
 **Gate 1 — Framework check.** Read `programmingLanguage` and `agentStack` from `.a365-workspace-detection.local.json`:
 


### PR DESCRIPTION
## Summary
Follow-up to #65 — the README wasn't updated in that PR.

- Bumps the shields.io version badge 1.0.1 -> 1.0.2 to match `plugin.json` / `marketplace.json`.
- Softens the "skills detect missing tenant prereqs" claim in the **Tenant prerequisites** section. Step 1.9 was removed in #65, so the skill no longer probes proactively — the README now tells developers what to do if the CLI reports a tenant-prereq error (share the `a365 setup requirements` command with their tenant admin).

## Test plan
- [ ] Visit the rendered README — version badge shows 1.0.2.
- [ ] Confirm the tenant-prereq paragraph reads cleanly and doesn't promise auto-detection.