### PR TITLE
ci: auto-release on plugin.json version bump (stable + pre-release)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -26,13 +26,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 2  # need previous commit to diff the version field
+          fetch-depth: 0  # need the push event's `before` commit to diff against the pre-push state
 
       - name: Compare old vs new version
         id: v
         run: |
+          BEFORE_SHA="${{ github.event.before }}"
           NEW=$(node -e "process.stdout.write(require('./plugins/agent365/.claude-plugin/plugin.json').version)")
-          OLD=$(git show HEAD~1:plugins/agent365/.claude-plugin/plugin.json 2>/dev/null \
+          OLD=$(git show "$BEFORE_SHA":plugins/agent365/.claude-plugin/plugin.json 2>/dev/null \
                 | node -e "let s=''; process.stdin.on('data',c=>s+=c).on('end',()=>{try{process.stdout.write(JSON.parse(s).version)}catch{process.stdout.write('')}})" || echo "")
           echo "new=$NEW"  >> "$GITHUB_OUTPUT"
           echo "old=$OLD"  >> "$GITHUB_OUTPUT"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,103 @@
+name: Auto-release on version bump
+
+# Watches the plugin manifest on main. When its `version` field changes,
+# creates a matching `v<version>` GitHub release. Pre-release versions
+# (anything with a `-suffix` per semver — e.g. 1.1.0-beta.1, 1.0.0-preview.7)
+# are published as pre-releases AND marked NOT-latest so they don't override
+# the stable channel that `check-version.js` reads via `gh release view`.
+#
+# Sister-workflow: validate.yml `version-parity` job blocks any PR where the
+# three manifest version fields (plugin.json, .claude-plugin/marketplace.json,
+# .github/plugin/marketplace.json) disagree. This workflow re-runs the same
+# check inline as a release-time safety net.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'plugins/agent365/.claude-plugin/plugin.json'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # need previous commit to diff the version field
+
+      - name: Compare old vs new version
+        id: v
+        run: |
+          NEW=$(node -e "process.stdout.write(require('./plugins/agent365/.claude-plugin/plugin.json').version)")
+          OLD=$(git show HEAD~1:plugins/agent365/.claude-plugin/plugin.json 2>/dev/null \
+                | node -e "let s=''; process.stdin.on('data',c=>s+=c).on('end',()=>{try{process.stdout.write(JSON.parse(s).version)}catch{process.stdout.write('')}})" || echo "")
+          echo "new=$NEW"  >> "$GITHUB_OUTPUT"
+          echo "old=$OLD"  >> "$GITHUB_OUTPUT"
+          if [ "$NEW" != "$OLD" ] && [ -n "$NEW" ]; then
+            echo "changed=true"  >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+          # Pre-release iff version has a semver pre-release suffix
+          # ('X.Y.Z-<anything>'). 1.0.3-rc.1, 2.0.0-beta, 1.1.0-preview.7 all match.
+          if echo "$NEW" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+-'; then
+            echo "prerelease=true"  >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Re-verify manifest version parity (release-time safety net)
+        if: steps.v.outputs.changed == 'true'
+        run: |
+          V1=$(node -e "process.stdout.write(require('./plugins/agent365/.claude-plugin/plugin.json').version)")
+          V2=$(node -e "process.stdout.write(require('./.claude-plugin/marketplace.json').version)")
+          V3=$(node -e "process.stdout.write(require('./.github/plugin/marketplace.json').metadata.version)")
+          if [ "$V1" != "$V2" ] || [ "$V1" != "$V3" ]; then
+            echo "::error::Manifest versions diverged at release time. plugin.json=$V1  .claude-plugin/marketplace.json=$V2  .github/plugin/marketplace.json=$V3"
+            echo "::error::validate.yml version-parity job should have blocked the PR. Fix all three then re-merge."
+            exit 1
+          fi
+          echo "✓ All three manifests at $V1"
+
+      - name: Bail if release tag already exists
+        id: tag
+        if: steps.v.outputs.changed == 'true'
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/v${{ steps.v.outputs.new }}" >/dev/null 2>&1; then
+            echo "exists=true"  >> "$GITHUB_OUTPUT"
+            echo "::notice::Release v${{ steps.v.outputs.new }} already exists — skipping."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create stable release
+        if: |
+          steps.v.outputs.changed == 'true'
+          && steps.tag.outputs.exists == 'false'
+          && steps.v.outputs.prerelease == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ steps.v.outputs.new }}" \
+            --title  "v${{ steps.v.outputs.new }}" \
+            --target main \
+            --generate-notes \
+            --latest
+
+      - name: Create pre-release
+        if: |
+          steps.v.outputs.changed == 'true'
+          && steps.tag.outputs.exists == 'false'
+          && steps.v.outputs.prerelease == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ steps.v.outputs.new }}" \
+            --title  "v${{ steps.v.outputs.new }}" \
+            --target main \
+            --generate-notes \
+            --prerelease \
+            --latest=false

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -20,6 +20,14 @@ on:
 permissions:
   contents: write
 
