### PR TITLE
refresh.sh Git Bash fix + Phase 4.5 (@mention) hard enforcement in workiq validator

### DIFF
--- a/plugins/agent365/hooks/stop/validate-add-workiq-tools.js
+++ b/plugins/agent365/hooks/stop/validate-add-workiq-tools.js
@@ -47,12 +47,19 @@ const issues = [];
 
 let agentStack = '';
 let cachedLanguage = '';
+// `wordMentionDeclined` is the machine-readable marker for "user explicitly
+// said No to the Phase 4.5 @mention offer in this session". When set to true,
+// the Phase 4.5 enforcement check below skips the wiring requirement — the
+// declined branch IS the valid completion state. add-workiq-tools/SKILL.md
+// Phase 4.5 "On No" writes this back to the detection cache.
+let wordMentionDeclined = false;
 try {
   const cachePath = path.join(cwd, '.a365-workspace-detection.local.json');
   if (fs.existsSync(cachePath)) {
     const cache = JSON.parse(fs.readFileSync(cachePath, 'utf8'));
-    agentStack     = normalizeStack(cache.agentStack);
-    cachedLanguage = normalizeLanguage(cache.programmingLanguage);
+    agentStack          = normalizeStack(cache.agentStack);
+    cachedLanguage      = normalizeLanguage(cache.programmingLanguage);
+    wordMentionDeclined = cache.wordMentionDeclined === true;
   }
 } catch {
   // Cache unreadable — fall through to loose detection
@@ -87,7 +94,13 @@ let manifestHasWordServer = false;
 if (fs.existsSync(manifestPath)) {
   try {
     const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-    const entries  = Array.isArray(manifest) ? manifest : (manifest.mcpServers ?? []);
+    // Accept all three shapes the repo's detection rules treat as valid:
+    //   - top-level array (oldest)
+    //   - { mcpServers: [...] } (current)
+    //   - { servers: [...] } (legacy v1 schema, per shared/agent-detection.md § has_workiq)
+    const entries  = Array.isArray(manifest)
+                       ? manifest
+                       : (manifest.mcpServers ?? manifest.servers ?? []);
     manifestHasWorkIQ = entries.some(entry => {
       const name = (entry.mcpServerName ?? entry.name ?? entry.uniqueName ?? '').toLowerCase();
       return name.includes('workiq') || name.includes('work_iq') || name.includes('mail') ||
@@ -289,7 +302,7 @@ if (isPython) checkPython();
 // All three are required by Phase 4.5; missing any one is strong evidence the
 // gates were never run.
 
-if (cachedLanguage === 'nodejs' && agentStack === 'langchain' && manifestHasWordServer) {
+if (cachedLanguage === 'nodejs' && agentStack === 'langchain' && manifestHasWordServer && !wordMentionDeclined) {
   const hasWpxComment   = anyFileContains(tsFiles, 'WpxComment');
   const hasProactive    = anyFileContains(tsFiles, 'proactive');
   const hasUserKeyIndex = anyFileContains(tsFiles, 'userKeyToConversationId');
@@ -303,9 +316,9 @@ if (cachedLanguage === 'nodejs' && agentStack === 'langchain' && manifestHasWord
       'Phase 4.5 (Word @mention) was silently skipped: ToolingManifest.json contains mcp_WordServer ' +
       'AND the cached stack is Node.js LangChain — both gates pass, so the @mention offer was required. ' +
       'Missing wiring: ' + missing + '. Either re-enter Phase 4.5 and wire the @mention handler (per ' +
-      'nodejs-workiq.md § "Word @mention notification handling"), or — if the user declined the offer ' +
-      'in this session — record that explicitly in the task-completion note for "Offer Word @mention ' +
-      'handler (if applicable)" before ending'
+      'nodejs-workiq.md § "Word @mention notification handling"), OR — if the user explicitly declined ' +
+      'the offer in this session — merge {"wordMentionDeclined": true} into ' +
+      '.a365-workspace-detection.local.json so this check honours their choice on re-runs'
     );
   }
 }

--- a/plugins/agent365/hooks/stop/validate-add-workiq-tools.js
+++ b/plugins/agent365/hooks/stop/validate-add-workiq-tools.js
@@ -80,6 +80,10 @@ if (HARD_STOP_PAIRS.has(`${cachedLanguage}:${agentStack}`)) {
 
 const manifestPath = path.join(cwd, 'ToolingManifest.json');
 let manifestHasWorkIQ = false;
+// Track mcp_WordServer specifically — gates the Phase 4.5 @mention enforcement
+// later in this validator. The exact catalog name is `mcp_WordServer`; we also
+// accept any case-insensitive variant on `mcp_word*` defensively.
+let manifestHasWordServer = false;
 if (fs.existsSync(manifestPath)) {
   try {
     const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
@@ -90,6 +94,10 @@ if (fs.existsSync(manifestPath)) {
              name.includes('calendar') || name.includes('teams') || name.includes('sharepoint') ||
              name.includes('onedrive') || name.includes('word') || name.includes('user') ||
              name.includes('copilot') || name.includes('dataverse');
+    });
+    manifestHasWordServer = entries.some(entry => {
+      const name = (entry.mcpServerName ?? entry.name ?? entry.uniqueName ?? '');
+      return /^mcp_word/i.test(name);
     });
   } catch {
     issues.push('ToolingManifest.json exists but could not be parsed — file may be malformed');
@@ -263,6 +271,44 @@ function checkPython() {
 if (isDotnet) checkDotnet();
 if (isNodejs) checkNodejs();
 if (isPython) checkPython();
+
+// ── Check 2a: Phase 4.5 (Word @mention) was not silently skipped ────────────
+// Phase 4.5 of add-workiq-tools/SKILL.md has two gates:
+//   Gate 1 — programmingLanguage = NodeJS AND agentStack = LangChain
+//   Gate 2 — mcp_WordServer present in ToolingManifest.json
+// When BOTH pass, the skill MUST surface the Word @mention offer to the user
+// and either wire the handler (yes branch) or explicitly record "user declined"
+// (no branch). The SKILL.md text is advisory — this validator turns it into a
+// hard session-end failure, so a model that silently jumps from Phase 4 to
+// Phase 5 (instead of falling through to Phase 4.5) can't get away with it.
+//
+// The "yes" branch writes three distinctive symbols into src/**/*.ts:
+//   - `WpxComment` — the case NotificationType.WpxComment branch
+//   - `proactive` — the AgentApplication super({ proactive: {} }) option
+//   - `userKeyToConversationId` — the per-user proactive conversation index
+// All three are required by Phase 4.5; missing any one is strong evidence the
+// gates were never run.
+
+if (cachedLanguage === 'nodejs' && agentStack === 'langchain' && manifestHasWordServer) {
+  const hasWpxComment   = anyFileContains(tsFiles, 'WpxComment');
+  const hasProactive    = anyFileContains(tsFiles, 'proactive');
+  const hasUserKeyIndex = anyFileContains(tsFiles, 'userKeyToConversationId');
+  if (!hasWpxComment || !hasProactive || !hasUserKeyIndex) {
+    const missing = [
+      !hasWpxComment   && 'WpxComment notification branch',
+      !hasProactive    && 'proactive: {} in AgentApplication super()',
+      !hasUserKeyIndex && 'userKeyToConversationId Map',
+    ].filter(Boolean).join('; ');
+    issues.push(
+      'Phase 4.5 (Word @mention) was silently skipped: ToolingManifest.json contains mcp_WordServer ' +
+      'AND the cached stack is Node.js LangChain — both gates pass, so the @mention offer was required. ' +
+      'Missing wiring: ' + missing + '. Either re-enter Phase 4.5 and wire the @mention handler (per ' +
+      'nodejs-workiq.md § "Word @mention notification handling"), or — if the user declined the offer ' +
+      'in this session — record that explicitly in the task-completion note for "Offer Word @mention ' +
+      'handler (if applicable)" before ending'
+    );
+  }
+}
 
 // ── Check 2b: WorkIQ did not clobber observability ──────────────────────────
 // If the project has the observability entry-point call, the handler-side

--- a/plugins/agent365/skills/add-workiq-tools/SKILL.md
+++ b/plugins/agent365/skills/add-workiq-tools/SKILL.md
@@ -557,7 +557,10 @@ grep -i '"mcpServerName":\s*"mcp_WordServer"' ToolingManifest.json
 
 **On No:**
 
-Tell the user: *"Skipped. Word tools still work for direct user prompts; only the proactive @mention path is omitted. You can re-enable later by re-running `/agent365:add-workiq-tools` — the skill is idempotent."*
+1. Tell the user verbatim: *"Skipped. Word tools still work for direct user prompts; only the proactive @mention path is omitted. You can re-enable later by re-running `/agent365:add-workiq-tools` — the skill is idempotent."*
+2. **Record the decision in the cache** so the stop-hook validator honours it instead of failing the session at end:
+   - **Read** `.a365-workspace-detection.local.json`, merge `{ "wordMentionDeclined": true }` into it, **Write** it back.
+   - Without this marker, `validate-add-workiq-tools.js` will treat the missing `WpxComment` / `proactive` / `userKeyToConversationId` symbols as evidence of a silent skip (Phase 4.5 silently bypassed) and hard-fail the session. The marker is the machine-readable signal that "user declined" is the legitimate completion state.
 
 **Mark task complete: "Offer Word @mention handler (if applicable)"**
 

--- a/scripts/refresh.sh
+++ b/scripts/refresh.sh
@@ -130,6 +130,12 @@ if [ -f "$copilot_instr" ]; then
         else
             node_path="$copilot_instr"
         fi
+        # `set -euo pipefail` (top of file) would normally abort the script the
+        # instant node exits non-zero. The snippet below uses non-zero exits AS
+        # its return channel (10 = file deleted, 11 = file rewritten,
+        # 2 = no clean H1 boundary). The `|| rc=$?` idiom captures the exit code
+        # without tripping errexit, so the case-handler below actually runs.
+        rc=0
         node -e "
             const fs = require('fs');
             const p = '$node_path';
@@ -150,8 +156,7 @@ if [ -f "$copilot_instr" ]; then
                 fs.writeFileSync(p, trimmed + '\n', 'utf8');
                 process.exit(11);
             }
-        "
-        rc=$?
+        " || rc=$?
         case "$rc" in
             10)
                 printf '  [v] Wiped .github/copilot-instructions.md (file was purely Agent 365 instructions)\n'

--- a/scripts/refresh.sh
+++ b/scripts/refresh.sh
@@ -118,9 +118,21 @@ if [ -f "$copilot_instr" ]; then
         # Use node for safe Unicode-correct string splitting (the H1 has an em-dash
         # in some upstream variants; awk/sed handling can drop bytes on Windows
         # checkouts that round-tripped through CRLF).
+        #
+        # Path-translation fix for Git Bash / MSYS on Windows: bash forms like
+        # /c/Users/... are NOT auto-translated when interpolated into a node -e
+        # script body (only argv is translated). Node on Windows then reads them
+        # as a path relative to the drive root and fails ENOENT. cygpath -m gives
+        # us a Windows-form path with forward slashes that works identically in
+        # Node on every OS.
+        if command -v cygpath >/dev/null 2>&1; then
+            node_path=$(cygpath -m "$copilot_instr")
+        else
+            node_path="$copilot_instr"
+        fi
         node -e "
             const fs = require('fs');
-            const p = '$copilot_instr';
+            const p = '$node_path';
             const c = fs.readFileSync(p, 'utf8');
             const marker = '# Agent 365 Skills';
             let trimmed = null;
@@ -187,7 +199,15 @@ do
 done
 
 if [ -n "$plugin_json" ]; then
-    installed_version=$(node -e "console.log(require('$plugin_json').version)" 2>/dev/null || true)
+    # Same Git Bash / MSYS path-translation gotcha as the copilot-instructions.md
+    # step above — convert with cygpath when available so node receives a path
+    # form it can actually open on Windows.
+    if command -v cygpath >/dev/null 2>&1; then
+        node_plugin_json=$(cygpath -m "$plugin_json")
+    else
+        node_plugin_json="$plugin_json"
+    fi
+    installed_version=$(node -e "console.log(require('$node_plugin_json').version)" 2>/dev/null || true)
     if [ -n "$installed_version" ]; then
         printf '\n\033[1;32mInstalled plugin version: %s\033[0m\n' "$installed_version"
     else


### PR DESCRIPTION
## Two robustness fixes for silent-failure paths hit today

### 1. `scripts/refresh.sh` — Git Bash / MSYS path crash on Windows

**Reported by user**: running `./scripts/refresh.sh` from Git Bash on Windows crashed on the surgical `.github/copilot-instructions.md` cleanup step with `ENOENT`, after already wiping `.agents/skills/` plugin copies. Refresh half-completed, requiring manual reinstall to recover.

**Root cause**: the script interpolates a Bash-form path (e.g. `/c/Users/.../.github/copilot-instructions.md`) directly into a `node -e` script body. MSYS auto-translates command-line argv but NOT strings interpolated inside a `-e` script. Node on Windows reads `/c/Users/...` as a path relative to the drive root and crashes with `ENOENT`.

**Fix**: convert with `cygpath -m` when available (Git Bash always has it; Linux/macOS bash never do, so the fallback is the unmodified path). `cygpath -m` produces a Windows path with forward slashes that Node accepts on every OS. Applied to both `node -e` call sites — the copilot-instructions.md cleanup (which actually crashed) and the plugin.json version read (would have silently failed too via the `2>/dev/null` suppressor).

Smoke-tested with a Windows-mounted tempdir:
- ✅ User content above the Agent 365 H1 preserved verbatim
- ✅ Agent 365 section surgically removed
- ✅ Plugin version reported correctly

### 2. `validate-add-workiq-tools.js` — Phase 4.5 (Word @mention) silent skip

**Reported by user, second occurrence**: Phase 4.5 of `add-workiq-tools` was silently skipped again in a live session even though both gates passed:
- Gate 1 — `programmingLanguage = NodeJS` AND `agentStack = LangChain` ✅
- Gate 2 — `mcp_WordServer` present in `ToolingManifest.json` ✅

PR #66 added explicit fall-through wording at §4.4 step 4 and flipped Phase 4.5's intro from *"most flows skip it"* to *"always enter, gates decide"* — but that's advisory. A real session today still silently jumped from Phase 4 (MCP wiring) to Phase 5 (permissions handoff), skipping Phase 4.5 entirely.

**Fix**: add a session-end hard-fail validator check. The "yes" branch of Phase 4.5 writes three distinctive symbols into `src/**/*.ts`:
- `WpxComment` — `NotificationType.WpxComment` branch
- `proactive` — `AgentApplication super({proactive: {}})`
- `userKeyToConversationId` — per-user proactive conversation index

When both gates pass at session end but any of those three symbols is missing, the validator fails with an actionable error pointing at `nodejs-workiq.md § Word @mention` and offering the *"user declined"* escape hatch for completion notes.

`manifestHasWordServer` is now captured alongside the existing `manifestHasWorkIQ` during the manifest parse step. WordServer detection accepts the canonical `mcp_WordServer` and any case-insensitive `mcp_word*` variant.

## Test plan

- [x] `VALIDATE_SKIP_EXEC=1 npm test` → 110/110 passing
- [ ] On a Windows Git Bash workspace with a stale install, run `./scripts/refresh.sh` — verify no ENOENT crash, copilot-instructions.md correctly trimmed, plugin version reported
- [ ] On a Node.js LangChain project with `mcp_WordServer` in manifest but no @mention wiring, run `/agent365:add-workiq-tools` and skip Phase 4.5 — stop-hook should fail at session end with the new "Phase 4.5 was silently skipped" message
- [ ] Same project after wiring `WpxComment` / `proactive` / `userKeyToConversationId` → stop-hook passes