### PR TITLE
Add A365 code validator skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "agent365-skills",
-  "description": "Production-ready skills for Microsoft Agent 365 — AI Teammate transformation, Blueprint provisioning, WorkIQ MCP servers, OTel observability, and local testing. Supports .NET, Node.js, and Python. Works with Claude Code and GitHub Copilot Chat.",
+  "description": "Production-ready skills for Microsoft Agent 365 — AI Teammate transformation, Blueprint provisioning, WorkIQ MCP servers, OTel observability, telemetry validation, and local testing. Supports .NET, Node.js, and Python. Works with Claude Code and GitHub Copilot Chat.",
   "version": "1.0.2",
   "owner": {
     "name": "Microsoft",
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "agent365",
-      "description": "Skills covering the full Agent 365 lifecycle: AI Teammate transformation, Blueprint provisioning (Registration / Observability paths), WorkIQ MCP servers (M365 data access), OTel observability instrumentation, and local testing with AgentsPlayground. Supports .NET (AgentFramework, Semantic Kernel), Node.js (LangChain, OpenAI Agents SDK, Claude SDK, Semantic Kernel, Google ADK), and Python (AgentFramework, LangChain, OpenAI, Claude, Semantic Kernel, Google ADK). Note: WorkIQ tooling narrows the supported set — see add-workiq-tools SKILL.md for the verified matrix.",
+      "description": "Skills covering the full Agent 365 lifecycle: AI Teammate transformation, Blueprint provisioning (Registration / Observability paths), WorkIQ MCP servers (M365 data access), OTel observability instrumentation, report-first telemetry validation with optional guided fixes, and local testing with AgentsPlayground. Supports .NET (AgentFramework, Semantic Kernel), Node.js (LangChain, OpenAI Agents SDK, Claude SDK, Semantic Kernel, Google ADK), and Python (AgentFramework, LangChain, OpenAI, Claude, Semantic Kernel, Google ADK). Note: WorkIQ tooling narrows the supported set — see add-workiq-tools SKILL.md for the verified matrix.",
       "source": "./plugins/agent365"
     }
   ]

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,6 +13,7 @@ Skills for instrumenting and registering Microsoft Agent 365 agents. When a user
 | `make-a365-agent` | Non-AI-Teammate blueprint provisioning (Register / Observability / WorkIQ paths) | `instrument-observability` (optional), `add-workiq-tools` (optional, skipped for S2S) |
 | `add-workiq-tools` | Wire MCP servers (Mail / Calendar / Word / etc.) into the agent | — |
 | `instrument-observability` | OTel + A365 tracing exporter wiring | — |
+| `a365-code-validator` | A365 observability/MAC Activity validation with optional guided fixes | — |
 | `test-local` | Launch agent + AgentsPlayground for local smoke test | — |
 
 Skills are designed to be additive, idempotent, and state-aware — re-running is safe.
@@ -32,6 +33,7 @@ between phases instead of asking permission.
 - `make-a365-agent`: agent name + directory; reuse-blueprint; hosted vs local; observability/WorkIQ offers.
 - `add-workiq-tools`: MCP server selection; Word @mention offer (only when `mcp_WordServer` is selected and stack is Node.js LangChain).
 - `instrument-observability`: agent kind + auth mode (only if not in cache).
+- `a365-code-validator`: after the report, asks whether to apply safe fixes, create a fix plan, or stop.
 - `test-local`: confirm before launching.
 
 CLI `Allow / Skip` prompts are the chat client's permission flow — not stopping conditions.
@@ -265,6 +267,37 @@ wrapping.
 - .NET: [plugins/agent365/skills/instrument-observability/references/dotnet-observability.md](../plugins/agent365/skills/instrument-observability/references/dotnet-observability.md)
 - Node.js: [plugins/agent365/skills/instrument-observability/references/nodejs-observability.md](../plugins/agent365/skills/instrument-observability/references/nodejs-observability.md)
 - Python: [plugins/agent365/skills/instrument-observability/references/python-observability.md](../plugins/agent365/skills/instrument-observability/references/python-observability.md)
+
+---
+
+## Skill: a365-code-validator
+
+**Full instructions:** [plugins/agent365/skills/a365-code-validator/SKILL.md](../plugins/agent365/skills/a365-code-validator/SKILL.md)
+
+**Trigger phrases:**
+- "validate a365 code"
+- "run a365 code validator"
+- "check a365 observability code"
+- "debug a365 activity missing"
+- "debug MAC activity for this agent"
+- "validate Agent 365 telemetry"
+- "check why Agent Activity is empty"
+- "check A365 exporter flags"
+- "validate gen_ai agent id"
+- "check A365 span types"
+
+**Summary of what this skill does:**
+1. Performs report-first static validation of an existing agent project.
+2. Checks exporter activation (`ENABLE_A365_OBSERVABILITY_EXPORTER` / `EnableAgent365Exporter`, Node `enableObservabilityExporter`, Python `a365_enable_observability_exporter`, .NET `EnableAgent365Exporter`).
+3. Checks identity binding: runtime Agent Identity / Source Agent ID must be used for `/agents/{agentId}` and `gen_ai.agent.id`; Blueprint ID belongs only in `microsoft.a365.agent.blueprint.id`.
+4. Checks semantic span coverage: `invoke_agent`, `chat`, `execute_tool`, and `output_messages` (or framework scopes that produce them).
+5. Checks S2S vs OBO endpoint expectations and token resolver signals.
+6. Produces a report with blockers, risky findings, and runtime verification commands for SDK logs and Maven Kusto.
+
+**This skill does NOT:** provision resources, install packages, run `a365 setup`, or run `a365 publish`. It does not modify source code unless the user explicitly chooses to apply safe fixes after the report.
+
+**Reference checklist:**
+- [plugins/agent365/skills/a365-code-validator/references/validation-checklist.md](../plugins/agent365/skills/a365-code-validator/references/validation-checklist.md)
 
 ---
 

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "agent365-skills",
   "metadata": {
-    "description": "Skills for Microsoft Agent 365 — transform agents into AI Teammates, register blueprints, add WorkIQ MCP servers, instrument observability, and test locally. Supports .NET, Node.js, and Python.",
+    "description": "Skills for Microsoft Agent 365 — transform agents into AI Teammates, register blueprints, add WorkIQ MCP servers, instrument observability, validate telemetry readiness, and test locally. Supports .NET, Node.js, and Python.",
     "version": "1.0.2"
   },
   "owner": {
@@ -12,7 +12,7 @@
     {
       "name": "agent365",
       "source": "./plugins/agent365",
-      "description": "Skills covering the full Agent 365 lifecycle: AI Teammate transformation, Blueprint provisioning (Registration / Observability paths), WorkIQ MCP servers (M365 data access), OTel observability instrumentation, and local testing with AgentsPlayground. Supports .NET (AgentFramework, Semantic Kernel), Node.js (LangChain, OpenAI Agents SDK, Claude SDK, Semantic Kernel, Google ADK), and Python (AgentFramework, LangChain, OpenAI, Claude, Semantic Kernel, Google ADK). Note: WorkIQ tooling narrows the supported set — see add-workiq-tools SKILL.md for the verified matrix.",
+      "description": "Skills covering the full Agent 365 lifecycle: AI Teammate transformation, Blueprint provisioning (Registration / Observability paths), WorkIQ MCP servers (M365 data access), OTel observability instrumentation, report-first telemetry validation with optional guided fixes, and local testing with AgentsPlayground. Supports .NET (AgentFramework, Semantic Kernel), Node.js (LangChain, OpenAI Agents SDK, Claude SDK, Semantic Kernel, Google ADK), and Python (AgentFramework, LangChain, OpenAI, Claude, Semantic Kernel, Google ADK). Note: WorkIQ tooling narrows the supported set — see add-workiq-tools SKILL.md for the verified matrix.",
       "version": "1.0.2",
       "skills": [
         "./skills/make-ai-teammate",
@@ -20,6 +20,7 @@
         "./skills/make-a365-agent",
         "./skills/add-workiq-tools",
         "./skills/instrument-observability",
+        "./skills/a365-code-validator",
         "./skills/test-local"
       ]
     }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Read this before making any changes to skill files.
 
 ## Plugin Purpose
 
-This plugin instruments and configures A365 agents. It contains six skills:
+This plugin instruments and configures A365 agents. It contains seven skills:
 
 | Skill | Command | Trigger |
 |-------|---------|---------|
@@ -16,6 +16,7 @@ This plugin instruments and configures A365 agents. It contains six skills:
 | `make-a365-agent` | `/agent365:make-a365-agent` | "provision agent with a365", "Registration setup", "observability setup", "register this agent" |
 | `add-workiq-tools` | `/agent365:add-workiq-tools` | "add workiq tools", "add MCP servers to this agent" |
 | `instrument-observability` | `/agent365:instrument-observability` | "instrument observability", "add a365 observability" |
+| `a365-code-validator` | `/agent365:a365-code-validator` | "validate a365 code", "debug MAC activity", "check A365 exporter flags" |
 | `test-local` | `/agent365:test-local` | "test this agent locally", "open agentsplayground" |
 
 **Supported languages for `make-ai-teammate`:** .NET (AgentFramework · Semantic Kernel) · Node.js (LangChain · OpenAI Agents SDK · Claude SDK · Semantic Kernel · Google ADK) · Python (AgentFramework · LangChain · OpenAI · Claude · Semantic Kernel · Google ADK)
@@ -40,6 +41,7 @@ a365-setup  →  make-ai-teammate    (AI Teammate path)
 make-a365-agent  →  instrument-observability  (Observability paths)
                  →  add-workiq-tools          (WorkIQ paths)
 
+a365-code-validator  (report-first; optional safe fixes after confirmation; no prerequisite)
 test-local  (no prerequisite)
 ```
 `make-ai-teammate` is **idempotent and state-aware**. Phase 0B detects three primary skill-state flags from the project — `has_obs` (observability wired), `has_workiq` (ToolingManifest.json has a non-empty mcpServers array), `disk_blueprint_present` (blueprint already registered, from `.a365-workspace-detection.local.json` / `a365.generated.config.json`). Phase 0C routes through an **8-row state matrix** (rows 1–8 over those flags): full flow → skip-obs → skip-workiq → register-only → no-re-register variants → "everything wired" confirmation (row 8 — sub-question: re-publish or verify-only). The skill creates the hosting layer, agent class, notification handling, full `a365.config.json`. **Phase 9.7.1a is the verification gate** — disk presence (`disk_blueprint_present`) is advisory only; the user is always asked explicitly whether the disk-side blueprint is the intended one before any skip/reuse decision (handles cases where disk lies about tenant state: deleted in Entra, file from another project, agent-name mismatch). If an existing blueprint is found, the skill asks the user explicitly: **Reuse** (skip setup-all), **Re-run** (idempotent — CLI reuses the blueprint ID but refreshes permissions and project settings), or **Fresh** (`a365 cleanup` first, then re-provision — destructive). When no blueprint exists, `a365 setup all --aiteammate --m365` runs unconditionally. (`--m365` is **always passed** for AI Teammate — no user question. Never pass `--authmode` with `--aiteammate` — AI Teammate uses the Agentic User identity.) It then asks **Phase 9.7.2 Run Target** (Prod vs Local), persisted to `.a365-workspace-detection.local.json` with remember-with-confirm on re-runs. For `runTarget = "prod"`: a **Phase 9.7.2b hosting sub-question** follows — *dev tunnel* (Microsoft Dev Tunnel exposing localhost — for in-Teams testing before deploying to a cloud) or *cloud endpoint* (Azure App Service / Container Apps / Functions; AWS App Runner / Lambda + API Gateway / ECS; Google Cloud Run / App Engine / Cloud Functions). The user supplies (or the skill derives) the HTTPS messaging endpoint URL, stored as `chosenEndpoint`. Phase 9.7.2c then **always** re-asserts `chosenEndpoint` on the blueprint via `a365 setup blueprint --update-endpoint <chosenEndpoint> --m365` — run **unconditionally** for AI Teammate prod (mandatory, NOT gated on a config/endpoint diff: the disk `messagingEndpoint` can be stale — dev-tunnel URL rotation, a non-persisted Teams Graph re-registration, or a reused/copied blueprint). Skipped only for `runTarget = "local"` or an empty/placeholder `chosenEndpoint`. (`--m365` is required — without it the CLI silently skips Teams Graph re-registration.) After reconciliation: **verifies** (read-only) the Teams manifest, runs `a365 publish` (packages `manifest.zip` — does NOT upload, does NOT touch the bot endpoint), then walks the user through **two required manual steps**: (a) verify the agent in Teams Developer Portal at `https://dev.teams.microsoft.com/tools/agent-blueprint/<agentBlueprintId>/configuration` — Agent Type=API Based, Notification URL = the reconciled `chosenEndpoint`/`messagingEndpoint` (required for Teams message delivery; the Notification URL is auto-registered by `--update-endpoint --m365` via the Teams Graph proxy on supported tenants — verify it, and set it by hand only as a fallback when the CLI reports automated registration isn't available for the tenant); and (b) request an agent instance from Teams Apps and wait for admin approval at admin.cloud.microsoft. For `runTarget = "local"`: agent runs at `http://localhost:3978/api/messages` (Node.js/Python default) — all publish/Dev-Portal/MAC-upload/instance steps are skipped — the skill routes directly to AgentsPlayground for smoke testing.
@@ -79,6 +81,10 @@ plugins/agent365/
 │   │       ├── dotnet-observability.md   # Authoritative .NET code patterns
 │   │       ├── nodejs-observability.md  # Authoritative Node.js code patterns
 │   │       └── python-observability.md  # Authoritative Python code patterns
+│   ├── a365-code-validator/
+│   │   ├── SKILL.md              # Observability/MAC Activity validator + guided fixes
+│   │   └── references/
+│   │       └── validation-checklist.md
 │   ├── add-workiq-tools/
 │   │   ├── SKILL.md              # WorkIQ MCP tool wiring
 │   │   └── references/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ agent365-skills/
 │       │   ├── make-a365-agent/SKILL.md               # Blueprint provisioning (Register / Observability paths)
 │       │   ├── make-ai-teammate/SKILL.md              # AI Teammate transformation + publish pipeline
 │       │   ├── instrument-observability/SKILL.md      # OTel + A365 tracing exporter instrumentation
+│       │   ├── a365-code-validator/SKILL.md           # Observability/MAC Activity validation + guided fixes
 │       │   ├── add-workiq-tools/SKILL.md              # WorkIQ MCP server wiring
 │       │   └── test-local/SKILL.md                    # Local testing with AgentsPlayground
 │       ├── hooks/
@@ -100,6 +101,11 @@ agent365-skills/
    launch confirmation). CLI permission prompts and manual browser steps
    (Teams Dev Portal, M365 Admin Center, GA consent) are not stopping conditions — surface
    them with URL + action and continue.
