### PR TITLE
Fix SessionStart hook schema and bump version to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent365-skills",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "description": "Skills for Microsoft Agent 365 — transform agents into AI Teammates, register blueprints, add WorkIQ MCP servers, instrument observability, and test locally. Supports .NET (AgentFramework, Semantic Kernel) and Node.js (LangChain, OpenAI Agents SDK, Claude SDK, Semantic Kernel, Google ADK) and Python (AgentFramework, LangChain, OpenAI, Claude, Semantic Kernel, Google ADK).",
   "license": "MIT",

--- a/plugins/agent365/.claude-plugin/plugin.json
+++ b/plugins/agent365/.claude-plugin/plugin.json
@@ -12,11 +12,15 @@
   "keywords": ["agent365", "microsoft", "observability", "opentelemetry", "workiq", "mcp", "langchain", "dotnet", "python", "semantic-kernel", "google-adk", "blueprint", "s2s", "msal", "ai-teammate"],
   "skills": "./skills/",
   "hooks": {
-    "sessionStart": [
+    "SessionStart": [
       {
-        "type": "command",
-        "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js",
-        "timeout": 5000
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/check-version.js",
+            "timeout": 5000
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## Changes

- Fix `SessionStart` hook in `plugins/agent365/.claude-plugin/plugin.json` to use the correct nested `hooks` array schema (and correct PascalCase event name).
- Bump version to `1.0.2` in `package.json`.