+# Serialize release runs so a slow earlier run can't move the `latest` pointer
+# backwards by completing after a faster later one. `cancel-in-progress: false`
+# is deliberate — we want every version bump to produce its release; we just
+# want them to land in order, not race.
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -81,10 +89,14 @@ jobs:
           && steps.v.outputs.prerelease == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
+        # Target the immutable triggering SHA — NOT the `main` branch ref. If a
+        # newer push lands on main between checkout and `gh release create`,
+        # targeting `main` would tag the wrong commit. github.sha is the commit
+        # whose plugin.json this workflow run actually read.
         run: |
           gh release create "v${{ steps.v.outputs.new }}" \
             --title  "v${{ steps.v.outputs.new }}" \
-            --target main \
+            --target "${{ github.sha }}" \
             --generate-notes \
             --latest
 
@@ -95,10 +107,12 @@ jobs:
           && steps.v.outputs.prerelease == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+        # Same race-safety reasoning as the stable release step above —
+        # target the immutable github.sha, not the moving `main` ref.
         run: |
           gh release create "v${{ steps.v.outputs.new }}" \
             --title  "v${{ steps.v.outputs.new }}" \
-            --target main \
+            --target "${{ github.sha }}" \
             --generate-notes \
             --prerelease \
             --latest=false


### PR DESCRIPTION
## What this adds

A GitHub Actions workflow that watches `plugins/agent365/.claude-plugin/plugin.json` on `main` and creates a matching `v<version>` release the moment the `version` field changes. Stable bumps land as latest releases; pre-release versions (semver `X.Y.Z-<suffix>`) land as pre-releases with `--latest=false` so they don't shadow the stable channel.

After this lands, future version bumps look like:

1. PR bumps `plugin.json` 1.0.2 → 1.0.3
2. PR merges to main
3. Workflow fires, creates tag `v1.0.3` with auto-generated notes
4. `check-version.js` (live-fetch sessionStart hook) picks it up next session and warns stale installs

## Decision matrix

| `plugin.json` version | Tag | `gh release create` flags |
|---|---|---|
| `1.0.3` | `v1.0.3` | `--latest --generate-notes` |
| `1.1.0` | `v1.1.0` | `--latest --generate-notes` |
| `1.1.0-beta.1` | `v1.1.0-beta.1` | `--prerelease --latest=false --generate-notes` |
| `2.0.0-rc.1` | `v2.0.0-rc.1` | `--prerelease --latest=false --generate-notes` |
| `1.0.0-preview.7` | `v1.0.0-preview.7` | `--prerelease --latest=false --generate-notes` |

Pre-release detection is a semver regex: anything matching `^[0-9]+\.[0-9]+\.[0-9]+-` is pre-release.

## Safety nets

1. **Path filter on `plugin.json`** — workflow only fires when that file actually changes. Edits to other files are ignored.
2. **Old-vs-new version diff** — protects against `plugin.json` edits that don't change the version field (description tweaks, keyword changes, etc.). Workflow exits early if the version didn't actually change.
3. **Idempotent tag check** (`git ls-remote --tags`) — re-running or replaying the push doesn't fail; existing tag is detected and skipped with a `::notice::`.
4. **Inline manifest-parity re-check** — `validate.yml` already runs the `version-parity` job on every PR (blocks merge if the three manifest versions disagree), but a release-time re-check guards against `version-parity` having been bypassed or against races where main lands a partial bump. Fails the release with an actionable `::error::` if the three diverge.
5. **No build artifacts** — plugin install mechanisms (`/plugin install`, `gh skill add`) clone the repo at the tag, so just the tag + auto-generated notes are sufficient.

## What this does NOT touch

- `validate.yml` — version-parity job already exists there (lines 46-66). No duplication.
- `test.yml` — unchanged.
- `check-version.js` — already live-fetches every session (PR #67), so it picks up new tags immediately. No changes needed.

## Test plan

- [ ] Merge PR. Verify workflow appears in Actions tab.
- [ ] Open a follow-up PR that bumps `plugin.json` from `1.0.2` → `1.0.3-preview.1` (and matches the other two marketplace.json files). Merge.
- [ ] Verify workflow fires, creates `v1.0.3-preview.1` pre-release with auto notes.
- [ ] Confirm release page shows pre-release badge AND that `gh release view --repo microsoft/agent365-skills --json tagName -q .tagName` still returns `v1.0.2` (the stable manual release), proving `--latest=false` worked.
- [ ] Bump again to `1.0.3` stable. Verify release fires as latest.