+
+11. **`a365-code-validator` is report-first.** It diagnoses exporter activation, agent-id
+   binding, semantic span coverage, and S2S/OBO endpoint mismatches, then asks whether to
+   apply safe fixes, create a fix plan, or stop. It must not provision, install packages,
+   or run `a365 publish`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Version](https://img.shields.io/badge/version-1.0.2-blue)](https://github.com/microsoft/agent365-skills/blob/main/plugins/agent365/.claude-plugin/plugin.json)
 
-Agent skills and MCP configuration for [Microsoft Agent 365](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/) — works with Claude Code and GitHub Copilot. Skills cover the full A365 lifecycle: transforming agents into AI Teammates, registering Blueprints for registration or Observability paths, wiring WorkIQ MCP servers, instrumenting observability, and local testing with AgentsPlayground.
+Agent skills and MCP configuration for [Microsoft Agent 365](https://learn.microsoft.com/en-us/microsoft-agent-365/developer/) — works with Claude Code and GitHub Copilot. Skills cover the full A365 lifecycle: transforming agents into AI Teammates, registering Blueprints for registration or Observability paths, wiring WorkIQ MCP servers, instrumenting observability, validating A365 telemetry code, and local testing with AgentsPlayground.
 
 Browse the [`plugins/agent365/skills/`](https://github.com/microsoft/agent365-skills/blob/main/plugins/agent365/skills) folder for the full catalog.
 
@@ -56,7 +56,7 @@ The fastest way to install for GitHub Copilot CLI and VS Code agent mode:
 gh skill add microsoft/agent365-skills
 ```
 
-This reads `.github/plugin/marketplace.json` and installs all six skills directly into your Copilot CLI session. Use `/skills list` to verify, and invoke skills by name:
+This reads `.github/plugin/marketplace.json` and installs all seven skills directly into your Copilot CLI session. Use `/skills list` to verify, and invoke skills by name:
 
 ```bash
 gh copilot suggest "Make this agent an AI Teammate"
@@ -72,7 +72,7 @@ cd my-agent-project
 node /path/to/agent365-skills/scripts/install.js
 ```
 
-The installer copies all six skill directories into `.agents/skills/` in your project. Skills then appear automatically in VS Code's Configure Skills menu (`/skills list`) and are loaded on demand by VS Code agent mode and the Copilot cloud agent.
+The installer copies all seven skill directories into `.agents/skills/` in your project. Skills then appear automatically in VS Code's Configure Skills menu (`/skills list`) and are loaded on demand by VS Code agent mode and the Copilot cloud agent.
 
 ### GitHub Copilot CLI (`gh copilot`)
 
@@ -101,6 +101,7 @@ a365-setup  (recommended entry point — handles CLI, Azure, Blueprint)
       s2s (Service Principal)                  └─ add-workiq-tools          (optional, obo only)
 
 test-local  ← standalone; run at any point to test your agent locally
+a365-code-validator  ← standalone; run at any point to diagnose MAC Activity / telemetry readiness
 ```
 
 `a365-setup` writes `.a365-workspace-detection.local.json`. All downstream skills read this file to skip re-detection.
@@ -130,6 +131,7 @@ The file is safe to delete — the next `a365-setup` run rebuilds it. Skills als
 ```
 "Make this agent an AI Teammate"    → make-ai-teammate       (Blueprint must exist)
 "Add observability to this agent"   → instrument-observability
+"Validate A365 code"                → a365-code-validator    (diagnostics + optional guided fixes)
 "Add WorkIQ tools to this agent"    → add-workiq-tools
 "Test this agent locally"           → test-local
 ```
@@ -257,6 +259,24 @@ All new code is marked `// A365 Observability — best-effort instrumentation` a
 "Make this agent visible in Microsoft Defender"
 "Wire up OpenTelemetry for this agent"      "Enable Agent 365 telemetry"
 "Add observability to this .NET agent"      "Add A365 observability to this Python agent"
+```
+
+---
+
+### `a365-code-validator` — Validate A365 Telemetry Readiness
+
+Report-first diagnostics for agents that should emit MAC Activity / Defender / Purview telemetry.
+Checks exporter activation, runtime agent ID vs blueprint ID binding, supported A365 semantic
+span operations, and S2S/OBO endpoint expectations. Produces a report with concrete runtime
+verification commands, then asks whether to apply safe fixes, create a fix plan, or stop.
+It does not provision resources or publish manifests.
+
+**Trigger phrases:**
+```
+"Validate A365 code"                 "Run A365 code validator"
+"Check A365 observability code"      "Debug MAC Activity for this agent"
+"Check why Agent Activity is empty"  "Validate gen_ai agent id"
+"Check A365 exporter flags"          "Check A365 span types"
 ```
 
 ---
@@ -414,7 +434,7 @@ To update after pulling changes, re-run `gh skill add microsoft/agent365-skills`
 
 ```bash
 npm test          # unit tests for every stop-hook validator (tests/*.test.js)
-npm run validate  # run all six stop-hook validators against the current directory
+npm run validate  # run all stop-hook validators against the current directory
 ```
 
 The stop-hook validators share a single project-tree walk via `plugins/agent365/hooks/lib/project-scan.js` — when adding a new validator, import `scanProject` / `filterByName` / `fileContains` from that module rather than re-implementing `findFiles`. The version check (`plugins/agent365/scripts/check-version.js`) runs as a `sessionStart` hook declared in `plugins/agent365/.claude-plugin/plugin.json` — it fires once per session (not once per skill invocation) and caches the `gh release view` result for 24h under `$LOCALAPPDATA/agent365-skills/` (Windows) or `~/.cache/agent365-skills/` (Unix), so the per-session cost is sub-millisecond after the first hit.

--- a/evals/README.md
+++ b/evals/README.md
@@ -19,7 +19,7 @@ evals/
     ├── instrument-observability/
     │   └── evals.json                # 5 test cases
     ├── a365-code-validator/
-    │   └── evals.json                # 4 test cases
+    │   └── evals.json                # 10 test cases
     └── test-local/
         └── evals.json                # 5 test cases
 ```
@@ -156,6 +156,12 @@ To manually test a skill against an eval:
 | 2 | Blueprint used as agent ID | Catches background/queue paths that set `gen_ai.agent.id` to blueprint |
 | 3 | Missing semantic spans | Catches baggage-only implementations that won't populate MAC Activity |
 | 4 | Node exporter flag missing | Catches `a365.enabled` without `enableObservabilityExporter` |
+| 5 | S2S token shape wrong | Catches bare `ClientSecretCredential`/MI token instead of the 3-hop FMI exchange (`AADSTS82001`) |
+| 6 | S2S endpoint via env only | Catches reliance on `A365_USE_S2S_ENDPOINT` env instead of the `a365_use_s2s_endpoint` code flag |
+| 7 | Caller identity wrong | Catches `user.id` set to the agent's own user / blank instead of the human caller OID |
+| 8 | Code clean, Activity empty | Branches to tenant-side causes (license assigned, Frontier enrollment, resource SP, lag) instead of a false code bug |
+| 9 | No `invoke_agent` root | Catches child-span-only runs / identity-less spans ("0 identity groups") that never land in MAC |
+| 10 | Guided remediation | Verifies `apply_safe_fixes` applies only the deterministic exporter fix and asks before design changes |
 
 ---
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -18,6 +18,8 @@ evals/
     │   └── evals.json                # 5 test cases
     ├── instrument-observability/
     │   └── evals.json                # 5 test cases
+    ├── a365-code-validator/
+    │   └── evals.json                # 4 test cases
     └── test-local/
         └── evals.json                # 5 test cases
 ```
@@ -37,10 +39,15 @@ Each `evals.json` file contains:
 
 ## Prerequisites
 
-All skills except `test-local` require `.a365-workspace-detection.local.json` to be present in the
+Most code-editing skills require `.a365-workspace-detection.local.json` to be present in the
 project directory. This file is written by `a365-setup` and contains `agentStack`,
 `programmingLanguage`, and `detectedAt`. Skills read from this cache instead of running their
 own detection.
+
+Exceptions:
+- `test-local` can run without the cache.
+- `a365-code-validator` can run without the cache because it is read-only and performs its own
+  static inspection.
 
 ---
 
@@ -55,6 +62,7 @@ To manually test a skill against an eval:
    - `a365-setup`: Any agent project with a365 CLI and Azure CLI installed
    - `add-workiq-tools`: An agent already transformed by `make-ai-teammate` (has `.a365-workspace-detection.local.json`)
    - `instrument-observability`: An agent already transformed by `make-ai-teammate`
+   - `a365-code-validator`: Any existing agent project; no setup prerequisite, read-only
    - `test-local`: Any agent with a build script or `dotnet run` / `uv run`
 
 2. **Start Claude** with the plugin loaded:
@@ -139,6 +147,15 @@ To manually test a skill against an eval:
 | 3 | agentsplayground not installed | Auto-install via npm then launch |
 | 4 | User declines launch | Show manual commands and exit cleanly |
 | 5 | Build fails | Stop before launch; surface error output |
+
+### `a365-code-validator` Evals
+
+| ID | Scenario | Purpose |
+|----|----------|---------|
+| 1 | Python exporter flag missing | Catches `enable_a365=True` without actual exporter activation |
+| 2 | Blueprint used as agent ID | Catches background/queue paths that set `gen_ai.agent.id` to blueprint |
+| 3 | Missing semantic spans | Catches baggage-only implementations that won't populate MAC Activity |
+| 4 | Node exporter flag missing | Catches `a365.enabled` without `enableObservabilityExporter` |
 
 ---
 

--- a/evals/agent365/a365-code-validator/evals.json
+++ b/evals/agent365/a365-code-validator/evals.json
@@ -1,6 +1,29 @@
 {
   "skill_name": "a365-code-validator",
   "eval_instructions": "Run these evals against existing agent projects or minimal fixtures. This skill is report-first: it must not modify source files until the user explicitly chooses to apply safe fixes. It must never run a365 setup, install packages, or run a365 publish. Verify that it produces a concise report with blockers, risky findings, runtime verification commands, and an explicit fix/plan/stop prompt.",
+  "trigger_tests": {
+    "instructions": "Run each prompt in a fresh session with the full agent365 skill library loaded. should_trigger prompts must activate a365-code-validator. should_not_trigger prompts must activate the named sibling (or no skill) and must NOT activate a365-code-validator — they guard the diagnose-vs-instrument boundary with instrument-observability and the other siblings. Report hit rate in each direction (>=2 runs each).",
+    "should_trigger": [
+      "Validate A365 code for this Python agent",
+      "Debug why Agent Activity is empty for this agent",
+      "Check why MAC Activity is empty but export returns 200",
+      "Our agent id looks wrong in Defender reporting — check the code",
+      "Pre-flight whether this agent will emit MAC Activity before we ship",
+      "Check A365 exporter flags for this S2S agent",
+      "Why are my spans exporting but not showing in the admin center",
+      "Validate the gen_ai agent id binding for this Node.js agent"
+    ],
+    "should_not_trigger": [
+      { "prompt": "Instrument observability for this agent", "expected_skill": "instrument-observability" },
+      { "prompt": "Add A365 tracing to my new agent from scratch", "expected_skill": "instrument-observability" },
+      { "prompt": "Set up observability for this .NET agent that has none yet", "expected_skill": "instrument-observability" },
+      { "prompt": "Register this agent with Agent 365 and create a blueprint", "expected_skill": "make-a365-agent" },
+      { "prompt": "Turn my agent into an AI Teammate", "expected_skill": "make-ai-teammate" },
+      { "prompt": "Add WorkIQ mail and calendar tools to my agent", "expected_skill": "add-workiq-tools" },
+      { "prompt": "Run my agent locally in AgentsPlayground", "expected_skill": "test-local" },
+      { "prompt": "Set up the A365 CLI and Azure prerequisites", "expected_skill": "a365-setup" }
+    ]
+  },
   "evals": [
     {
       "id": 1,
@@ -63,6 +86,95 @@
         "Phase 3: Checks BaggageBuilder / InvokeAgentScope / configureA365Hosting signals",
         "Phase 5: Produces read-only report",
         "Phase 6: Asks whether to apply safe fixes, create a fix plan, or stop before editing"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Validate A365 code for this S2S Python agent",
+      "description": "Python S2S agent mints the observability token with a bare ClientSecretCredential / DefaultAzureCredential against the observability resource instead of the 3-hop FMI exchange",
+      "expected_output": "The skill flags the token shape: a plain client-credentials or bare managed-identity token has the app/MI as its principal, not the runtime Agent Identity, so the backend rejects it. It explains the failure signatures and recommends the 3-hop FMI exchange (blueprint creds + fmi_path=<agentId> -> agent-identity assertion -> OtelWrite token). Read-only; prints no internal endpoints.",
+      "files": [],
+      "expectations": [
+        "Phase 3.5: Flags token shape — a bare ClientSecretCredential/DefaultAzureCredential yields an app/MI principal, not the runtime Agent Identity",
+        "Phase 3.5: Explains the failure signatures: AADSTS82001 (plain client-credentials), 403 (principal != gen_ai.agent.id), and 400 TenantIdInvalid when no valid token is bound",
+        "Phase 3.5: Recommends the 3-hop FMI exchange (blueprint creds + fmi_path=<agentIdentityAppId> -> agent-identity assertion -> Observability API token with roles containing OtelWrite)",
+        "Phase 3: References validation-checklist section 5 (token shape) for the exchange detail",
+        "Phase 5: Does not print internal cluster names, private endpoints, tenant IDs, real agent IDs, or correlation IDs",
+        "Phase 6: Does not generate a full token service silently — offers a plan and asks for a second confirmation"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Check A365 exporter flags for this S2S agent",
+      "description": "S2S agent selects the endpoint only via A365_USE_S2S_ENDPOINT=true in env; the use_microsoft_opentelemetry(...) call does not pass a365_use_s2s_endpoint=True",
+      "expected_output": "The skill flags reliance on the env var for S2S endpoint selection and recommends setting the transport flag in code (a365_use_s2s_endpoint=True / useS2SEndpoint:true / UseS2SEndpoint), so the S2S token is not posted to the OBO route. It notes this mirrors passing the exporter-enable flag in code rather than depending on env parity.",
+      "files": [],
+      "expectations": [
+        "Phase 3.5: Reports that the S2S endpoint is selected via env only, not the a365_use_s2s_endpoint / useS2SEndpoint / UseS2SEndpoint code option",
+        "Phase 3.5: Explains that an S2S token posted to the OBO endpoint is rejected — token type must match the route",
+        "Phase 3.5: Recommends setting the S2S transport flag in code because env-only selection is more fragile",
+        "Phase 5: Concise report that separates export success from Activity eligibility",
+        "Phase 6: Offers the endpoint/exporter flag as a deterministic safe fix after confirmation"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Debug MAC Activity — caller shows blank for this Teams agent",
+      "description": "HumanToAgent / Teams path sets user.id to the agent's own Agent User OID (or leaves it blank) instead of the human sender's object ID",
+      "expected_output": "The skill flags caller identity: for HumanToAgent, user.id must be the human caller's Entra object ID; the agent's own Agent User belongs in microsoft.agent.user.id. Export can succeed while the caller/user Activity stays blank. It notes the human OID is often already available from the inbound activity's from.aadObjectId.",
+      "files": [],
+      "expectations": [
+        "Phase 3.4: Flags caller identity — user.id set to the agent's own user / blank instead of the human caller OID",
+        "Phase 3.4: Explains user.id = human caller OID (HumanToAgent); microsoft.agent.user.id = the agent's own Agent User OID",
+        "Phase 3.4: Notes export can succeed (HTTP 200) while caller/user Activity remains blank",
+        "Phase 3: Suggests sourcing the human OID from the inbound activity from.aadObjectId where available",
+        "Phase 5: Read-only report with no real user/agent/tenant IDs printed",
+        "Phase 6: Offers to split user.id vs microsoft.agent.user.id as a confirmed fix"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "Debug why Agent Activity is empty",
+      "description": "All code checks pass (exporter on, correct runtime agent identity, semantic spans present, export returns 200/sent) but MAC Activity is still empty",
+      "expected_output": "The skill confirms the code path is correct and does NOT invent a code bug. It branches to tenant-side verification: at least one user has an M365 E7 / Agent 365 license ASSIGNED, the tenant is Frontier-enrolled, the observability resource SP is present, and ingestion lag (Defender CloudAppEvents populates before the admin center).",
+      "files": [],
+      "expectations": [
+        "Phase 3: Confirms exporter enabled, identity binding correct, and semantic spans present — the code path passes",
+        "Phase 4: Branches to the tenant-side checklist when code is clean but Activity is empty, rather than reporting a false code blocker",
+        "Phase 4: Lists license ASSIGNED (M365 E7 / Agent 365, not just present), Frontier enrollment, resource SP present, and ingestion lag",
+        "Phase 4: Provides az ad sp show --id 9b975845-388f-4429-889e-eab1ef63949c as the resource-SP check, and notes a 404 / AADSTS500011 means it is not provisioned in the tenant",
+        "Phase 5: Frames the remaining causes as tenant/onboarding, not code",
+        "Phase 5: Notes that HTTP 200 / 'sent' is not proof of MAC visibility (ingestion lag plus tenant gating)"
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "Check why MAC Activity is empty for this Node.js AI Teammate",
+      "description": "Exporter succeeds but logs show 'Partitioned into 0 identity groups' / 'N spans skipped (missing tenant or agent ID)' and only a child chat span exports; no invoke_agent root",
+      "expected_output": "The skill reads the run shape: MAC Activity ingests invoke_agent rows, and the exported span is a child chat/inference span while the invoke_agent root is either not created or dropped for missing tenant/agent id. It recommends creating an explicit invoke_agent root and ensuring identity baggage (tenant_id + agent_id) wraps every span via the hosting baggage middleware.",
+      "files": [],
+      "expectations": [
+        "Phase 3.3: Reports a missing invoke_agent root — auto-instrumentation only emits chat/inference; agent-level operations must be created explicitly",
+        "Phase 3: Interprets 'Partitioned into 0 identity groups' / 'spans skipped (missing tenant or agent ID)' as spans starting outside the identity baggage scope",
+        "Phase 3.4: Notes MAC Activity ingests invoke_agent rows; a run with only child chat spans is queryable in Defender but invisible in the admin center",
+        "Phase 3: Recommends the hosting baggage middleware (configureA365Hosting / ObservabilityHostingManager with enable baggage) so identity propagates to every span, with invoke_agent started inside that scope",
+        "Phase 4: Provides SDK log grep for 'identity groups' and 'No eligible' signals",
+        "Phase 6: Offers to add the invoke_agent / output_messages scopes as a confirmed follow-up"
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "Validate A365 code and fix it",
+      "description": "Guided remediation — Python project missing the exporter flag; user chooses apply_safe_fixes after the report",
+      "expected_output": "After the BLOCKED report, the user selects apply_safe_fixes. The skill applies ONLY the deterministic exporter fix — adds a365_enable_observability_exporter=True (or the kwargs equivalent) preserving code style — and adds a commented .env template entry. It does NOT wire a token service or wrap semantic spans without a second explicit confirmation.",
+      "files": [],
+      "expectations": [
+        "Phase 5: Presents the concise report first; makes no edits before the user chooses",
+        "Phase 6: Offers apply_safe_fixes / make_fix_plan / report_only, with make_fix_plan as the default",
+        "Phase 6: On apply_safe_fixes, adds a365_enable_observability_exporter=True to the existing use_microsoft_opentelemetry(...) call, preserving existing style",
+        "Phase 6: Adds only a commented or empty ENABLE_A365_OBSERVABILITY_EXPORTER template entry; never hardcodes real IDs or secrets",
+        "Phase 6: Does NOT generate a token service or wrap semantic spans without a second explicit confirmation",
+        "Phase 6: Fix report lists applied fixes, items still needing input, and the validation to rerun"
       ]
     }
   ]

--- a/evals/agent365/a365-code-validator/evals.json
+++ b/evals/agent365/a365-code-validator/evals.json
@@ -1,0 +1,69 @@
+{
+  "skill_name": "a365-code-validator",
+  "eval_instructions": "Run these evals against existing agent projects or minimal fixtures. This skill is report-first: it must not modify source files until the user explicitly chooses to apply safe fixes. It must never run a365 setup, install packages, or run a365 publish. Verify that it produces a concise report with blockers, risky findings, runtime verification commands, and an explicit fix/plan/stop prompt.",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Validate A365 code for this Python agent",
+      "description": "Python project with microsoft-opentelemetry and enable_a365=True but missing explicit exporter flag",
+      "expected_output": "The skill detects Python, runs the static validator, and returns a concise BLOCKED/PASS WITH RISKS report. It flags missing a365_enable_observability_exporter=True or runtime ENABLE_A365_OBSERVABILITY_EXPORTER=true as a blocker without dumping internal backend details.",
+      "files": [],
+      "expectations": [
+        "Phase 1: Reads pyproject.toml / requirements.txt and Python source files",
+        "Phase 2: Runs validate-a365-code-validator.js or performs equivalent static checks",
+        "Phase 3: Reports exporter activation status",
+        "Phase 3: Explains the two Python flags: enable_a365 and a365_enable_observability_exporter",
+        "Phase 4: Provides local/App Service commands to verify exporter env",
+        "Phase 5: Does not edit source files or run provisioning",
+        "Phase 5: Default report is concise (8 bullets or fewer), with optional details separated",
+        "Phase 6: Asks whether to apply safe fixes, create a fix plan, or stop"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Debug MAC Activity for this agent",
+      "description": "Python background/queue poller calls a365_request_scope with blueprint_id but no agent_id",
+      "expected_output": "The skill identifies the identity-binding bug in a concise report: gen_ai.agent.id can fall back to the Blueprint ID. It recommends passing the runtime Agent Identity / Source Agent ID explicitly while keeping the blueprint in microsoft.a365.agent.blueprint.id.",
+      "files": [],
+      "expectations": [
+        "Phase 1: Reads queue/background worker files",
+        "Phase 2: Reports python-blueprint-as-agent-id or equivalent finding",
+        "Phase 3: Explains token principal == route agentId == gen_ai.agent.id",
+        "Phase 3: Distinguishes runtime Agent Identity from Blueprint ID",
+        "Phase 4: Provides local/App Service commands to verify exporter runtime settings",
+        "Phase 5: Recommends concrete fix order without suggesting a365 publish for blueprint-based observability",
+        "Phase 5: Does not include private endpoint paths, Kusto queries, tenant IDs, real agent IDs, or correlation IDs",
+        "Phase 6: Does not modify identity config until the user confirms the runtime agent identity field name"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Check A365 span types",
+      "description": "Agent sets baggage but does not explicitly create supported A365 semantic spans",
+      "expected_output": "The skill reports that baggage alone is insufficient for MAC Activity. It checks for supported operations (invoke_agent, chat, execute_tool, output_messages) or framework scopes and recommends adding/confirming semantic spans.",
+      "files": [],
+      "expectations": [
+        "Phase 3: Lists supported operation names",
+        "Phase 3: Flags generic HTTP/OpenAI spans as insufficient for Activity when no semantic spans are present",
+        "Phase 4: Provides SDK log grep commands for identity groups and no eligible genAI spans",
+        "Phase 5: Separates backend export readiness from Activity UI visibility",
+        "Phase 6: Offers semantic-span fixes as a separate, confirmed follow-up rather than silently editing"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Run A365 code validator on this Node.js agent",
+      "description": "Node.js project uses useMicrosoftOpenTelemetry with a365.enabled but missing enableObservabilityExporter",
+      "expected_output": "The skill detects Node.js, flags missing enableObservabilityExporter:true or ENABLE_A365_OBSERVABILITY_EXPORTER=true, checks baggage/scope anchors, and provides runtime log verification commands.",
+      "files": [],
+      "expectations": [
+        "Phase 1: Reads package.json and JS/TS source files",
+        "Phase 2: Runs static validator",
+        "Phase 3: Checks useMicrosoftOpenTelemetry a365.enabled and enableObservabilityExporter",
+        "Phase 3: Checks BaggageBuilder / InvokeAgentScope / configureA365Hosting signals",
+        "Phase 5: Produces read-only report",
+        "Phase 6: Asks whether to apply safe fixes, create a fix plan, or stop before editing"
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent365-skills",
   "version": "1.0.2",
   "private": true,
-  "description": "Skills for Microsoft Agent 365 — transform agents into AI Teammates, register blueprints, add WorkIQ MCP servers, instrument observability, and test locally. Supports .NET (AgentFramework, Semantic Kernel) and Node.js (LangChain, OpenAI Agents SDK, Claude SDK, Semantic Kernel, Google ADK) and Python (AgentFramework, LangChain, OpenAI, Claude, Semantic Kernel, Google ADK).",
+  "description": "Skills for Microsoft Agent 365 — transform agents into AI Teammates, register blueprints, add WorkIQ MCP servers, instrument observability, validate telemetry readiness, and test locally. Supports .NET (AgentFramework, Semantic Kernel) and Node.js (LangChain, OpenAI Agents SDK, Claude SDK, Semantic Kernel, Google ADK) and Python (AgentFramework, LangChain, OpenAI, Claude, Semantic Kernel, Google ADK).",
   "license": "MIT",
   "author": {
     "name": "Microsoft",
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "test": "node --test tests/*.test.js",
-    "validate": "node plugins/agent365/hooks/stop/validate-a365-setup.js && node plugins/agent365/hooks/stop/validate-make-a365-agent.js && node plugins/agent365/hooks/stop/validate-make-ai-teammate.js && node plugins/agent365/hooks/stop/validate-instrument-observability.js && node plugins/agent365/hooks/stop/validate-add-workiq-tools.js && node plugins/agent365/hooks/stop/validate-test-local.js"
+    "validate": "node plugins/agent365/hooks/stop/validate-a365-setup.js && node plugins/agent365/hooks/stop/validate-make-a365-agent.js && node plugins/agent365/hooks/stop/validate-make-ai-teammate.js && node plugins/agent365/hooks/stop/validate-instrument-observability.js && node plugins/agent365/hooks/stop/validate-a365-code-validator.js && node plugins/agent365/hooks/stop/validate-add-workiq-tools.js && node plugins/agent365/hooks/stop/validate-test-local.js"
   },
   "engines": {
     "node": ">=18"

--- a/plugins/agent365/hooks/stop/validate-a365-code-validator.js
+++ b/plugins/agent365/hooks/stop/validate-a365-code-validator.js
@@ -116,6 +116,13 @@ function validatePython() {
   const hasExplicitExporter = anyFileMatches(pyFiles, /\ba365_enable_observability_exporter\s*=\s*True\b/);
   const hasExplicitExporterFalse = anyFileMatches(pyFiles, /\ba365_enable_observability_exporter\s*=\s*False\b/);
   const hasExporterEnv = envHasTruthy('ENABLE_A365_OBSERVABILITY_EXPORTER') || envHasTruthy('EnableAgent365Exporter');
+  const hasExplicitS2S = anyFileMatches(pyFiles, /\ba365_use_s2s_endpoint\s*=\s*True\b/);
+  const hasExplicitS2SFalse = anyFileMatches(pyFiles, /\ba365_use_s2s_endpoint\s*=\s*False\b/);
+  const hasS2SEnv = envHasTruthy('A365_USE_S2S_ENDPOINT');
+  const hasS2SIntent = anyFileContains(pyFiles, 'a365_contextual_token_resolver') ||
+    anyFileContains(pyFiles, 'agent_source_identity') ||
+    anyFileContains(pyFiles, 'AgentIdentityTokenResolver') ||
+    hasS2SEnv;
 
   if (hasMicrosoftOpenTelemetryPackage && !hasDistroCall) {
     add(
@@ -157,6 +164,29 @@ function validatePython() {
     );
   }
 
+  if (hasDistroCall && hasS2SIntent && hasExplicitS2SFalse) {
+    add(
+      'critical',
+      'python-s2s-endpoint-disabled',
+      'Python appears to use S2S/Agent Identity export but passes a365_use_s2s_endpoint=False. S2S agents must use service-to-service endpoint mode.',
+      pyFiles.find(f => /a365_use_s2s_endpoint\s*=\s*False\b/.test(read(f)))
+    );
+  } else if (hasDistroCall && hasS2SIntent && !hasExplicitS2S && hasS2SEnv) {
+    add(
+      'medium',
+      'python-s2s-endpoint-env-dependent',
+      'Python appears to use S2S/Agent Identity export but depends on A365_USE_S2S_ENDPOINT=true in env. Prefer passing a365_use_s2s_endpoint=True in code.',
+      pyFiles.find(f => fileContains(f, 'use_microsoft_opentelemetry'))
+    );
+  } else if (hasDistroCall && hasS2SIntent && !hasExplicitS2S && !hasS2SEnv) {
+    add(
+      'high',
+      'python-s2s-endpoint-not-set',
+      'Python appears to use S2S/Agent Identity export but does not set a365_use_s2s_endpoint=True or A365_USE_S2S_ENDPOINT=true.',
+      pyFiles.find(f => fileContains(f, 'use_microsoft_opentelemetry'))
+    );
+  }
+
   for (const file of pyFiles) {
     const content = read(file);
     for (const block of findCallBlocks(content, 'a365_request_scope')) {
@@ -185,6 +215,46 @@ function validatePython() {
       'python-no-explicit-a365-semantic-spans',
       'No explicit InvokeAgentScope/InferenceScope/ExecuteToolScope or gen_ai.operation.name markers found. The app may rely entirely on auto-instrumentation; MAC Activity needs invoke_agent/chat/execute_tool/output_messages spans.'
     );
+  }
+
+  const pythonText = pyFiles.map(read).join('\n');
+  const hasInvoke = /InvokeAgentScope|gen_ai\.operation\.name['"]?\s*[:=]|invoke_agent/.test(pythonText);
+  const hasExecuteTool = /ExecuteToolScope|execute_tool/.test(pythonText);
+  const hasAgentName = /gen_ai\.agent\.name|\bagent_name\s*=|AgentDetails\s*\([^)]*agent_name/s.test(pythonText);
+  const hasConversation = /gen_ai\.conversation\.id|\bconversation_id\s*=|\.conversation_id\s*\(/.test(pythonText);
+  const hasChannel = /microsoft\.channel\.name|\bchannel_name\s*=|\.channel_name\s*\(/.test(pythonText);
+  const hasInputMessages = /gen_ai\.input\.messages|record_input_messages|Request\s*\(\s*content\s*=/.test(pythonText);
+  const hasOutputMessages = /gen_ai\.output\.messages|record_output_messages|record_response/.test(pythonText);
+  const hasAgentUser = /microsoft\.agent\.user\.id|\bagent_user_oid\s*=|\.agent_user_id\s*\(/.test(pythonText);
+
+  if (hasDistroCall && hasInvoke && !hasAgentName) {
+    add('medium', 'python-missing-agent-name', 'No gen_ai.agent.name/AgentDetails agent_name signal found. Admin/reporting surfaces may show a GUID or blank agent name.');
+  }
+  if (hasDistroCall && hasInvoke && !hasConversation) {
+    add('medium', 'python-missing-conversation-id', 'No gen_ai.conversation.id/conversation_id signal found. Reportable runs need a conversation or logical run ID.');
+  }
+  if (hasDistroCall && hasInvoke && !hasChannel) {
+    add('medium', 'python-missing-channel-name', 'No microsoft.channel.name/channel_name signal found. Activity/reporting surfaces need a channel such as msteams, web, icm, or scheduler.');
+  }
+  if (hasDistroCall && hasInvoke && !hasInputMessages) {
+    add('medium', 'python-missing-input-messages', 'No gen_ai.input.messages/record_input_messages signal found for invoke/chat spans.');
+  }
+  if (hasDistroCall && hasInvoke && !hasOutputMessages) {
+    add('medium', 'python-missing-output-messages', 'No gen_ai.output.messages/record_output_messages/record_response signal found for invoke/chat/output spans.');
+  }
+  if (hasDistroCall && hasExecuteTool) {
+    const hasToolCallId = /gen_ai\.tool\.call\.id|tool_call_id/.test(pythonText);
+    const hasToolArgs = /gen_ai\.tool\.call\.arguments|arguments\s*=/.test(pythonText);
+    const hasToolResult = /gen_ai\.tool\.call\.result|record_response/.test(pythonText);
+    if (!hasToolCallId || !hasToolArgs || !hasToolResult) {
+      add('medium', 'python-incomplete-tool-span-details', 'execute_tool spans found, but tool call id/arguments/result are not all visible. Tool activity can be incomplete.');
+    }
+  }
+  if (hasDistroCall && /a365_contextual_token_resolver/.test(pythonText) && /user\.id|\buser_oid\b/.test(pythonText) && !hasAgentUser) {
+    add('medium', 'python-obo-agent-user-attribute-missing', 'Code uses contextual token resolution and user.id/user_oid, but no microsoft.agent.user.id/agent_user_oid signal is visible. OBO/Agent-User export may never trigger.');
+  }
+  if (hasDistroCall && /OPERATIONS\s*=\s*\[[^\]]*['"]inference['"]|gen_ai\.operation\.name[\s\S]{0,300}['"]inference['"]/.test(pythonText)) {
+    add('medium', 'python-direct-inference-operation-name', 'Code appears to emit gen_ai.operation.name=inference directly. Public docs use chat for LLM spans; direct inference operations may not classify as expected.');
   }
 }
 

--- a/plugins/agent365/hooks/stop/validate-a365-code-validator.js
+++ b/plugins/agent365/hooks/stop/validate-a365-code-validator.js
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+/**
+ * validate-a365-code-validator.js
+ *
+ * Read-only static scanner for the a365-code-validator skill. This validator
+ * reports potential A365 observability/MAC Activity issues, but it deliberately
+ * returns ok:true because findings are the expected output of a validation skill.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+  scanProject,
+  filterByName,
+  fileContains,
+  anyFileContains,
+  readJson,
+} = require('../lib/project-scan');
+
+const cwd = process.cwd();
+function isTestPath(filePath) {
+  const parts = filePath.split(path.sep).map(p => p.toLowerCase());
+  return parts.includes('tests') || parts.includes('test') || parts.includes('__tests__');
+}
+
+const allFiles = scanProject(cwd, { maxDepth: 7 })
+  .filter(f => !path.basename(f).includes('validate-a365-code-validator'))
+  .filter(f => !f.includes(path.join('plugins', 'agent365', 'hooks')))
+  .filter(f => !f.includes(path.join('plugins', 'agent365', 'skills', 'a365-code-validator')))
+  .filter(f => !isTestPath(f));
+const csprojFiles = filterByName(allFiles, '.csproj');
+const tsFiles = filterByName(allFiles, '.ts', '.js');
+const pyFiles = filterByName(allFiles, '.py');
+const envFiles = filterByName(allFiles, '.env', '.env.example', '.env.production', '.env.local');
+const appSettingsFiles = filterByName(allFiles, 'appsettings.json', 'appsettings.Development.json');
+const reqFiles = filterByName(allFiles, 'requirements.txt', 'pyproject.toml');
+const packageJsonFiles = filterByName(allFiles, 'package.json');
+
+const findings = [];
+
+function read(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function rel(filePath) {
+  return path.relative(cwd, filePath).replace(/\\/g, '/');
+}
+
+function add(severity, id, message, filePath = '') {
+  findings.push({
+    severity,
+    id,
+    message,
+    file: filePath ? rel(filePath) : undefined,
+  });
+}
+
+function envHasTruthy(name) {
+  const truthy = new RegExp(`^\\s*${name}\\s*=\\s*(true|1|yes)\\s*$`, 'im');
+  return envFiles.some(f => truthy.test(read(f)));
+}
+
+function envHasFalsy(name) {
+  const falsy = new RegExp(`^\\s*${name}\\s*=\\s*(false|0|no)\\s*$`, 'im');
+  return envFiles.some(f => falsy.test(read(f)));
+}
+
+function anyFileMatches(files, regex) {
+  return files.some(f => regex.test(read(f)));
+}
+
+function isDevelopmentSettings(filePath) {
+  return path.basename(filePath).toLowerCase().includes('development');
+}
+
+function findCallBlocks(content, functionName) {
+  const blocks = [];
+  let index = 0;
+  const needle = `${functionName}(`;
+  while ((index = content.indexOf(needle, index)) !== -1) {
+    const start = index;
+    let depth = 0;
+    let end = -1;
+    for (let i = index + functionName.length; i < content.length; i++) {
+      const ch = content[i];
+      if (ch === '(') depth++;
+      if (ch === ')') {
+        depth--;
+        if (depth === 0) {
+          end = i + 1;
+          break;
+        }
+      }
+    }
+    if (end === -1) {
+      break;
+    }
+    blocks.push(content.slice(start, end));
+    index = end;
+  }
+  return blocks;
+}
+
+function validatePython() {
+  const hasMicrosoftOpenTelemetryPackage = reqFiles.some(f => fileContains(f, 'microsoft-opentelemetry'));
+  const hasDistroCall = anyFileContains(pyFiles, 'use_microsoft_opentelemetry');
+  const hasEnableA365 = anyFileContains(pyFiles, 'enable_a365');
+  const hasExplicitExporter = anyFileMatches(pyFiles, /\ba365_enable_observability_exporter\s*=\s*True\b/);
+  const hasExplicitExporterFalse = anyFileMatches(pyFiles, /\ba365_enable_observability_exporter\s*=\s*False\b/);
+  const hasExporterEnv = envHasTruthy('ENABLE_A365_OBSERVABILITY_EXPORTER') || envHasTruthy('EnableAgent365Exporter');
+
+  if (hasMicrosoftOpenTelemetryPackage && !hasDistroCall) {
+    add(
+      'high',
+      'python-missing-distro-init',
+      'microsoft-opentelemetry is installed, but no Python file calls use_microsoft_opentelemetry(). A365 spans will not export.',
+      reqFiles.find(f => fileContains(f, 'microsoft-opentelemetry'))
+    );
+  }
+
+  if (hasDistroCall && hasEnableA365 && hasExplicitExporterFalse) {
+    add(
+      'critical',
+      'python-exporter-explicitly-disabled',
+      'Python passes a365_enable_observability_exporter=False. This disables A365 backend export.',
+      pyFiles.find(f => /a365_enable_observability_exporter\s*=\s*False\b/.test(read(f)))
+    );
+  } else if (hasDistroCall && hasEnableA365 && !hasExplicitExporter && !hasExporterEnv) {
+    add(
+      'critical',
+      'python-exporter-not-enabled',
+      'Python enables A365 processing but neither passes a365_enable_observability_exporter=True nor sets ENABLE_A365_OBSERVABILITY_EXPORTER=true. Spans may be enriched locally but never sent to the A365 backend.',
+      pyFiles.find(f => fileContains(f, 'use_microsoft_opentelemetry'))
+    );
+  } else if (hasDistroCall && hasEnableA365 && !hasExplicitExporter && hasExporterEnv) {
+    add(
+      'medium',
+      'python-exporter-env-dependent',
+      'Python does not pass a365_enable_observability_exporter=True in code and depends on runtime env ENABLE_A365_OBSERVABILITY_EXPORTER/EnableAgent365Exporter being true.',
+      pyFiles.find(f => fileContains(f, 'use_microsoft_opentelemetry'))
+    );
+  }
+
+  if (envHasFalsy('ENABLE_A365_OBSERVABILITY_EXPORTER') || envHasFalsy('EnableAgent365Exporter')) {
+    add(
+      'high',
+      'exporter-env-disabled',
+      'An env file explicitly disables A365 export. This is fine for local console-only runs, but production/MAC Activity requires the exporter to be true.'
+    );
+  }
+
+  for (const file of pyFiles) {
+    const content = read(file);
+    for (const block of findCallBlocks(content, 'a365_request_scope')) {
+      if (block.includes('blueprint_id') && !/\bagent_id\s*=/.test(block)) {
+        add(
+          'critical',
+          'python-blueprint-as-agent-id',
+          'a365_request_scope passes blueprint_id but no agent_id. If the helper falls back to blueprint_id, gen_ai.agent.id becomes the blueprint ID and S2S/MAC Activity can fail identity binding.',
+          file
+        );
+      }
+    }
+  }
+
+  const hasManualScopes = anyFileContains(pyFiles, 'InvokeAgentScope') ||
+    anyFileContains(pyFiles, 'InferenceScope') ||
+    anyFileContains(pyFiles, 'ExecuteToolScope');
+  const hasOperationName = anyFileContains(pyFiles, 'gen_ai.operation.name') ||
+    anyFileContains(pyFiles, 'invoke_agent') ||
+    anyFileContains(pyFiles, 'execute_tool') ||
+    anyFileContains(pyFiles, 'output_messages');
+
+  if (hasDistroCall && !hasManualScopes && !hasOperationName) {
+    add(
+      'medium',
+      'python-no-explicit-a365-semantic-spans',
+      'No explicit InvokeAgentScope/InferenceScope/ExecuteToolScope or gen_ai.operation.name markers found. The app may rely entirely on auto-instrumentation; MAC Activity needs invoke_agent/chat/execute_tool/output_messages spans.'
+    );
+  }
+}
+
+function validateNode() {
+  const hasMicrosoftOtelPackage = packageJsonFiles.some(f => fileContains(f, '@microsoft/opentelemetry'));
+  const hasDistroCall = anyFileContains(tsFiles, 'useMicrosoftOpenTelemetry');
+  const hasA365Enabled = anyFileContains(tsFiles, 'enabled: true') || anyFileContains(tsFiles, 'enabled:true');
+  const hasExporterFlag = anyFileMatches(tsFiles, /\benableObservabilityExporter\s*:\s*true\b/);
+  const hasExporterFalse = anyFileMatches(tsFiles, /\benableObservabilityExporter\s*:\s*false\b/);
+  const hasExporterEnv = envHasTruthy('ENABLE_A365_OBSERVABILITY_EXPORTER');
+
+  if (hasMicrosoftOtelPackage && !hasDistroCall) {
+    add(
+      'high',
+      'node-missing-distro-init',
+      '@microsoft/opentelemetry is installed, but no JS/TS file calls useMicrosoftOpenTelemetry().',
+      packageJsonFiles.find(f => fileContains(f, '@microsoft/opentelemetry'))
+    );
+  }
+
+  if (hasDistroCall && hasA365Enabled && hasExporterFalse) {
+    add(
+      'critical',
+      'node-exporter-explicitly-disabled',
+      'Node code sets enableObservabilityExporter:false. This disables A365 backend export.',
+      tsFiles.find(f => /enableObservabilityExporter\s*:\s*false\b/.test(read(f)))
+    );
+  } else if (hasDistroCall && hasA365Enabled && !hasExporterFlag && !hasExporterEnv) {
+    add(
+      'critical',
+      'node-exporter-not-enabled',
+      'Node code enables A365 but does not set enableObservabilityExporter:true or ENABLE_A365_OBSERVABILITY_EXPORTER=true. Spans may not reach the A365 backend.',
+      tsFiles.find(f => fileContains(f, 'useMicrosoftOpenTelemetry'))
+    );
+  }
+
+  if (hasDistroCall && !anyFileContains(tsFiles, 'BaggageBuilder') && !anyFileContains(tsFiles, 'InvokeAgentScope') && !anyFileContains(tsFiles, 'configureA365Hosting')) {
+    add(
+      'high',
+      'node-missing-identity-scope',
+      'No BaggageBuilder/InvokeAgentScope/configureA365Hosting usage found. Spans can be filtered as missing tenant/agent identity.'
+    );
+  }
+
+  const hasSemanticSpans = anyFileContains(tsFiles, 'InvokeAgentScope') ||
+    anyFileContains(tsFiles, 'InferenceScope') ||
+    anyFileContains(tsFiles, 'ExecuteToolScope') ||
+    anyFileContains(tsFiles, 'gen_ai.operation.name') ||
+    anyFileContains(tsFiles, 'invoke_agent') ||
+    anyFileContains(tsFiles, 'execute_tool') ||
+    anyFileContains(tsFiles, 'output_messages');
+
+  if (hasDistroCall && !hasSemanticSpans) {
+    add(
+      'medium',
+      'node-no-explicit-a365-semantic-spans',
+      'No InvokeAgentScope/InferenceScope/ExecuteToolScope or supported gen_ai.operation.name markers found. Baggage alone is not enough for MAC Activity.'
+    );
+  }
+}
+
+function validateDotnet() {
+  const hasOtelPackage = csprojFiles.some(f =>
+    fileContains(f, 'Microsoft.OpenTelemetry') ||
+    fileContains(f, 'Microsoft.Agents.A365.Observability'));
+  const hasOtelWiring = anyFileContains(allFiles.filter(f => f.endsWith('.cs')), 'UseMicrosoftOpenTelemetry') ||
+    anyFileContains(allFiles.filter(f => f.endsWith('.cs')), 'AddA365Tracing');
+
+  if (hasOtelPackage && !hasOtelWiring) {
+    add(
+      'high',
+      'dotnet-missing-observability-wiring',
+      'A365/.NET observability packages are referenced, but no UseMicrosoftOpenTelemetry/AddA365Tracing wiring was found.',
+      csprojFiles.find(f => fileContains(f, 'Microsoft.OpenTelemetry') || fileContains(f, 'Microsoft.Agents.A365.Observability'))
+    );
+  }
+
+  const appSettingsWithExporter = appSettingsFiles.filter(f => fileContains(f, 'EnableAgent365Exporter'));
+  const productionSettings = appSettingsWithExporter.filter(f => !isDevelopmentSettings(f));
+  const appSettingsFalse = productionSettings.find(f => /"EnableAgent365Exporter"\s*:\s*false/i.test(read(f)));
+  if (hasOtelWiring && appSettingsFalse) {
+    add(
+      'high',
+      'dotnet-exporter-disabled',
+      'appsettings has EnableAgent365Exporter:false. Backend export is disabled until this is true in production.',
+      appSettingsFalse
+    );
+  } else if (hasOtelWiring && appSettingsWithExporter.length === 0) {
+    add(
+      'medium',
+      'dotnet-exporter-config-missing',
+      'No EnableAgent365Exporter setting found. .NET exporter defaults can be console-only unless production config sets it true.'
+    );
+  }
+
+  if (hasOtelWiring && !anyFileContains(allFiles.filter(f => f.endsWith('.cs')), 'InvokeAgentScope')) {
+    add(
+      'medium',
+      'dotnet-no-invoke-agent-scope',
+      'No InvokeAgentScope found. MAC Activity needs invoke_agent parent spans to anchor chat/tool/inference activity.'
+    );
+  }
+}
+
+function validateSetupArtifacts() {
+  const generated = readJson(path.join(cwd, 'a365.generated.config.json'));
+  if (generated) {
+    if (generated.completed === false) {
+      add(
+        'medium',
+        'a365-generated-config-incomplete',
+        'a365.generated.config.json has completed:false. Setup may be partial; verify consent/resource grants before expecting MAC Activity.',
+        path.join(cwd, 'a365.generated.config.json')
+      );
+    }
+    if (generated.agentBlueprintId && generated.agenticAppId && generated.agentBlueprintId === generated.agenticAppId) {
+      add(
+        'critical',
+        'blueprint-id-used-as-agent-id',
+        'a365.generated.config.json has identical blueprint and agentic app IDs. Verify runtime gen_ai.agent.id uses the agent instance/source agent ID, not the blueprint ID.',
+        path.join(cwd, 'a365.generated.config.json')
+      );
+    }
+  }
+}
+
+validatePython();
+validateNode();
+validateDotnet();
+validateSetupArtifacts();
+
+const severityOrder = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
+findings.sort((a, b) => (severityOrder[a.severity] ?? 99) - (severityOrder[b.severity] ?? 99));
+
+process.stdout.write(JSON.stringify({
+  ok: true,
+  findingCount: findings.length,
+  findings,
+}, null, 2));

--- a/plugins/agent365/skills/a365-code-validator/SKILL.md
+++ b/plugins/agent365/skills/a365-code-validator/SKILL.md
@@ -1,12 +1,16 @@
 ---
 name: a365-code-validator
 description: >
-  Validator and optional guided fixer for Agent 365 observability code and configuration.
-  Checks whether
-  an agent can actually emit MAC Activity telemetry by validating exporter activation,
-  agent identity binding, supported A365 semantic span types, S2S/OBO endpoint selection,
-  and common Python/Node.js/.NET failure modes that cause incidents. Defaults to read-only
-  reporting, then asks before applying safe fixes.
+  Validates and optionally fixes Agent 365 observability code so an agent actually emits MAC
+  Activity telemetry. Use when an Agent 365 agent's telemetry isn't reaching MAC Activity or
+  Defender, when spans export (HTTP 200 / "sent") but Activity stays empty, when the caller or
+  agent id looks wrong in reporting, or to pre-flight whether an agent will emit MAC Activity
+  before shipping. Diagnoses and fixes existing instrumentation; do NOT use it to add
+  observability from scratch — use instrument-observability for that.
+  Checks exporter activation, runtime agent-identity binding (vs blueprint id),
+  the S2S FMI / OBO token shape, S2S vs OBO endpoint selection, and the required semantic spans
+  (invoke_agent/chat/execute_tool/output_messages) plus Activity attributes. Read-only by default;
+  asks before applying safe fixes. Python, Node.js, and .NET.
 compatibility:
   - claude-code
   - vscode-copilot
@@ -72,6 +76,16 @@ silent or confusing A365 Activity failures:
 
 No source code is modified during validation. After the report, the skill asks whether to
 apply safe fixes, create a fix plan only, or stop.
+
+---
+
+## Output is support-safe (applies to every phase)
+
+This report may be pasted into a customer or partner thread, so it must be safe to share:
+**never** print internal cluster/database names, Kusto queries, private endpoint or route
+templates, correlation IDs, or real tenant/agent IDs. Report file/function names and public,
+supportable signals only. This is non-negotiable — it holds even when a user asks for "just
+the raw details."
 
 ---
 
@@ -243,7 +257,39 @@ output_messages
 Generic HTTP spans alone are not enough. Flag code that only sets baggage but never
 creates or auto-generates supported semantic spans.
 
-### 3.4 S2S vs OBO transport mode
+### 3.4 Activity/run context coverage
+
+If the developer expects MAC Activity or Defender agent-activity views (not just exporter
+HTTP 200), inspect whether real runs carry the public Agent 365 activity attributes:
+
+| Attribute | What to validate |
+|---|---|
+| `gen_ai.agent.name` | Human-readable agent name exists; otherwise UI can show a GUID/blank |
+| `gen_ai.conversation.id` | Present on every span; for non-chat agents use a logical run/job/incident ID |
+| `microsoft.channel.name` | Present on every span; use `msteams` for Teams, or a product/source value such as `icm`, `web`, `scheduler` |
+| `microsoft.session.id` | Prefer a stable run/session ID; optional, but useful for grouping |
+| `user.id` | Human caller OID for `HumanToAgent`; do not confuse it with the agent's own user |
+| `microsoft.agent.user.id` | Agent's own Agent User OID when testing AI teammate / Agent-User / OBO |
+| `gen_ai.input.messages` / `gen_ai.output.messages` | Present on invoke/chat/output spans where applicable |
+| Tool details | `gen_ai.tool.name`, `gen_ai.tool.type`, `gen_ai.tool.call.id`, `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result` |
+| Model details | `gen_ai.request.model`, `gen_ai.provider.name` on `chat` spans |
+
+When reviewing a mixed app, separate the two objectives:
+
+```text
+S2S/export success proves telemetry plumbing.
+AI teammate/HumanToAgent or EventToAgent run context proves Activity/reporting eligibility.
+```
+
+Do not require Teams-specific values for autonomous agents; require equivalent logical run
+context instead.
+
+Caller identity caveat: for `HumanToAgent`, `user.id` is the caller ID used for "who ran
+this agent" reporting. If it is missing or set to the agent identity / agent user instead
+of the human caller object ID, export can succeed while caller/user Activity remains blank
+or incomplete.
+
+### 3.5 S2S vs OBO transport mode
 
 Do not expose or require internal service URLs in the report. Validate only the structural
 intent:
@@ -255,6 +301,18 @@ intent:
 
 Report whether the code appears to select the correct transport mode (`useS2SEndpoint` /
 `a365_use_s2s_endpoint` / `UseS2SEndpoint`) for S2S, without printing backend route templates.
+For Python S2S, prefer `a365_use_s2s_endpoint=True` in code rather than relying only on
+`A365_USE_S2S_ENDPOINT=true` in runtime environment. Also check the **token shape**: the S2S
+observability token must come from the 3-hop FMI exchange (principal == runtime Agent Identity),
+not a bare client-credentials call — see checklist §5 for the failure signatures
+(`AADSTS82001` / 403).
+
+### 3.6 Blueprint permission inheritance wording
+
+Do not claim that application app roles can never inherit from blueprints. Current public
+Entra Agent ID docs describe both `inheritableScopes` and `inheritableRoles`. If a repo or
+tenant shows delegated scope inheritance working but S2S app roles requiring direct assignment,
+report it as a provisioning/configuration behavior to verify, not as the intended scalable model.
 
 **Mark task complete.**
 
@@ -293,15 +351,39 @@ Select-String .a365-observability.log -Pattern "Agent365Exporter|identity groups
 
 ### Backend verification handoff
 
-If backend verification is required, tell the user to use their team's approved telemetry
-playbook or service dashboard to confirm:
+If backend verification is required, keep customer-facing validation on public/supportable
+surfaces:
 
-1. requests are arriving for the runtime Agent Identity / Source Agent ID,
-2. the request is accepted,
-3. downstream reporting marks the batch as delivered.
+1. SDK/exporter logs show export success and no chunk failures,
+2. direct OTel responses have `partialSuccess` empty/null where applicable,
+3. Microsoft Defender Advanced Hunting `CloudAppEvents` shows the expected AgentId /
+   TargetAgentId / AlternateId after indexing.
 
-Do not include internal cluster names, database names, Kusto queries, private endpoint paths,
-or correlation IDs in the skill output.
+If the user is on an internal service team, they may also use their team's approved
+dashboard/playbook to confirm request acceptance and downstream delivery, but do not print
+those internal queries or endpoints in the validator report.
+
+(Report only support-safe signals — see **Output is support-safe** above.)
+
+### If code checks pass but Activity is still empty — verify tenant-side
+
+Most "exporter returns 200/`sent` but nothing shows in MAC" incidents are **not** code bugs.
+When the code checks above pass, have the user confirm, in the *target* tenant:
+
+> **Provenance (verified 2026-07-06):** the license SKU name, the observability resource-SP
+> GUID, the `AADSTS*` codes, the `Agent365.Observability.OtelWrite` scope, and the ingestion-lag
+> figure below are preview-era Agent 365 facts and will change. Re-verify against current Agent 365
+> onboarding docs before quoting them to a customer.
+
+- **License assigned** — at least one user has an **M365 E7 or Agent 365 license _assigned_**
+  (the SKU merely existing in the tenant isn't enough); otherwise the request is accepted and
+  silently dropped.
+- **Frontier / Agent 365 preview enrollment** — the tenant is enrolled; CDX/demo tenants often
+  aren't by default.
+- **Observability resource SP present** — `az ad sp show --id 9b975845-388f-4429-889e-eab1ef63949c`
+  returns a service principal in the tenant. A `404` / `AADSTS500011` ("resource principal … not
+  found") means the observability app isn't provisioned there — an onboarding step, not a code fix.
+- **Ingestion lag** — Defender `CloudAppEvents` populates before the admin center; give it ~5 min.
 
 **Mark task complete.**
 
@@ -354,8 +436,7 @@ Style rules:
 - Keep the default report to **8 bullets or fewer**.
 - Put details under **Optional details**, not in the main blocker list.
 - Use exact file/function names for evidence, but do not paste long code blocks.
-- Do not include internal cluster names, database names, Kusto queries, private endpoint paths,
-  tenant IDs, real agent IDs, or correlation IDs.
+- Redact per **Output is support-safe** above (no internal infra, tenant/agent IDs, or correlation IDs).
 - Do not suggest `a365 publish` unless the agent is an AI Teammate / M365 package flow;
   blueprint-based observability does not use `a365 publish`.
 

--- a/plugins/agent365/skills/a365-code-validator/SKILL.md
+++ b/plugins/agent365/skills/a365-code-validator/SKILL.md
@@ -1,0 +1,462 @@
+---
+name: a365-code-validator
+description: >
+  Validator and optional guided fixer for Agent 365 observability code and configuration.
+  Checks whether
+  an agent can actually emit MAC Activity telemetry by validating exporter activation,
+  agent identity binding, supported A365 semantic span types, S2S/OBO endpoint selection,
+  and common Python/Node.js/.NET failure modes that cause incidents. Defaults to read-only
+  reporting, then asks before applying safe fixes.
+compatibility:
+  - claude-code
+  - vscode-copilot
+  - github-copilot-cli
+user-invocable: true
+argument-hint: "Optional: path to agent project, or agent id / blueprint id to include in the report"
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, AskUserQuestion, TaskCreate, TaskUpdate, TaskList
+model: sonnet
+hooks:
+  preToolUse:
+    - type: command
+      command: node ${CLAUDE_PLUGIN_ROOT}/hooks/preToolUse/path-guard.js
+      timeout: 5000
+  stop:
+    - type: command
+      command: node ${CLAUDE_PLUGIN_ROOT}/hooks/stop/validate-a365-code-validator.js
+      timeout: 15000
+    - type: prompt
+      prompt: |
+        Verify the validation result was presented to the user with:
+        1. exporter activation status;
+        2. identity binding status (agent id vs blueprint id);
+        3. semantic span coverage (invoke_agent/chat/execute_tool/output_messages);
+        4. endpoint/token mode (S2S vs OBO);
+        5. concrete next debug commands;
+        6. if blockers were found, the user was asked whether to fix now, create a fix plan, or stop.
+        Return {"ok": false, "reason": "<missing item>"} if any item is absent.
+        Otherwise return {"ok": true}.
+      timeout: 30000
+---
+
+# A365 Code Validator
+
+> **Trigger phrases** — any of these will activate this skill automatically:
+> - "validate a365 code"
+> - "run a365 code validator"
+> - "check a365 observability code"
+> - "debug a365 activity missing"
+> - "debug MAC activity for this agent"
+> - "validate Agent 365 telemetry"
+> - "check why Agent Activity is empty"
+> - "check A365 exporter flags"
+> - "validate gen_ai agent id"
+> - "check A365 span types"
+
+---
+
+## Overview
+
+This skill performs a **report-first** validation of an existing agent codebase to answer:
+
+> "If this agent runs now, will its spans reach the A365 backend and become eligible for MAC Activity?"
+
+It is designed for incident response. It checks the exact classes of bugs that cause
+silent or confusing A365 Activity failures:
+
+1. Exporter configured but not actually enabled.
+2. `gen_ai.agent.id` set to a Blueprint ID instead of the runtime Agent Identity / Source Agent ID.
+3. Generic HTTP/OpenAI spans emitted without A365 semantic operations.
+4. S2S/OBO endpoint mismatch.
+5. Missing token resolver or wrong S2S token shape.
+6. MAC reporting expectations confused with raw ingest success.
+
+No source code is modified during validation. After the report, the skill asks whether to
+apply safe fixes, create a fix plan only, or stop.
+
+---
+
+## Phase 0 — Create and Display Task List
+
+> **Show the user this checklist BEFORE Phase 1.** Exactly one task is in progress at a time.
+> Claude Code uses `TaskCreate` / `TaskUpdate`; VS Code Copilot Chat / GitHub Copilot CLI
+> should show and update a markdown checklist.
+
+```text
+TaskCreate: "Detect stack and A365 artifacts"
+TaskCreate: "Run static A365 code validator"
+TaskCreate: "Inspect identity binding and semantic spans"
+TaskCreate: "Prepare runtime verification commands"
+TaskCreate: "Summarize blockers and next fixes"
+TaskCreate: "Offer guided remediation"
+```
+
+---
+
+## Phase 1 — Detect Stack and A365 Artifacts
+
+**Mark task in progress:** "Detect stack and A365 artifacts"
+
+Read, in parallel when possible:
+
+- `.a365-workspace-detection.local.json` if present
+- `a365.config.json`
+- `a365.generated.config.json`
+- `.env`, `.env.example`, `.env.production`, `.env.local`
+- `appsettings.json`, `appsettings.Development.json`
+- `package.json`
+- `requirements.txt`, `pyproject.toml`
+- `*.csproj`
+
+Detect:
+
+| Signal | Meaning |
+|---|---|
+| `microsoft-opentelemetry` | Python A365 distro present |
+| `@microsoft/opentelemetry` | Node.js A365 distro present |
+| `Microsoft.OpenTelemetry` | .NET A365 distro present |
+| `agentBlueprintId` / `agenticAppId` | Distinguish Blueprint ID from runtime Agent Identity |
+| `ENABLE_A365_OBSERVABILITY_EXPORTER` / `EnableAgent365Exporter` | Runtime exporter gate |
+| `authMode` | Drives S2S vs OBO path expectations |
+
+**Mark task complete.**
+
+---
+
+## Phase 2 — Run Static A365 Code Validator
+
+**Mark task in progress:** "Run static A365 code validator"
+
+Run the validator from the target project root.
+
+When running from the plugin source (Claude Code / marketplace plugin), use:
+
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/hooks/stop/validate-a365-code-validator.js
+```
+
+If the runtime cannot expand `${CLAUDE_PLUGIN_ROOT}`, run with the absolute plugin path:
+
+```bash
+node /path/to/agent365-skills/plugins/agent365/hooks/stop/validate-a365-code-validator.js
+```
+
+When running from an open-standard `.agents/skills/a365-code-validator/` install, use the
+standalone copy that ships with the skill:
+
+```bash
+node .agents/skills/a365-code-validator/references/a365-code-validator.js
+```
+
+Parse the JSON output. Treat findings by severity:
+
+| Severity | Meaning |
+|---|---|
+| `critical` | Known MAC Activity blocker — fix before expecting activity |
+| `high` | Likely export or identity failure |
+| `medium` | Risky or env-dependent — verify before incident closure |
+| `low` / `info` | Useful context |
+
+**Important:** Findings are not stop-hook failures. A validation run is successful when it
+accurately reports what is wrong.
+
+**Mark task complete.**
+
+---
+
+## Phase 3 — Inspect Identity Binding and Semantic Spans
+
+**Mark task in progress:** "Inspect identity binding and semantic spans"
+
+Read the reference checklist:
+
+```text
+${CLAUDE_PLUGIN_ROOT}/skills/a365-code-validator/references/validation-checklist.md
+```
+
+Then inspect source for these required MAC Activity inputs:
+
+### 3.1 Exporter activation
+
+Python must have either explicit code:
+
+```python
+use_microsoft_opentelemetry(
+    enable_a365=True,
+    a365_enable_observability_exporter=True,
+)
+```
+
+or a runtime env guarantee:
+
+```text
+ENABLE_A365_OBSERVABILITY_EXPORTER=true
+```
+
+Node.js must have:
+
+```ts
+useMicrosoftOpenTelemetry({
+  a365: {
+    enabled: true,
+    enableObservabilityExporter: true,
+  },
+});
+```
+
+.NET must have:
+
+```json
+"EnableAgent365Exporter": true
+```
+
+### 3.2 Identity binding
+
+Verify the same runtime Agent Identity is used consistently:
+
+```text
+token azp/appid/oid == route /agents/{agentId} == span gen_ai.agent.id
+```
+
+The following is wrong for S2S/MAC Activity:
+
+```text
+gen_ai.agent.id = <blueprint id>
+```
+
+Blueprint belongs in:
+
+```text
+microsoft.a365.agent.blueprint.id
+```
+
+### 3.3 Semantic span coverage
+
+MAC Activity needs supported A365 operations:
+
+```text
+invoke_agent
+chat
+execute_tool
+output_messages
+```
+
+Generic HTTP spans alone are not enough. Flag code that only sets baggage but never
+creates or auto-generates supported semantic spans.
+
+### 3.4 S2S vs OBO transport mode
+
+Do not expose or require internal service URLs in the report. Validate only the structural
+intent:
+
+| Auth mode | Structural expectation |
+|---|---|
+| S2S / application | Uses service-to-service export mode and a token for the runtime Agent Identity |
+| OBO / agentic-user | Uses delegated export mode and a token whose delegated scope includes observability write |
+
+Report whether the code appears to select the correct transport mode (`useS2SEndpoint` /
+`a365_use_s2s_endpoint` / `UseS2SEndpoint`) for S2S, without printing backend route templates.
+
+**Mark task complete.**
+
+---
+
+## Phase 4 — Prepare Runtime Verification Commands
+
+**Mark task in progress:** "Prepare runtime verification commands"
+
+Generate commands appropriate for the project.
+
+### Local / App Service env check
+
+For Azure App Service:
+
+```powershell
+az webapp config appsettings list `
+  -g <resource-group> `
+  -n <app-name> `
+  --query "[?name=='ENABLE_A365_OBSERVABILITY_EXPORTER' || name=='EnableAgent365Exporter' || name=='A365_USE_S2S_ENDPOINT']"
+```
+
+For local PowerShell:
+
+```powershell
+$env:ENABLE_A365_OBSERVABILITY_EXPORTER="true"
+$env:OTEL_LOG_LEVEL="INFO"
+$env:A365_OBSERVABILITY_LOG_LEVEL="debug"
+```
+
+### SDK log grep
+
+```powershell
+Select-String .a365-observability.log -Pattern "Agent365Exporter|identity groups|Obtained token|export|No token|No eligible"
+```
+
+### Backend verification handoff
+
+If backend verification is required, tell the user to use their team's approved telemetry
+playbook or service dashboard to confirm:
+
+1. requests are arriving for the runtime Agent Identity / Source Agent ID,
+2. the request is accepted,
+3. downstream reporting marks the batch as delivered.
+
+Do not include internal cluster names, database names, Kusto queries, private endpoint paths,
+or correlation IDs in the skill output.
+
+**Mark task complete.**
+
+---
+
+## Phase 5 — Summarize Blockers and Next Fixes
+
+**Mark task in progress:** "Summarize blockers and next fixes"
+
+Return a concise report. Default to the short format below; include the optional details block
+only when the user asks for deeper debugging or when a blocker needs a code pointer to be
+actionable.
+
+```markdown
+## A365 Code Validator Result
+
+**Status:** PASS / PASS WITH RISKS / BLOCKED
+
+**Blockers**
+1. **<short title>** — <one-sentence impact>.  
+   Fix: <one-sentence fix>.
+2. **<short title>** — <one-sentence impact>.  
+   Fix: <one-sentence fix>.
+
+**High-risk checks**
+- <short item> — <why to verify>.
+
+**Identity binding**
+- Runtime agent id: <source / missing / from config>
+- Blueprint id: <source / missing / from config>
+- Verdict: <correct | wrong | unclear>
+
+**Semantic spans**
+- Found: <invoke_agent/chat/execute_tool/output_messages or "none">
+- Missing: <ops or "none">
+
+**Recommended fix order**
+1. <fix root cause first>
+2. <then fix config/env>
+3. <then verify spans/identity>
+
+**Optional details**
+- Files: `<file>:<line or function>`, ...
+- Runtime check: <local/App Service env check or SDK log grep>
+- Backend verification: use the team's approved telemetry playbook; do not paste internal
+  cluster names, private endpoints, or correlation IDs into this report.
+```
+
+Style rules:
+- Keep the default report to **8 bullets or fewer**.
+- Put details under **Optional details**, not in the main blocker list.
+- Use exact file/function names for evidence, but do not paste long code blocks.
+- Do not include internal cluster names, database names, Kusto queries, private endpoint paths,
+  tenant IDs, real agent IDs, or correlation IDs.
+- Do not suggest `a365 publish` unless the agent is an AI Teammate / M365 package flow;
+  blueprint-based observability does not use `a365 publish`.
+
+**Mark task complete.**
+
+---
+
+## Phase 6 — Offer Guided Remediation
+
+**Mark task in progress:** "Offer guided remediation"
+
+If there are no `critical` or `high` findings, say:
+
+```markdown
+No blocking fixes needed. Keep the runtime verification commands handy for live validation.
+```
+
+Then mark the task complete and stop.
+
+If there are `critical` or `high` findings, ask the user with `AskUserQuestion`:
+
+```text
+I found blockers. What would you like me to do next?
+```
+
+Options:
+
+| Option | Meaning |
+|---|---|
+| `apply_safe_fixes` | Apply only low-risk, deterministic code/config-template fixes |
+| `make_fix_plan` | Produce an implementation plan, no edits |
+| `report_only` | Stop after the report |
+
+Default: `make_fix_plan`.
+
+### Safe fixes allowed after confirmation
+
+Only apply these automatically when the user chooses `apply_safe_fixes`:
+
+1. **Python exporter kwarg**
+   - If code calls `use_microsoft_opentelemetry(...)` or builds `kwargs` for that call and already
+     sets `enable_a365=True`, add the explicit exporter flag:
+     ```python
+     a365_enable_observability_exporter=True
+     ```
+     or:
+     ```python
+     kwargs["a365_enable_observability_exporter"] = True
+     ```
+   - Preserve existing code style.
+
+2. **Environment templates**
+   - Add missing, commented or empty template entries only:
+     ```text
+     ENABLE_A365_OBSERVABILITY_EXPORTER=true
+     ```
+   - For S2S mode, add the version-appropriate S2S transport setting only if the code/reference for
+     that project already names it. Do not invent a setting name.
+
+3. **Config field scaffolding for runtime agent identity**
+   - If the project already has a settings/config class, add a clearly named optional field such as
+     `agent_identity_app_id` / `AGENT_IDENTITY_APP_ID`.
+   - Use an empty default or placeholder; never hardcode real IDs.
+   - Update `.env.example` if present.
+
+### Fixes that require a second explicit question
+
+Ask a focused follow-up before editing:
+
+1. **Which runtime agent identity config name to use**
+   - Suggested default: `AGENT_IDENTITY_APP_ID` / `agent_identity_app_id`.
+   - Ask if the repo already uses a different naming convention.
+
+2. **Token resolver wiring**
+   - If the project already has a token provider with the required exchange flow, ask whether to
+     wire an observability token resolver to it.
+   - If no such provider exists, do not generate a full token service silently. Provide a plan and
+     ask the user to confirm a follow-up implementation.
+
+3. **Semantic spans**
+   - Ask whether to add only top-level `invoke_agent` / `output_messages` scopes first, or also wrap
+     tools and LLM calls.
+   - Prefer incremental fixes: identity/exporter first, semantic span enrichment second.
+
+### Fix report
+
+After applying fixes, show:
+
+```markdown
+**Applied fixes**
+- ...
+
+**Still needs user input**
+- ...
+
+**Validation to rerun**
+- `validate a365 code`
+- runtime exporter log check
+```
+
+Run the smallest available project tests if the edited repo has an obvious test command and the
+user did not decline validation. Otherwise, state that no obvious test command was run.
+
+**Mark task complete.**

--- a/plugins/agent365/skills/a365-code-validator/references/a365-code-validator.js
+++ b/plugins/agent365/skills/a365-code-validator/references/a365-code-validator.js
@@ -76,6 +76,15 @@ function envTrue(name) {
   return env.some(f => re.test(read(f)));
 }
 
+function envFalse(name) {
+  const re = new RegExp(`^\\s*${name}\\s*=\\s*(false|0|no)\\s*$`, 'im');
+  return env.some(f => re.test(read(f)));
+}
+
+function readJsonSafe(file) {
+  try { return JSON.parse(fs.readFileSync(file, 'utf8')); } catch { return null; }
+}
+
 function callBlocks(content, name) {
   const blocks = [];
   let index = 0;
@@ -105,6 +114,13 @@ function validatePython() {
   const exporterTrue = anyMatches(py, /\ba365_enable_observability_exporter\s*=\s*True\b/);
   const exporterFalse = anyMatches(py, /\ba365_enable_observability_exporter\s*=\s*False\b/);
   const exporterEnv = envTrue('ENABLE_A365_OBSERVABILITY_EXPORTER') || envTrue('EnableAgent365Exporter');
+  const s2sTrue = anyMatches(py, /\ba365_use_s2s_endpoint\s*=\s*True\b/);
+  const s2sFalse = anyMatches(py, /\ba365_use_s2s_endpoint\s*=\s*False\b/);
+  const s2sEnv = envTrue('A365_USE_S2S_ENDPOINT');
+  const s2sIntent = anyContains(py, 'a365_contextual_token_resolver') ||
+    anyContains(py, 'agent_source_identity') ||
+    anyContains(py, 'AgentIdentityTokenResolver') ||
+    s2sEnv;
 
   if (hasPackage && !hasDistro) {
     add('high', 'python-missing-distro-init', 'microsoft-opentelemetry is installed but no use_microsoft_opentelemetry() call was found.', req.find(f => read(f).includes('microsoft-opentelemetry')));
@@ -113,6 +129,19 @@ function validatePython() {
     add('critical', 'python-exporter-explicitly-disabled', 'Python passes a365_enable_observability_exporter=False; A365 backend export is disabled.', py.find(f => /a365_enable_observability_exporter\s*=\s*False\b/.test(read(f))));
   } else if (hasDistro && hasEnableA365 && !exporterTrue && !exporterEnv) {
     add('critical', 'python-exporter-not-enabled', 'Python enables A365 but does not explicitly enable the observability exporter and no truthy exporter env was found.', py.find(f => read(f).includes('use_microsoft_opentelemetry')));
+  } else if (hasDistro && hasEnableA365 && !exporterTrue && exporterEnv) {
+    add('medium', 'python-exporter-env-dependent', 'Python does not pass a365_enable_observability_exporter=True in code and depends on runtime env ENABLE_A365_OBSERVABILITY_EXPORTER/EnableAgent365Exporter being true.', py.find(f => read(f).includes('use_microsoft_opentelemetry')));
+  }
+
+  if (envFalse('ENABLE_A365_OBSERVABILITY_EXPORTER') || envFalse('EnableAgent365Exporter')) {
+    add('high', 'exporter-env-disabled', 'An env file explicitly disables A365 export. This is fine for local console-only runs, but production/MAC Activity requires the exporter to be true.');
+  }
+  if (hasDistro && s2sIntent && s2sFalse) {
+    add('critical', 'python-s2s-endpoint-disabled', 'Python appears to use S2S/Agent Identity export but passes a365_use_s2s_endpoint=False.', py.find(f => /a365_use_s2s_endpoint\s*=\s*False\b/.test(read(f))));
+  } else if (hasDistro && s2sIntent && !s2sTrue && s2sEnv) {
+    add('medium', 'python-s2s-endpoint-env-dependent', 'Python appears to use S2S/Agent Identity export but depends on A365_USE_S2S_ENDPOINT=true in env. Prefer a365_use_s2s_endpoint=True in code.', py.find(f => read(f).includes('use_microsoft_opentelemetry')));
+  } else if (hasDistro && s2sIntent && !s2sTrue && !s2sEnv) {
+    add('high', 'python-s2s-endpoint-not-set', 'Python appears to use S2S/Agent Identity export but does not set a365_use_s2s_endpoint=True or A365_USE_S2S_ENDPOINT=true.', py.find(f => read(f).includes('use_microsoft_opentelemetry')));
   }
 
   for (const file of py) {
@@ -132,6 +161,34 @@ function validatePython() {
     anyContains(py, 'output_messages');
   if (hasDistro && !hasSemantic) {
     add('medium', 'python-no-explicit-a365-semantic-spans', 'No explicit supported A365 semantic spans found; MAC Activity needs invoke_agent/chat/execute_tool/output_messages.');
+  }
+
+  const pythonText = py.map(read).join('\n');
+  const hasInvoke = /InvokeAgentScope|gen_ai\.operation\.name['"]?\s*[:=]|invoke_agent/.test(pythonText);
+  const hasExecuteTool = /ExecuteToolScope|execute_tool/.test(pythonText);
+  const hasAgentName = /gen_ai\.agent\.name|\bagent_name\s*=|AgentDetails\s*\([^)]*agent_name/s.test(pythonText);
+  const hasConversation = /gen_ai\.conversation\.id|\bconversation_id\s*=|\.conversation_id\s*\(/.test(pythonText);
+  const hasChannel = /microsoft\.channel\.name|\bchannel_name\s*=|\.channel_name\s*\(/.test(pythonText);
+  const hasInputMessages = /gen_ai\.input\.messages|record_input_messages|Request\s*\(\s*content\s*=/.test(pythonText);
+  const hasOutputMessages = /gen_ai\.output\.messages|record_output_messages|record_response/.test(pythonText);
+  const hasAgentUser = /microsoft\.agent\.user\.id|\bagent_user_oid\s*=|\.agent_user_id\s*\(/.test(pythonText);
+
+  if (hasDistro && hasInvoke && !hasAgentName) add('medium', 'python-missing-agent-name', 'No gen_ai.agent.name/AgentDetails agent_name signal found. Admin/reporting surfaces may show a GUID or blank agent name.');
+  if (hasDistro && hasInvoke && !hasConversation) add('medium', 'python-missing-conversation-id', 'No gen_ai.conversation.id/conversation_id signal found. Reportable runs need a conversation or logical run ID.');
+  if (hasDistro && hasInvoke && !hasChannel) add('medium', 'python-missing-channel-name', 'No microsoft.channel.name/channel_name signal found. Activity/reporting surfaces need a channel such as msteams, web, icm, or scheduler.');
+  if (hasDistro && hasInvoke && !hasInputMessages) add('medium', 'python-missing-input-messages', 'No gen_ai.input.messages/record_input_messages signal found for invoke/chat spans.');
+  if (hasDistro && hasInvoke && !hasOutputMessages) add('medium', 'python-missing-output-messages', 'No gen_ai.output.messages/record_output_messages/record_response signal found for invoke/chat/output spans.');
+  if (hasDistro && hasExecuteTool) {
+    const hasToolCallId = /gen_ai\.tool\.call\.id|tool_call_id/.test(pythonText);
+    const hasToolArgs = /gen_ai\.tool\.call\.arguments|arguments\s*=/.test(pythonText);
+    const hasToolResult = /gen_ai\.tool\.call\.result|record_response/.test(pythonText);
+    if (!hasToolCallId || !hasToolArgs || !hasToolResult) add('medium', 'python-incomplete-tool-span-details', 'execute_tool spans found, but tool call id/arguments/result are not all visible. Tool activity can be incomplete.');
+  }
+  if (hasDistro && /a365_contextual_token_resolver/.test(pythonText) && /user\.id|\buser_oid\b/.test(pythonText) && !hasAgentUser) {
+    add('medium', 'python-obo-agent-user-attribute-missing', 'Code uses contextual token resolution and user.id/user_oid, but no microsoft.agent.user.id/agent_user_oid signal is visible. OBO/Agent-User export may never trigger.');
+  }
+  if (hasDistro && /OPERATIONS\s*=\s*\[[^\]]*['"]inference['"]|gen_ai\.operation\.name[\s\S]{0,300}['"]inference['"]/.test(pythonText)) {
+    add('medium', 'python-direct-inference-operation-name', 'Code appears to emit gen_ai.operation.name=inference directly. Public docs use chat for LLM spans; direct inference operations may not classify as expected.');
   }
 }
 
@@ -173,19 +230,34 @@ function validateDotnet() {
   if (hasPackage && !hasWiring) {
     add('high', 'dotnet-missing-observability-wiring', 'A365/.NET packages are referenced but no UseMicrosoftOpenTelemetry/AddA365Tracing wiring was found.', csproj.find(f => read(f).includes('Microsoft.OpenTelemetry') || read(f).includes('Microsoft.Agents.A365.Observability')));
   }
-  const prodSettings = appsettings.filter(f => !path.basename(f).toLowerCase().includes('development'));
+  const withExporter = appsettings.filter(f => read(f).includes('EnableAgent365Exporter'));
+  const prodSettings = withExporter.filter(f => !path.basename(f).toLowerCase().includes('development'));
   const disabled = prodSettings.find(f => /"EnableAgent365Exporter"\s*:\s*false/i.test(read(f)));
   if (hasWiring && disabled) {
     add('high', 'dotnet-exporter-disabled', 'Production appsettings has EnableAgent365Exporter:false.', disabled);
+  } else if (hasWiring && withExporter.length === 0) {
+    add('medium', 'dotnet-exporter-config-missing', 'No EnableAgent365Exporter setting found. .NET exporter defaults can be console-only unless production config sets it true.');
   }
   if (hasWiring && !anyContains(cs, 'InvokeAgentScope')) {
     add('medium', 'dotnet-no-invoke-agent-scope', 'No InvokeAgentScope found; MAC Activity needs an invoke_agent parent span.');
   }
 }
 
+function validateSetupArtifacts() {
+  const generated = readJsonSafe(path.join(cwd, 'a365.generated.config.json'));
+  if (!generated) return;
+  if (generated.completed === false) {
+    add('medium', 'a365-generated-config-incomplete', 'a365.generated.config.json has completed:false. Setup may be partial; verify consent/resource grants before expecting MAC Activity.', path.join(cwd, 'a365.generated.config.json'));
+  }
+  if (generated.agentBlueprintId && generated.agenticAppId && generated.agentBlueprintId === generated.agenticAppId) {
+    add('critical', 'blueprint-id-used-as-agent-id', 'a365.generated.config.json has identical blueprint and agentic app IDs. Verify runtime gen_ai.agent.id uses the agent instance/source agent ID, not the blueprint ID.', path.join(cwd, 'a365.generated.config.json'));
+  }
+}
+
 validatePython();
 validateNode();
 validateDotnet();
+validateSetupArtifacts();
 
 const order = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
 findings.sort((a, b) => (order[a.severity] ?? 99) - (order[b.severity] ?? 99));

--- a/plugins/agent365/skills/a365-code-validator/references/a365-code-validator.js
+++ b/plugins/agent365/skills/a365-code-validator/references/a365-code-validator.js
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+//
+// Standalone open-standard runner for the a365-code-validator skill.
+// Keep this dependency-free so it works after scripts/install.js copies only
+// SKILL.md + references/ into .agents/skills/.
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const cwd = process.cwd();
+const skipDirs = new Set(['node_modules', 'dist', 'bin', 'obj', '__pycache__', '.venv', 'venv']);
+const files = [];
+
+function walk(dir, depth = 0) {
+  if (depth > 7) return;
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (full.includes(path.join('plugins', 'agent365', 'hooks')) ||
+        full.includes(path.join('plugins', 'agent365', 'skills', 'a365-code-validator'))) {
+      continue;
+    }
+    if (entry.isDirectory()) {
+      const lowerName = entry.name.toLowerCase();
+      if (entry.name.startsWith('.') || skipDirs.has(entry.name) || lowerName === 'tests' || lowerName === 'test' || lowerName === '__tests__') continue;
+      walk(full, depth + 1);
+    } else if (entry.isFile() && !entry.name.includes('a365-code-validator')) {
+      files.push(full);
+    }
+  }
+}
+
+walk(cwd);
+
+function read(file) {
+  try { return fs.readFileSync(file, 'utf8'); } catch { return ''; }
+}
+
+function rel(file) {
+  return path.relative(cwd, file).replace(/\\/g, '/');
+}
+
+function byName(...names) {
+  return files.filter(f => names.some(n => path.basename(f) === n || path.basename(f).endsWith(n)));
+}
+
+function anyContains(list, pattern) {
+  return list.some(f => read(f).includes(pattern));
+}
+
+function anyMatches(list, regex) {
+  return list.some(f => regex.test(read(f)));
+}
+
+const findings = [];
+function add(severity, id, message, file) {
+  findings.push({ severity, id, message, file: file ? rel(file) : undefined });
+}
+
+const py = byName('.py');
+const ts = byName('.ts', '.js');
+const req = byName('requirements.txt', 'pyproject.toml');
+const pkg = byName('package.json');
+const env = byName('.env', '.env.example', '.env.production', '.env.local');
+const cs = byName('.cs');
+const csproj = byName('.csproj');
+const appsettings = byName('appsettings.json', 'appsettings.Development.json');
+
+function envTrue(name) {
+  const re = new RegExp(`^\\s*${name}\\s*=\\s*(true|1|yes)\\s*$`, 'im');
+  return env.some(f => re.test(read(f)));
+}
+
+function callBlocks(content, name) {
+  const blocks = [];
+  let index = 0;
+  const needle = `${name}(`;
+  while ((index = content.indexOf(needle, index)) !== -1) {
+    const start = index;
+    let depth = 0;
+    let end = -1;
+    for (let i = index + name.length; i < content.length; i++) {
+      if (content[i] === '(') depth++;
+      if (content[i] === ')') {
+        depth--;
+        if (depth === 0) { end = i + 1; break; }
+      }
+    }
+    if (end < 0) break;
+    blocks.push(content.slice(start, end));
+    index = end;
+  }
+  return blocks;
+}
+
+function validatePython() {
+  const hasPackage = req.some(f => read(f).includes('microsoft-opentelemetry'));
+  const hasDistro = anyContains(py, 'use_microsoft_opentelemetry');
+  const hasEnableA365 = anyContains(py, 'enable_a365');
+  const exporterTrue = anyMatches(py, /\ba365_enable_observability_exporter\s*=\s*True\b/);
+  const exporterFalse = anyMatches(py, /\ba365_enable_observability_exporter\s*=\s*False\b/);
+  const exporterEnv = envTrue('ENABLE_A365_OBSERVABILITY_EXPORTER') || envTrue('EnableAgent365Exporter');
+
+  if (hasPackage && !hasDistro) {
+    add('high', 'python-missing-distro-init', 'microsoft-opentelemetry is installed but no use_microsoft_opentelemetry() call was found.', req.find(f => read(f).includes('microsoft-opentelemetry')));
+  }
+  if (hasDistro && hasEnableA365 && exporterFalse) {
+    add('critical', 'python-exporter-explicitly-disabled', 'Python passes a365_enable_observability_exporter=False; A365 backend export is disabled.', py.find(f => /a365_enable_observability_exporter\s*=\s*False\b/.test(read(f))));
+  } else if (hasDistro && hasEnableA365 && !exporterTrue && !exporterEnv) {
+    add('critical', 'python-exporter-not-enabled', 'Python enables A365 but does not explicitly enable the observability exporter and no truthy exporter env was found.', py.find(f => read(f).includes('use_microsoft_opentelemetry')));
+  }
+
+  for (const file of py) {
+    for (const block of callBlocks(read(file), 'a365_request_scope')) {
+      if (block.includes('blueprint_id') && !/\bagent_id\s*=/.test(block)) {
+        add('critical', 'python-blueprint-as-agent-id', 'a365_request_scope passes blueprint_id but no agent_id; gen_ai.agent.id can become the Blueprint ID.', file);
+      }
+    }
+  }
+
+  const hasSemantic = anyContains(py, 'InvokeAgentScope') ||
+    anyContains(py, 'InferenceScope') ||
+    anyContains(py, 'ExecuteToolScope') ||
+    anyContains(py, 'gen_ai.operation.name') ||
+    anyContains(py, 'invoke_agent') ||
+    anyContains(py, 'execute_tool') ||
+    anyContains(py, 'output_messages');
+  if (hasDistro && !hasSemantic) {
+    add('medium', 'python-no-explicit-a365-semantic-spans', 'No explicit supported A365 semantic spans found; MAC Activity needs invoke_agent/chat/execute_tool/output_messages.');
+  }
+}
+
+function validateNode() {
+  const hasPackage = pkg.some(f => read(f).includes('@microsoft/opentelemetry'));
+  const hasDistro = anyContains(ts, 'useMicrosoftOpenTelemetry');
+  const hasEnabled = anyMatches(ts, /\benabled\s*:\s*true\b/);
+  const exporterTrue = anyMatches(ts, /\benableObservabilityExporter\s*:\s*true\b/);
+  const exporterFalse = anyMatches(ts, /\benableObservabilityExporter\s*:\s*false\b/);
+  const exporterEnv = envTrue('ENABLE_A365_OBSERVABILITY_EXPORTER');
+
+  if (hasPackage && !hasDistro) {
+    add('high', 'node-missing-distro-init', '@microsoft/opentelemetry is installed but no useMicrosoftOpenTelemetry() call was found.', pkg.find(f => read(f).includes('@microsoft/opentelemetry')));
+  }
+  if (hasDistro && hasEnabled && exporterFalse) {
+    add('critical', 'node-exporter-explicitly-disabled', 'Node code sets enableObservabilityExporter:false; A365 backend export is disabled.', ts.find(f => /enableObservabilityExporter\s*:\s*false\b/.test(read(f))));
+  } else if (hasDistro && hasEnabled && !exporterTrue && !exporterEnv) {
+    add('critical', 'node-exporter-not-enabled', 'Node code enables A365 but does not enable the exporter and no truthy exporter env was found.', ts.find(f => read(f).includes('useMicrosoftOpenTelemetry')));
+  }
+  const hasIdentity = anyContains(ts, 'BaggageBuilder') || anyContains(ts, 'InvokeAgentScope') || anyContains(ts, 'configureA365Hosting');
+  if (hasDistro && !hasIdentity) {
+    add('high', 'node-missing-identity-scope', 'No BaggageBuilder/InvokeAgentScope/configureA365Hosting usage found; spans may lack agent identity.');
+  }
+  const hasSemantic = anyContains(ts, 'InvokeAgentScope') ||
+    anyContains(ts, 'InferenceScope') ||
+    anyContains(ts, 'ExecuteToolScope') ||
+    anyContains(ts, 'gen_ai.operation.name') ||
+    anyContains(ts, 'invoke_agent') ||
+    anyContains(ts, 'execute_tool') ||
+    anyContains(ts, 'output_messages');
+  if (hasDistro && !hasSemantic) {
+    add('medium', 'node-no-explicit-a365-semantic-spans', 'No explicit supported A365 semantic spans found; baggage alone is not enough for MAC Activity.');
+  }
+}
+
+function validateDotnet() {
+  const hasPackage = csproj.some(f => read(f).includes('Microsoft.OpenTelemetry') || read(f).includes('Microsoft.Agents.A365.Observability'));
+  const hasWiring = anyContains(cs, 'UseMicrosoftOpenTelemetry') || anyContains(cs, 'AddA365Tracing');
+  if (hasPackage && !hasWiring) {
+    add('high', 'dotnet-missing-observability-wiring', 'A365/.NET packages are referenced but no UseMicrosoftOpenTelemetry/AddA365Tracing wiring was found.', csproj.find(f => read(f).includes('Microsoft.OpenTelemetry') || read(f).includes('Microsoft.Agents.A365.Observability')));
+  }
+  const prodSettings = appsettings.filter(f => !path.basename(f).toLowerCase().includes('development'));
+  const disabled = prodSettings.find(f => /"EnableAgent365Exporter"\s*:\s*false/i.test(read(f)));
+  if (hasWiring && disabled) {
+    add('high', 'dotnet-exporter-disabled', 'Production appsettings has EnableAgent365Exporter:false.', disabled);
+  }
+  if (hasWiring && !anyContains(cs, 'InvokeAgentScope')) {
+    add('medium', 'dotnet-no-invoke-agent-scope', 'No InvokeAgentScope found; MAC Activity needs an invoke_agent parent span.');
+  }
+}
+
+validatePython();
+validateNode();
+validateDotnet();
+
+const order = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
+findings.sort((a, b) => (order[a.severity] ?? 99) - (order[b.severity] ?? 99));
+process.stdout.write(JSON.stringify({ ok: true, findingCount: findings.length, findings }, null, 2));

--- a/plugins/agent365/skills/a365-code-validator/references/validation-checklist.md
+++ b/plugins/agent365/skills/a365-code-validator/references/validation-checklist.md
@@ -3,6 +3,11 @@
 Use this checklist when validating whether an agent can emit telemetry that appears in
 Microsoft Admin Center (MAC) Activity.
 
+> **Provenance (verified 2026-07-06):** the resource GUID `9b975845-…`, the `AADSTS*` codes,
+> the `Agent365.Observability.OtelWrite` scope, and the license SKU names in §5 and §8 are
+> preview-era Agent 365 facts and will change. Re-verify against current onboarding docs before
+> quoting them to a customer.
+
 ---
 
 ## 1. Exporter Activation
@@ -109,7 +114,38 @@ Look for:
 
 ---
 
-## 4. Endpoint Selection
+## 4. Activity / Run Context
+
+Exporter success alone does not prove a run is eligible for MAC Activity. Validate the
+documented Agent 365 activity attributes when the developer expects user-facing activity or
+run reporting.
+
+| Attribute | Expectation |
+|---|---|
+| `gen_ai.agent.name` | Human-readable name for display |
+| `gen_ai.conversation.id` | Required; for non-chat/event agents, generate a logical run/job/incident ID |
+| `microsoft.channel.name` | Required; use `msteams` for Teams, or a product/source value such as `icm`, `web`, `scheduler` |
+| `microsoft.session.id` | Optional but recommended for grouping |
+| `user.id` | Human caller OID for `HumanToAgent` |
+| `microsoft.agent.user.id` | Agent's own Agent User OID for AI teammate / Agent-User / OBO |
+| `gen_ai.input.messages` | Required for `invoke_agent` and `chat` |
+| `gen_ai.output.messages` | Required for `invoke_agent`, `chat`, and `output_messages` |
+| `gen_ai.tool.call.id`, `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result` | Required for `execute_tool` |
+| `gen_ai.request.model`, `gen_ai.provider.name` | Required for `chat` |
+
+Run shape should be one root `invoke_agent` span with child `chat`, `execute_tool`, and
+`output_messages` spans sharing the same trace ID and using parent span IDs. Autonomous
+agents do not need to pretend to be Teams chat, but they still need equivalent logical run
+context if Activity/reporting is expected.
+
+Caller identity caveat: for `HumanToAgent`, `user.id` is the caller ID used for "who ran
+this agent" reporting. If `user.id` is missing or contains the agent identity / agent user
+instead of the human caller object ID, export can still succeed while caller/user Activity is
+blank or incomplete.
+
+---
+
+## 5. Endpoint Selection
 
 | Auth mode | Structural transport expectation |
 |---|---|
@@ -128,9 +164,42 @@ OBO / agentic-user uses:
 scp contains Agent365.Observability.OtelWrite
 ```
 
+For Python S2S, prefer setting `a365_use_s2s_endpoint=True` in code. Depending on
+`A365_USE_S2S_ENDPOINT=true` in environment is more fragile and should be called out.
+
+### How the S2S token is minted (the right shape)
+
+A plain client-credentials call for the observability scope fails with `AADSTS82001`
+("agentic application … not permitted to request app-only tokens") — the blueprint can't mint
+it directly. The token must come from the **3-hop FMI exchange**, so its principal equals the
+runtime Agent Identity:
+
+```text
+leg 1: blueprint creds (secret, or MI assertion on Azure) + fmi_path=<agentIdentityAppId>
+        -> assertion T1   (scope api://AzureADTokenExchange/.default)
+leg 3: authenticate AS the agent identity using T1 as the client assertion
+        -> Observability API token (scope api://9b975845-.../.default), azp == agent id, roles:[OtelWrite]
+```
+
+Flag S2S code that mints the obs token with a bare `ClientSecretCredential` /
+`DefaultAzureCredential` against the observability resource: it yields a token whose principal
+is the app/MI, not the agent identity, which the backend rejects (403 — or a 400
+`TenantIdInvalid` when no valid token is bound). `AADSTS500011` here instead means the
+observability resource SP isn't in the tenant (an onboarding gap, not a code fix).
+
 ---
 
-## 5. Runtime Verification
+## 6. Permission Inheritance
+
+Current public Entra Agent ID docs describe both `inheritableScopes` and
+`inheritableRoles` for blueprint permissions. Do not state that application roles can never
+inherit from blueprints. If a tenant/test shows the delegated scope inheriting but the S2S
+app role requiring direct assignment, report it as a provisioning/configuration behavior to
+verify rather than the intended scalable model.
+
+---
+
+## 7. Runtime Verification
 
 SDK logs should show:
 
@@ -150,25 +219,31 @@ No token returned
 401 / 403
 ```
 
-Backend telemetry should show accepted exports for the runtime Agent Identity and delivered
-downstream reporting. Use the service team's approved dashboard or telemetry playbook; do not
-paste internal cluster, database, endpoint, or correlation details into the validator report.
+Customer-accessible validation uses SDK/exporter logs, direct OTel `partialSuccess` where
+available, and Microsoft Defender Advanced Hunting `CloudAppEvents`. Internal service teams
+may additionally use their approved dashboard/playbook, but do not paste internal cluster,
+database, endpoint, or correlation details into the validator report.
 
 ---
 
-## 6. Common Incident Patterns
+## 8. Common Incident Patterns
 
 | Pattern | Fix |
----|---|
+|---|---|
+| Export accepted (200/`sent`) but nothing in MAC | Confirm a user has an M365 E7 / Agent 365 license **assigned** (not just present), and the tenant is Frontier-enrolled |
+| Token fails `AADSTS500011` (resource principal not found) | Observability resource SP isn't in the tenant — Frontier/observability onboarding, not a code fix |
+| S2S token via bare `ClientSecretCredential` → 403 / `AADSTS82001` | Mint via the 3-hop FMI exchange so the principal == runtime Agent Identity (see §5) |
 | Python only passes `enable_a365=True` | Also pass `a365_enable_observability_exporter=True` or set exporter env true |
 | Queue/background job calls baggage helper with only `blueprint_id` | Pass the runtime `agent_id` explicitly |
 | Testbench works but app does not | Testbench manually emits supported spans; app may only emit generic spans |
 | `a365 publish` expected for blueprint observability | Do not use publish; blueprint-based observability is setup + exporter + backend ingest |
 | MAC shows agent but Activity empty | Agent registration exists, but telemetry may not have reached reporting under the agent's ObservabilityId |
+| Export succeeds but Activity remains empty | Check run context: `conversation.id`, `channel.name`, root `invoke_agent`, message payloads, and span parent/child shape |
+| Caller/user activity blank | Check `user.id`; for `HumanToAgent` it must be the human caller's Microsoft Entra object ID |
 
 ---
 
-## 7. Report Style
+## 9. Report Style
 
 Default report should be short and action-oriented:
 
@@ -186,16 +261,8 @@ Default report should be short and action-oriented:
 **Fix order:** token/identity → exporter flag → S2S/OBO mode → semantic spans → backend verification.
 ```
 
-Only add detailed evidence when needed. Keep concrete file/function names; avoid internal
-infrastructure details, real tenant IDs, real agent IDs, correlation IDs, or backend route paths.
+Only add detailed evidence when needed. Keep concrete file/function names and redact per the
+skill's **Output is support-safe** rule.
 
-After the concise report, always offer:
-
-```text
-Do you want me to apply safe fixes, make a fix plan, or stop here?
-```
-
-Do not edit until the user chooses a fix option. Safe fixes are limited to deterministic changes
-such as enabling the exporter flag, adding non-secret config placeholders, and wiring an existing
-runtime agent identity config value into baggage. Token-service implementation and semantic span
-wrapping require a second explicit confirmation because they are design changes.
+The concise report, the "apply safe fixes / make a fix plan / stop" prompt, and the safe-fix
+boundaries are owned by `SKILL.md` Phases 5–6 — follow those. This section is only the example shape.

--- a/plugins/agent365/skills/a365-code-validator/references/validation-checklist.md
+++ b/plugins/agent365/skills/a365-code-validator/references/validation-checklist.md
@@ -1,0 +1,201 @@
+# A365 Code Validator — Reference Checklist
+
+Use this checklist when validating whether an agent can emit telemetry that appears in
+Microsoft Admin Center (MAC) Activity.
+
+---
+
+## 1. Exporter Activation
+
+### Python
+
+Required code:
+
+```python
+use_microsoft_opentelemetry(
+    enable_a365=True,
+    a365_enable_observability_exporter=True,
+)
+```
+
+`enable_a365=True` alone registers A365 processors/enrichment. The exporter is activated by
+`a365_enable_observability_exporter=True` or the environment variable:
+
+```text
+ENABLE_A365_OBSERVABILITY_EXPORTER=true
+```
+
+### Node.js
+
+Required code:
+
+```ts
+useMicrosoftOpenTelemetry({
+  a365: {
+    enabled: true,
+    enableObservabilityExporter: true,
+    tokenResolver,
+  },
+});
+```
+
+### .NET
+
+Required production configuration:
+
+```json
+{
+  "EnableAgent365Exporter": true
+}
+```
+
+---
+
+## 2. Identity Binding
+
+The backend enforces three-way binding:
+
+```text
+token principal == /agents/{agentId} == gen_ai.agent.id
+```
+
+For S2S, the token should be for the runtime Agent Identity / Source Agent ID. Do not use
+the Blueprint ID in `/agents/{agentId}` or `gen_ai.agent.id`.
+
+Correct:
+
+```text
+gen_ai.agent.id = <runtime Agent Identity / Source Agent ID>
+microsoft.a365.agent.blueprint.id = <Blueprint ID>
+```
+
+Incorrect:
+
+```text
+gen_ai.agent.id = <Blueprint ID>
+```
+
+Symptoms:
+
+| Symptom | Likely cause |
+|---|---|
+| Export rejected for Blueprint ID | Blueprint ID used where the runtime Agent Identity is required |
+| Backend accepts export but Activity is empty | Missing semantic spans, unindexed data, or wrong ObservabilityId |
+| No backend export record | Exporter disabled or no eligible identity groups |
+
+---
+
+## 3. Supported Semantic Operations
+
+MAC Activity expects A365 semantic operations:
+
+```text
+invoke_agent
+chat
+execute_tool
+output_messages
+```
+
+Generic HTTP spans are not enough for Activity. They may be useful in raw OTel/App Insights,
+but the Activity reporting path can filter them before user-facing reporting.
+
+Look for:
+
+| Stack | Positive signals |
+|---|---|
+| Python | `InvokeAgentScope`, `InferenceScope`, `ExecuteToolScope`, `gen_ai.operation.name` |
+| Node.js | `InvokeAgentScope.start`, `InferenceScope.start`, `ExecuteToolScope.start` |
+| .NET | `InvokeAgentScope.Start`, `.UseOpenTelemetry()` on `IChatClient` |
+
+---
+
+## 4. Endpoint Selection
+
+| Auth mode | Structural transport expectation |
+|---|---|
+| S2S / application | Service-to-service export mode; token principal is the runtime Agent Identity |
+| OBO / delegated / agentic-user | Delegated export mode; delegated token carries observability write scope |
+
+S2S also requires an Observability API token with:
+
+```text
+roles contains Agent365.Observability.OtelWrite
+```
+
+OBO / agentic-user uses:
+
+```text
+scp contains Agent365.Observability.OtelWrite
+```
+
+---
+
+## 5. Runtime Verification
+
+SDK logs should show:
+
+```text
+identity groups >= 1
+Obtained token for agent <agentId>
+Sending export batch for agent <agentId>
+HTTP 200 exporting spans
+```
+
+Bad signs:
+
+```text
+0 identity groups
+No eligible genAI spans
+No token returned
+401 / 403
+```
+
+Backend telemetry should show accepted exports for the runtime Agent Identity and delivered
+downstream reporting. Use the service team's approved dashboard or telemetry playbook; do not
+paste internal cluster, database, endpoint, or correlation details into the validator report.
+
+---
+
+## 6. Common Incident Patterns
+
+| Pattern | Fix |
+---|---|
+| Python only passes `enable_a365=True` | Also pass `a365_enable_observability_exporter=True` or set exporter env true |
+| Queue/background job calls baggage helper with only `blueprint_id` | Pass the runtime `agent_id` explicitly |
+| Testbench works but app does not | Testbench manually emits supported spans; app may only emit generic spans |
+| `a365 publish` expected for blueprint observability | Do not use publish; blueprint-based observability is setup + exporter + backend ingest |
+| MAC shows agent but Activity empty | Agent registration exists, but telemetry may not have reached reporting under the agent's ObservabilityId |
+
+---
+
+## 7. Report Style
+
+Default report should be short and action-oriented:
+
+```markdown
+**Status:** BLOCKED
+
+**Blockers**
+1. **Exporter not enabled** — spans may be enriched but not exported.
+   Fix: enable the explicit exporter flag or runtime env.
+2. **Wrong agent identity** — runtime spans may use Blueprint ID instead of Agent Identity.
+   Fix: pass the runtime Agent Identity as `agent_id`; keep Blueprint ID only as metadata.
+3. **Semantic spans missing** — generic HTTP spans may not populate Activity.
+   Fix: add/confirm `invoke_agent`, `chat`, `execute_tool`, `output_messages`.
+
+**Fix order:** token/identity → exporter flag → S2S/OBO mode → semantic spans → backend verification.
+```
+
+Only add detailed evidence when needed. Keep concrete file/function names; avoid internal
+infrastructure details, real tenant IDs, real agent IDs, correlation IDs, or backend route paths.
+
+After the concise report, always offer:
+
+```text
+Do you want me to apply safe fixes, make a fix plan, or stop here?
+```
+
+Do not edit until the user chooses a fix option. Safe fixes are limited to deterministic changes
+such as enabling the exporter flag, adding non-secret config placeholders, and wiring an existing
+runtime agent identity config value into baggage. Token-service implementation and semantic span
+wrapping require a second explicit confirmation because they are design changes.

--- a/tests/validate-a365-code-validator-parity.test.js
+++ b/tests/validate-a365-code-validator-parity.test.js
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+'use strict';
+
+// Parity guard: the plugin stop-hook runner and the standalone open-standard
+// runner that ship with the a365-code-validator skill MUST report the same
+// findings. SKILL.md Phase 2 routes plugin installs to the former and
+// `.agents/skills` installs to the latter, so any drift means one install path
+// silently gives a weaker diagnosis. These two files diverged once (the
+// standalone copy was missing the critical `blueprint-id-used-as-agent-id`
+// check plus four others); this test fails if they drift again.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const { createFixture, runValidator, cleanup } = require('./helpers');
+
+const PLUGIN = path.join(__dirname, '../plugins/agent365/hooks/stop/validate-a365-code-validator.js');
+const STANDALONE = path.join(__dirname, '../plugins/agent365/skills/a365-code-validator/references/a365-code-validator.js');
+
+function sortedIds(result) {
+  return (result.findings || []).map(f => f.id).sort();
+}
+
+// Each fixture targets a check that was previously missing from the standalone
+// runner, plus one broad mixed-stack case.
+const fixtures = {
+  'python exporter env-dependent (was missing from standalone)': {
+    'requirements.txt': 'microsoft-opentelemetry>=1.3.4\n',
+    '.env.example': 'ENABLE_A365_OBSERVABILITY_EXPORTER=true\n',
+    'app.py': 'from microsoft.opentelemetry import use_microsoft_opentelemetry\n\nuse_microsoft_opentelemetry(enable_a365=True)\n',
+  },
+  'env explicitly disables exporter (was missing from standalone)': {
+    'requirements.txt': 'microsoft-opentelemetry>=1.3.4\n',
+    '.env': 'ENABLE_A365_OBSERVABILITY_EXPORTER=false\n',
+    'app.py': 'from microsoft.opentelemetry import use_microsoft_opentelemetry\n\nuse_microsoft_opentelemetry(enable_a365=True, a365_enable_observability_exporter=True)\n',
+  },
+  'blueprint id == agentic app id (critical, was missing from standalone)': {
+    'requirements.txt': 'microsoft-opentelemetry>=1.3.4\n',
+    'app.py': 'from microsoft.opentelemetry import use_microsoft_opentelemetry\n\nuse_microsoft_opentelemetry(enable_a365=True, a365_enable_observability_exporter=True)\n',
+    'a365.generated.config.json': JSON.stringify({
+      completed: true,
+      agentBlueprintId: '11111111-1111-1111-1111-111111111111',
+      agenticAppId: '11111111-1111-1111-1111-111111111111',
+    }, null, 2),
+  },
+  'dotnet wiring but no exporter config (was missing from standalone)': {
+    'agent.csproj': '<Project><ItemGroup><PackageReference Include="Microsoft.OpenTelemetry" Version="1.0.0" /></ItemGroup></Project>',
+    'Program.cs': 'builder.Services.UseMicrosoftOpenTelemetry();\n',
+  },
+  'broad mixed python case': {
+    'requirements.txt': 'microsoft-opentelemetry>=1.3.4\n',
+    '.env.example': 'A365_USE_S2S_ENDPOINT=true\n',
+    'app.py': [
+      'from microsoft.opentelemetry import use_microsoft_opentelemetry',
+      '',
+      'use_microsoft_opentelemetry(',
+      '    enable_a365=True,',
+      '    a365_enable_observability_exporter=True,',
+      '    a365_contextual_token_resolver=lambda ctx: "token",',
+      ')',
+      '',
+      'with tracer.start_as_current_span("invoke_agent") as span:',
+      '    span.set_attribute("gen_ai.operation.name", "invoke_agent")',
+    ].join('\n'),
+  },
+};
+
+describe('validate-a365-code-validator parity (plugin runner vs standalone runner)', () => {
+  for (const [label, files] of Object.entries(fixtures)) {
+    test(`identical finding IDs — ${label}`, () => {
+      const dir = createFixture(files);
+      try {
+        const pluginResult = runValidator(PLUGIN, dir);
+        const standaloneResult = runValidator(STANDALONE, dir);
+        assert.equal(pluginResult.ok, true);
+        assert.equal(standaloneResult.ok, true);
+        assert.deepEqual(
+          sortedIds(standaloneResult),
+          sortedIds(pluginResult),
+          `standalone runner drifted from plugin runner.\n` +
+          `  plugin:     ${JSON.stringify(sortedIds(pluginResult))}\n` +
+          `  standalone: ${JSON.stringify(sortedIds(standaloneResult))}`
+        );
+      } finally {
+        cleanup(dir);
+      }
+    });
+  }
+});

--- a/tests/validate-a365-code-validator.test.js
+++ b/tests/validate-a365-code-validator.test.js
@@ -124,6 +124,111 @@ def run(settings):
     }
   });
 
+  test('Python S2S env-only endpoint reports env-dependent finding', () => {
+    const dir = createFixture({
+      'requirements.txt': 'microsoft-opentelemetry>=1.3.4\n',
+      '.env.example': 'A365_USE_S2S_ENDPOINT=true\n',
+      'app.py': `
+from microsoft.opentelemetry import use_microsoft_opentelemetry
+
+use_microsoft_opentelemetry(
+    enable_a365=True,
+    a365_enable_observability_exporter=True,
+    a365_contextual_token_resolver=lambda ctx: "token",
+)
+      `.trim(),
+    });
+
+    try {
+      const result = runValidator(VALIDATOR, dir);
+      assert.equal(result.ok, true);
+      assert.ok(findingIds(result).includes('python-s2s-endpoint-env-dependent'));
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  test('Python missing activity context reports activity field findings', () => {
+    const dir = createFixture({
+      'requirements.txt': 'microsoft-opentelemetry>=1.3.4\n',
+      'app.py': `
+from microsoft.opentelemetry import use_microsoft_opentelemetry
+
+use_microsoft_opentelemetry(enable_a365=True, a365_enable_observability_exporter=True)
+
+def run():
+    with tracer.start_as_current_span("invoke_agent") as span:
+        span.set_attribute("gen_ai.operation.name", "invoke_agent")
+      `.trim(),
+    });
+
+    try {
+      const result = runValidator(VALIDATOR, dir);
+      assert.equal(result.ok, true);
+      const ids = findingIds(result);
+      assert.ok(ids.includes('python-missing-agent-name'));
+      assert.ok(ids.includes('python-missing-conversation-id'));
+      assert.ok(ids.includes('python-missing-channel-name'));
+      assert.ok(ids.includes('python-missing-input-messages'));
+      assert.ok(ids.includes('python-missing-output-messages'));
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  test('Python contextual resolver with only user.id reports OBO agent user gap', () => {
+    const dir = createFixture({
+      'requirements.txt': 'microsoft-opentelemetry>=1.3.4\n',
+      'app.py': `
+from microsoft.opentelemetry import use_microsoft_opentelemetry
+
+use_microsoft_opentelemetry(
+    enable_a365=True,
+    a365_enable_observability_exporter=True,
+    a365_use_s2s_endpoint=True,
+    a365_contextual_token_resolver=lambda ctx: "token",
+)
+
+def run():
+    span.set_attribute("gen_ai.operation.name", "invoke_agent")
+    span.set_attribute("gen_ai.agent.name", "Agent")
+    span.set_attribute("gen_ai.conversation.id", "conv")
+    span.set_attribute("microsoft.channel.name", "msteams")
+    span.set_attribute("gen_ai.input.messages", "[]")
+    span.set_attribute("gen_ai.output.messages", "[]")
+    span.set_attribute("user.id", "agent-user")
+      `.trim(),
+    });
+
+    try {
+      const result = runValidator(VALIDATOR, dir);
+      assert.equal(result.ok, true);
+      assert.ok(findingIds(result).includes('python-obo-agent-user-attribute-missing'));
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  test('Python direct inference operation reports unsupported operation finding', () => {
+    const dir = createFixture({
+      'requirements.txt': 'microsoft-opentelemetry>=1.3.4\n',
+      'app.py': `
+from microsoft.opentelemetry import use_microsoft_opentelemetry
+
+use_microsoft_opentelemetry(enable_a365=True, a365_enable_observability_exporter=True)
+OPERATIONS = ["invoke_agent", "chat", "execute_tool", "output_messages", "inference"]
+      `.trim(),
+    });
+
+    try {
+      const result = runValidator(VALIDATOR, dir);
+      assert.equal(result.ok, true);
+      assert.ok(findingIds(result).includes('python-direct-inference-operation-name'));
+    } finally {
+      cleanup(dir);
+    }
+  });
+
   test('Node baggage-only project reports missing semantic spans', () => {
     const dir = createFixture({
       'package.json': JSON.stringify({

--- a/tests/validate-a365-code-validator.test.js
+++ b/tests/validate-a365-code-validator.test.js
@@ -1,0 +1,188 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const { createFixture, runValidator, cleanup } = require('./helpers');
+
+const VALIDATOR = path.join(__dirname, '../plugins/agent365/hooks/stop/validate-a365-code-validator.js');
+
+function findingIds(result) {
+  return (result.findings || []).map(f => f.id);
+}
+
+describe('validate-a365-code-validator', () => {
+  test('Python enable_a365 without exporter flag reports critical exporter finding', () => {
+    const dir = createFixture({
+      'pyproject.toml': `
+[project]
+dependencies = ["microsoft-opentelemetry>=1.3.4"]
+      `.trim(),
+      'app.py': `
+from microsoft.opentelemetry import use_microsoft_opentelemetry
+
+use_microsoft_opentelemetry(enable_a365=True)
+      `.trim(),
+    });
+
+    try {
+      const result = runValidator(VALIDATOR, dir);
+      assert.equal(result.ok, true);
+      assert.ok(findingIds(result).includes('python-exporter-not-enabled'));
+      assert.equal(
+        result.findings.find(f => f.id === 'python-exporter-not-enabled').severity,
+        'critical'
+      );
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  test('Python queue poller scope with blueprint_id only reports identity binding finding', () => {
+    const dir = createFixture({
+      'requirements.txt': 'microsoft-opentelemetry>=1.3.4\n',
+      'observability.py': `
+from microsoft.opentelemetry import use_microsoft_opentelemetry
+
+use_microsoft_opentelemetry(enable_a365=True, a365_enable_observability_exporter=True)
+      `.trim(),
+      'queue_poller.py': `
+from observability import a365_request_scope
+
+def run_cycle(settings):
+    with a365_request_scope(
+        tenant_id=settings.agent_tenant_id,
+        blueprint_id=settings.agent_blueprint_app_id,
+    ):
+        return "ok"
+      `.trim(),
+    });
+
+    try {
+      const result = runValidator(VALIDATOR, dir);
+      assert.equal(result.ok, true);
+      assert.ok(findingIds(result).includes('python-blueprint-as-agent-id'));
+      assert.equal(
+        result.findings.find(f => f.id === 'python-blueprint-as-agent-id').severity,
+        'critical'
+      );
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  test('Python explicit exporter false reports disabled exporter finding', () => {
+    const dir = createFixture({
+      'requirements.txt': 'microsoft-opentelemetry>=1.3.4\n',
+      'app.py': `
+from microsoft.opentelemetry import use_microsoft_opentelemetry
+
+use_microsoft_opentelemetry(enable_a365=True, a365_enable_observability_exporter=False)
+      `.trim(),
+    });
+
+    try {
+      const result = runValidator(VALIDATOR, dir);
+      assert.equal(result.ok, true);
+      assert.ok(findingIds(result).includes('python-exporter-explicitly-disabled'));
+      assert.equal(
+        result.findings.find(f => f.id === 'python-exporter-explicitly-disabled').severity,
+        'critical'
+      );
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  test('Python explicit exporter and agent_id scope does not report critical Python findings', () => {
+    const dir = createFixture({
+      'requirements.txt': 'microsoft-opentelemetry>=1.3.4\n',
+      'app.py': `
+from microsoft.opentelemetry import use_microsoft_opentelemetry
+
+use_microsoft_opentelemetry(enable_a365=True, a365_enable_observability_exporter=True)
+
+def run(settings):
+    with a365_request_scope(
+        tenant_id=settings.agent_tenant_id,
+        agent_id=settings.agent_identity_app_id,
+        blueprint_id=settings.agent_blueprint_app_id,
+    ):
+        return "ok"
+      `.trim(),
+    });
+
+    try {
+      const result = runValidator(VALIDATOR, dir);
+      assert.equal(result.ok, true);
+      assert.ok(!findingIds(result).includes('python-exporter-not-enabled'));
+      assert.ok(!findingIds(result).includes('python-blueprint-as-agent-id'));
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  test('Node baggage-only project reports missing semantic spans', () => {
+    const dir = createFixture({
+      'package.json': JSON.stringify({
+        name: 'node-agent',
+        dependencies: { '@microsoft/opentelemetry': '^1.0.0' },
+      }, null, 2),
+      'index.ts': `
+import { useMicrosoftOpenTelemetry, BaggageBuilder } from '@microsoft/opentelemetry';
+
+useMicrosoftOpenTelemetry({
+  a365: {
+    enabled: true,
+    enableObservabilityExporter: true,
+    tokenResolver: () => '',
+  },
+});
+
+new BaggageBuilder().build();
+      `.trim(),
+    });
+
+    try {
+      const result = runValidator(VALIDATOR, dir);
+      assert.equal(result.ok, true);
+      assert.ok(findingIds(result).includes('node-no-explicit-a365-semantic-spans'));
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  test('Node explicit exporter false reports disabled exporter finding', () => {
+    const dir = createFixture({
+      'package.json': JSON.stringify({
+        name: 'node-agent',
+        dependencies: { '@microsoft/opentelemetry': '^1.0.0' },
+      }, null, 2),
+      'index.ts': `
+import { useMicrosoftOpenTelemetry } from '@microsoft/opentelemetry';
+
+useMicrosoftOpenTelemetry({
+  a365: {
+    enabled: true,
+    enableObservabilityExporter: false,
+    tokenResolver: () => '',
+  },
+});
+      `.trim(),
+    });
+
+    try {
+      const result = runValidator(VALIDATOR, dir);
+      assert.equal(result.ok, true);
+      assert.ok(findingIds(result).includes('node-exporter-explicitly-disabled'));
+      assert.equal(
+        result.findings.find(f => f.id === 'node-exporter-explicitly-disabled').severity,
+        'critical'
+      );
+    } finally {
+      cleanup(dir);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Add a report-first A365 code validator skill for observability/MAC Activity readiness
- Add static validator checks for exporter activation, identity binding, semantic spans, and setup risks
- Add standalone open-standard validator copy, evals, docs/catalog updates, and unit tests

## Validation
- npm test