### PR TITLE
Add Purview DLP integration skill for Agent 365

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,6 +14,7 @@ Skills for instrumenting and registering Microsoft Agent 365 agents. When a user
 | `add-workiq-tools` | Wire MCP servers (Mail / Calendar / Word / etc.) into the agent | — |
 | `instrument-observability` | OTel + A365 tracing exporter wiring | — |
 | `a365-code-validator` | A365 observability/MAC Activity validation with optional guided fixes | — |
+| `purview-dlp-integration` | Add a Purview DLP gate that blocks sensitive prompts before the LLM | — |
 | `test-local` | Launch agent + AgentsPlayground for local smoke test | — |
 
 Skills are designed to be additive, idempotent, and state-aware — re-running is safe.
@@ -34,6 +35,7 @@ between phases instead of asking permission.
 - `add-workiq-tools`: MCP server selection; Word @mention offer (only when `mcp_WordServer` is selected and stack is Node.js LangChain).
 - `instrument-observability`: agent kind + auth mode (only if not in cache).
 - `a365-code-validator`: after the report, asks whether to apply safe fixes, create a fix plan, or stop.
+- `purview-dlp-integration`: DLP policy choice (new / existing / skip); agentic auth handler name and app id/display name only when not discoverable from a365 config.
 - `test-local`: confirm before launching.
 
 CLI `Allow / Skip` prompts are the chat client's permission flow — not stopping conditions.
@@ -302,6 +304,42 @@ wrapping.
 
 ---
 
+## Skill: purview-dlp-integration
+
+**Full instructions:** [plugins/agent365/skills/purview-dlp-integration/SKILL.md](../plugins/agent365/skills/purview-dlp-integration/SKILL.md)
+
+**Trigger phrases:**
+- "add purview dlp to my agent"
+- "add data loss prevention to my a365 agent"
+- "block credit cards / ssns / pii before my agent's llm sees them"
+- "enforce compliance / audit on agent prompts and responses"
+- "wire a dlp gate into my agent code"
+- "call the graph processContent api from my agent"
+- "add purview blocking to my node.js / python / .net agent"
+
+**Summary of what this skill does:**
+1. Auto-discovers app (client) id, display name, blueprint id, tenant id, and current Graph scopes from `a365.config.json` + `a365.generated.config.json`; asks the customer only for what's missing (DLP policy choice, sensitive info type, admin UPN, agentic auth handler name).
+2. Detects the agent language and picks the matching guard + wiring: Node.js → `assets/purview.ts`, Python → `assets/purview.py`, .NET → `assets/purview.cs` (best-effort port). All three share the same env vars, PowerShell scripts, DLP policy, and `[purview]` log format.
+3. Copies ONE generic, env-driven guard file into the agent source (no edits needed).
+4. Wires two gates into the message handler: the **INPUT gate** calls `processContent(uploadText)` before the LLM (blocks the turn → the LLM is never called), and the optional **OUTPUT gate** calls `processContent(downloadText)` before the reply. Passes the agent's own **agentic delegated** auth handler + handler name + turn context — evaluated as `/me` (the agent identity).
+5. Appends env vars to `.env` — `PURVIEW_DLP_ENABLED` is the only required key on an A365 project (app id / display name / blueprint id are auto-read from the a365 config).
+6. Guides the delegated scope grant via `scripts/Grant-DelegatedGraphScope.ps1` — **appends** `Content.Process.User` to the agent's agentic consent (never `az ad app permission admin-consent` on the blueprint app).
+7. **DLP policy choice (new / existing / skip):** creates a dedicated AI-app policy via `scripts/New-AiAppDlpPolicy.ps1` (Applications / Managed-cloud-apps location, `RestrictAccess=Block` on `UploadText`, `EnforcementPlanes=Application`), reuses an existing one (`-ListExisting`), or skips (guard stays wired but logs `allowed … 0 policyAction(s)` until a matching policy exists).
+8. Verifies via the `[purview] uploadText -> BLOCKED (… errors=0)` log — not `DistributionStatus` (reads `Pending` even for live policies). Confirms tenant prerequisites (pay-as-you-go billing + DSPM-for-AI onboarding).
+
+**Non-negotiable constraints:** agentic delegated token + `/me` (never app-only client credentials on a blueprint app — Graph strips data-plane roles); `contentEntry.name` always set + `processingErrors` fail-closed; dedicated AI-app policy; `RestrictAccess` block on `UploadText`; never `admin-consent` the blueprint app; trust the `[purview]` log, not `DistributionStatus`.
+
+**This skill does NOT:** provision the blueprint, run `a365 setup`, install SDK / MSAL / Graph packages (the guard uses the agent's own auth handler + a plain HTTPS POST), or enable tenant billing / DSPM — it surfaces those as manual admin steps.
+
+**Prerequisite:** an A365 agent with a blueprint (run `a365-setup` / `make-a365-agent` first so values auto-discover). Works standalone on a non-A365 project when you supply the app id, display name, and tenant id.
+
+**Reference patterns:**
+- Guards + wiring: [plugins/agent365/skills/purview-dlp-integration/assets/purview.ts](../plugins/agent365/skills/purview-dlp-integration/assets/purview.ts) · [purview.py](../plugins/agent365/skills/purview-dlp-integration/assets/purview.py) · [purview.cs](../plugins/agent365/skills/purview-dlp-integration/assets/purview.cs)
+- Portal / tenant enablement: [plugins/agent365/skills/purview-dlp-integration/references/purview-portal-guide.md](../plugins/agent365/skills/purview-dlp-integration/references/purview-portal-guide.md)
+- Troubleshooting: [plugins/agent365/skills/purview-dlp-integration/references/troubleshooting.md](../plugins/agent365/skills/purview-dlp-integration/references/troubleshooting.md)
+
+---
+
 ## Skill: test-local
 
 **Full instructions:** [plugins/agent365/skills/test-local/SKILL.md](../plugins/agent365/skills/test-local/SKILL.md)
@@ -361,6 +399,12 @@ All code added by WorkIQ wiring must be marked with the language-appropriate com
 - C# / JavaScript / TypeScript: `// A365 WorkIQ — added by add-workiq-tools skill`
 - Python: `# A365 WorkIQ — added by add-workiq-tools skill`
 
+All best-effort DLP wiring added by `purview-dlp-integration` (notably the .NET port) is marked:
+- C# / JavaScript / TypeScript: `// A365 DLP — best-effort wiring (verify against SDK source before production)`
+- Python: `# A365 DLP — best-effort wiring (verify against SDK source before production)`
+
+The Purview guard files themselves (`purview.ts` / `purview.py` / `purview.cs`) are copied in verbatim — generic and env-driven, no edits needed.
+
 Skills are **additive and idempotent** — never delete or restructure existing agent code.
 
 ## Skill Dependency Chain
@@ -374,6 +418,8 @@ make-ai-teammate  →  instrument-observability  (automatic — part of AI Teamm
 
 make-a365-agent   →  instrument-observability  (Optional — always offered)
                   →  add-workiq-tools          (Optional — skipped when authMode = s2s)
+
+purview-dlp-integration  (additive — run after the agent has a blueprint; independent of observability / WorkIQ)
 
 test-local  (no prerequisite — works after any step)
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Read this before making any changes to skill files.
 
 ## Plugin Purpose
 
-This plugin instruments and configures A365 agents. It contains seven skills:
+This plugin instruments and configures A365 agents. It contains eight skills:
 
 | Skill | Command | Trigger |
 |-------|---------|---------|
@@ -17,6 +17,7 @@ This plugin instruments and configures A365 agents. It contains seven skills:
 | `add-workiq-tools` | `/agent365:add-workiq-tools` | "add workiq tools", "add MCP servers to this agent" |
 | `instrument-observability` | `/agent365:instrument-observability` | "instrument observability", "add a365 observability" |
 | `a365-code-validator` | `/agent365:a365-code-validator` | "validate a365 code", "debug MAC activity", "check A365 exporter flags" |
+| `purview-dlp-integration` | `/agent365:purview-dlp-integration` | "add purview dlp", "block credit cards/PII before the LLM", "add data loss prevention to my agent" |
 | `test-local` | `/agent365:test-local` | "test this agent locally", "open agentsplayground" |
 
 **Supported languages for `make-ai-teammate`:** .NET (AgentFramework · Semantic Kernel) · Node.js (LangChain · OpenAI Agents SDK · Claude SDK · Semantic Kernel · Google ADK) · Python (AgentFramework · LangChain · OpenAI · Claude · Semantic Kernel · Google ADK)
@@ -27,6 +28,8 @@ This plugin instruments and configures A365 agents. It contains seven skills:
 - **.NET:** Agent Framework · Semantic Kernel (different API: `AddToolServersToAgentAsync`, not `GetMcpToolsAsync`) · Azure AI Foundry (best-effort — package published, no Microsoft sample)
 - **Node.js:** LangChain (returns new agent — capture return) · OpenAI Agents SDK (mutates in place) · Claude SDK (first arg is `Options`, mutates in place) · ⚠ Semantic Kernel and Google ADK **hard-stop** (no Microsoft adapter — skill exits at Phase 0B)
 - **Python:** Agent Framework (uses `turn_context=` kwarg, requires `initial_tools=[]`) · OpenAI Agents SDK (uses `context=` kwarg, no `agentic_app_id`) · Google ADK (passes `agentic_app_id`, wraps in `asyncio.wait_for`) · Semantic Kernel and Azure AI Foundry (best-effort — package published, no Microsoft sample) · ⚠ LangChain / Claude SDK / CrewAI **hard-stop** (no Microsoft adapter; Claude and CrewAI samples ship a local DIY `mcp_tool_registration_service.py` scaffold — out of scope for this skill)
+
+**Supported languages for `purview-dlp-integration`:** Node.js (`@microsoft/agents-hosting`) · Python (`microsoft-agents-hosting-*`) · .NET (`Microsoft.Agents.*` — best-effort guard port). One generic env-driven guard + minimal INPUT/OUTPUT gate wiring per language; shared PowerShell scripts, DLP policy, and `[purview]` log format.
 
 **Skill dependency chain:**
 ```
@@ -42,6 +45,7 @@ make-a365-agent  →  instrument-observability  (Observability paths)
                  →  add-workiq-tools          (WorkIQ paths)
 
 a365-code-validator  (report-first; optional safe fixes after confirmation; no prerequisite)
+purview-dlp-integration  (additive DLP gate; needs a blueprint for auto-discovery; independent of observability / WorkIQ)
 test-local  (no prerequisite)
 ```
 `make-ai-teammate` is **idempotent and state-aware**. Phase 0B detects three primary skill-state flags from the project — `has_obs` (observability wired), `has_workiq` (ToolingManifest.json has a non-empty mcpServers array), `disk_blueprint_present` (blueprint already registered, from `.a365-workspace-detection.local.json` / `a365.generated.config.json`). Phase 0C routes through an **8-row state matrix** (rows 1–8 over those flags): full flow → skip-obs → skip-workiq → register-only → no-re-register variants → "everything wired" confirmation (row 8 — sub-question: re-publish or verify-only). The skill creates the hosting layer, agent class, notification handling, full `a365.config.json`. **Phase 9.7.1a is the verification gate** — disk presence (`disk_blueprint_present`) is advisory only; the user is always asked explicitly whether the disk-side blueprint is the intended one before any skip/reuse decision (handles cases where disk lies about tenant state: deleted in Entra, file from another project, agent-name mismatch). If an existing blueprint is found, the skill asks the user explicitly: **Reuse** (skip setup-all), **Re-run** (idempotent — CLI reuses the blueprint ID but refreshes permissions and project settings), or **Fresh** (`a365 cleanup` first, then re-provision — destructive). When no blueprint exists, `a365 setup all --aiteammate --m365` runs unconditionally. (`--m365` is **always passed** for AI Teammate — no user question. Never pass `--authmode` with `--aiteammate` — AI Teammate uses the Agentic User identity.) It then asks **Phase 9.7.2 Run Target** (Prod vs Local), persisted to `.a365-workspace-detection.local.json` with remember-with-confirm on re-runs. For `runTarget = "prod"`: a **Phase 9.7.2b hosting sub-question** follows — *dev tunnel* (Microsoft Dev Tunnel exposing localhost — for in-Teams testing before deploying to a cloud) or *cloud endpoint* (Azure App Service / Container Apps / Functions; AWS App Runner / Lambda + API Gateway / ECS; Google Cloud Run / App Engine / Cloud Functions). The user supplies (or the skill derives) the HTTPS messaging endpoint URL, stored as `chosenEndpoint`. Phase 9.7.2c then **always** re-asserts `chosenEndpoint` on the blueprint via `a365 setup blueprint --update-endpoint <chosenEndpoint> --m365` — run **unconditionally** for AI Teammate prod (mandatory, NOT gated on a config/endpoint diff: the disk `messagingEndpoint` can be stale — dev-tunnel URL rotation, a non-persisted Teams Graph re-registration, or a reused/copied blueprint). Skipped only for `runTarget = "local"` or an empty/placeholder `chosenEndpoint`. (`--m365` is required — without it the CLI silently skips Teams Graph re-registration.) After reconciliation: **verifies** (read-only) the Teams manifest, runs `a365 publish` (packages `manifest.zip` — does NOT upload, does NOT touch the bot endpoint), then walks the user through **two required manual steps**: (a) verify the agent in Teams Developer Portal at `https://dev.teams.microsoft.com/tools/agent-blueprint/<agentBlueprintId>/configuration` — Agent Type=API Based, Notification URL = the reconciled `chosenEndpoint`/`messagingEndpoint` (required for Teams message delivery; the Notification URL is auto-registered by `--update-endpoint --m365` via the Teams Graph proxy on supported tenants — verify it, and set it by hand only as a fallback when the CLI reports automated registration isn't available for the tenant); and (b) request an agent instance from Teams Apps and wait for admin approval at admin.cloud.microsoft. For `runTarget = "local"`: agent runs at `http://localhost:3978/api/messages` (Node.js/Python default) — all publish/Dev-Portal/MAC-upload/instance steps are skipped — the skill routes directly to AgentsPlayground for smoke testing.
@@ -50,6 +54,8 @@ test-local  (no prerequisite)
 `a365-setup` outputs a mandatory intro message, detects stack/language/CEA/`hasBlueprintConfig`, and the three skill-state flags **`has_aiteammate_structure`**, **`has_obs`**, **`has_workiq`** (the same primary flags that drive `make-ai-teammate` Phase 0C's 8-row matrix). Always updates the a365 CLI to latest (explicit exception to the ✅-skip rule), checks for an existing Azure CLI session before logging in, shows a ✅/❌ prerequisite summary and only processes ❌ missing tools. Asks the blueprint question (reuse vs fresh) then asks **capabilities first** — capability options are auto-filtered: Observability is hidden if `has_obs = true`, WorkIQ is hidden if `has_workiq = true`, the menu collapses to Register + WorkIQ when `(has_aiteammate_structure && has_obs)` (legacy "already an AI Teammate" route, computed inline — the legacy `hasAITeammateChanges` field is **derived, no longer stored**). If AI Teammate is selected, auth mode is skipped (always `agentic-user`); if non-AI Teammate, asks `obo` or `s2s`. Cache fields written: `agentStack`, `programmingLanguage`, `usesTeamsOrCopilot`, `hasBlueprintConfig`, `has_aiteammate_structure`, `has_obs`, `has_workiq`, `agentType`, `authMode`, `reuseBlueprint`, `existingBlueprintId`. Delegates: AI Teammate path → `make-ai-teammate`; all other paths → `make-a365-agent`.
 `make-a365-agent` checks for an existing blueprint config before collecting inputs — if found, asks the developer whether to reuse (skips `a365 setup all`) or create fresh. Runs `a365 setup all --authmode obo|s2s` for non-AI Teammate paths; add `--m365` for CEA agents and follow with `a365 setup permissions bot`. `Agent365.Observability.OtelWrite` is auto-granted at provisioning, but other permission grants (Graph, Bot API, custom resources) require Global Administrator consent — when the developer isn't a GA, `a365 setup all` automatically prints next-steps (typically a PowerShell script) for a GA to complete. There is no separate `setup admin` subcommand. Then conditionally invokes `instrument-observability` and `add-workiq-tools`.
 `add-workiq-tools` and `instrument-observability` read `.a365-workspace-detection.local.json` to skip re-detection and verify prerequisites. `add-workiq-tools` Phase 0B includes a **framework support guard** that hard-stops on unsupported `(programmingLanguage, agentStack)` pairs (Python LangChain / Claude / CrewAI; Node.js Semantic Kernel / Google ADK) before any CLI command runs. Phase 4 branches on the cached `agentStack` into 11 framework-specific sub-sections (§4.1 .NET Agent Framework through §4.11 Python Azure AI Foundry); the stop-hook validator (`validate-add-workiq-tools.js`) is also framework-aware and requires the framework-matching symbol (e.g., `AddToolServersToAgentAsync` for .NET SK, `add_tool_servers_to_agent` for Python). **Phase 4.5 (gated)** offers the Word `@mention` notification handler when *both* gates pass: `programmingLanguage = NodeJS && agentStack = LangChain`, AND `mcp_WordServer` is in `ToolingManifest.json`. Wires `proactive: {}`, per-user conversation index, and a `NotificationType.WpxComment` branch — best-effort because no Microsoft Node.js sample is published yet. Best-effort branches (Python SK, Python/.NET Azure AI Foundry, and the Phase 4.5 @mention handler) mark all generated lines with `// A365 WorkIQ — best-effort wiring (verify against SDK source before production)`.
+
+`purview-dlp-integration` is **additive** and independent of observability / WorkIQ. It auto-discovers the app (client) id, display name, blueprint id, and current Graph scopes from `a365.config.json` + `a365.generated.config.json`, then asks only for what's missing (DLP policy choice, sensitive info type, admin UPN, agentic auth handler name). It detects the agent language and copies ONE generic env-driven guard (`assets/purview.ts` / `purview.py` / `purview.cs` — the .NET guard is a best-effort port), then applies minimal wiring: an **INPUT gate** that calls the Graph `processContent` API before the LLM (blocks the turn → the LLM is never called) and an optional **OUTPUT gate** before the reply. The guard uses the agent's own **agentic delegated** token evaluated as `/me` (never app-only client credentials on a blueprint app), always sets `contentEntry.name`, and fails closed. It guides the delegated `Content.Process.User` scope grant (`scripts/Grant-DelegatedGraphScope.ps1` — appends, never `admin-consent` on the blueprint app) and a DLP-policy choice (new via `scripts/New-AiAppDlpPolicy.ps1`, existing via `-ListExisting`, or skip). Success is judged by the `[purview] uploadText -> BLOCKED (… errors=0)` log, not `DistributionStatus`. The stop-hook validator (`validate-purview-dlp-integration.js`) is report-first (advisory findings, never blocks) because the skill supports a legitimate "start disabled / skip policy" bring-up state.
 
 The skills are designed to be **non-destructive**, **idempotent**, and **additive**.
 They read before writing, ask before doing anything risky, and leave the codebase
@@ -91,6 +97,11 @@ plugins/agent365/
 │   │       ├── dotnet-workiq.md  # .NET MCP tool patterns
 │   │       ├── nodejs-workiq.md  # Node.js MCP tool patterns
 │   │       └── python-workiq.md  # Python MCP tool patterns
+│   ├── purview-dlp-integration/
+│   │   ├── SKILL.md              # Purview DLP guard + gate wiring (Node.js / Python / .NET)
+│   │   ├── assets/              # Guards (purview.ts/py/cs), wiring snippets, env example
+│   │   ├── references/          # Portal/tenant enablement guide + troubleshooting
+│   │   └── scripts/             # Grant-DelegatedGraphScope.ps1, New-AiAppDlpPolicy.ps1
 │   └── test-local/
 │       └── SKILL.md              # AgentsPlayground local testing
 ├── shared/
@@ -104,6 +115,7 @@ plugins/agent365/
 │       ├── validate-make-a365-agent.js   # Stop hook validator for make-a365-agent
 │       ├── validate-instrument-observability.js  # Stop hook validator — build check included
 │       ├── validate-add-workiq-tools.js  # Stop hook validator — build check included
+│       ├── validate-purview-dlp-integration.js  # Stop hook validator — report-first (advisory findings)
 │       └── validate-test-local.js
 └── AGENTS.md                     # This file
 ```
@@ -121,6 +133,8 @@ evals/
     ├── instrument-observability/
     │   └── evals.json
     ├── add-workiq-tools/
+    │   └── evals.json
+    ├── purview-dlp-integration/
     │   └── evals.json
     └── test-local/
         └── evals.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ agent365-skills/
 │       │   ├── instrument-observability/SKILL.md      # OTel + A365 tracing exporter instrumentation
 │       │   ├── a365-code-validator/SKILL.md           # Observability/MAC Activity validation + guided fixes
 │       │   ├── add-workiq-tools/SKILL.md              # WorkIQ MCP server wiring
+│       │   ├── purview-dlp-integration/SKILL.md       # Purview DLP guard + gate wiring (Node.js / Python / .NET)
 │       │   └── test-local/SKILL.md                    # Local testing with AgentsPlayground
 │       ├── hooks/
 │       │   ├── preToolUse/path-guard.js               # Blocks writes outside project root
@@ -29,6 +30,7 @@ agent365-skills/
 │       │       ├── validate-make-ai-teammate.js
 │       │       ├── validate-instrument-observability.js
 │       │       ├── validate-add-workiq-tools.js
+│       │       ├── validate-purview-dlp-integration.js
 │       │       └── validate-test-local.js
 │       └── shared/agent-detection.md  # Shared heuristics for detecting agent type and authMode
 ├── tests/                             # Unit tests for stop hook validators
@@ -36,7 +38,8 @@ agent365-skills/
 │   ├── validate-a365-setup.test.js
 │   ├── validate-make-a365-agent.test.js
 │   ├── validate-observability.test.js
-│   └── validate-workiq.test.js
+│   ├── validate-workiq.test.js
+│   └── validate-purview-dlp-integration.test.js
 ├── evals/
 │   └── agent365/                      # Evaluation test cases (one per skill)
 │       ├── a365-setup/evals.json
@@ -44,6 +47,7 @@ agent365-skills/
 │       ├── make-ai-teammate/evals.json
 │       ├── instrument-observability/evals.json
 │       ├── add-workiq-tools/evals.json
+│       ├── purview-dlp-integration/evals.json
 │       └── test-local/evals.json
 ├── scripts/install.js                 # One-liner installer for Claude Code + Copilot CLI
 ├── AGENTS.md                          # Top-level contributor guidelines
@@ -108,6 +112,15 @@ agent365-skills/
    available. It then asks whether to apply safe fixes, create a fix plan, or stop. It must
    not provision, install packages, mutate Graph, grant permissions, or run `a365 publish`.
 
+12. **`purview-dlp-integration` is additive and report-first-validated.** It copies one generic
+   env-driven guard (`purview.ts` / `purview.py` / `purview.cs`) and wires an INPUT gate before
+   the LLM + an optional OUTPUT gate. The guard uses the agent's **agentic delegated** token
+   evaluated as `/me` (never app-only client credentials on a blueprint app), always sets
+   `contentEntry.name`, and fails closed. Never run `az ad app permission admin-consent` on the
+   blueprint app — append the `Content.Process.User` scope instead. Its validator
+   (`validate-purview-dlp-integration.js`) is report-first (advisory `findings`, always
+   `ok: true`) because "start disabled / skip policy" is a valid bring-up state.
+
 ---
 
 ## Testing
@@ -142,4 +155,4 @@ For comprehensive eval test cases, see [evals/README.md](evals/README.md).
 
 ## Allowed commands
 
-`dotnet *`, `npm *`, `node *`, `python *`, `python3 *`, `pip *`, `pip3 *`, `uv *`, `a365 *`, `az *`, `devtunnel *`, `agentsplayground *`, `git *`, `grep *`, `find *`, `cat *`, `ls *`
+`dotnet *`, `npm *`, `node *`, `python *`, `python3 *`, `pip *`, `pip3 *`, `uv *`, `a365 *`, `az *`, `pwsh *`, `devtunnel *`, `agentsplayground *`, `git *`, `grep *`, `find *`, `cat *`, `ls *`

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ a365-setup  (recommended entry point — handles CLI, Azure, Blueprint)
 
 test-local  ← standalone; run at any point to test your agent locally
 a365-code-validator  ← standalone; run at any point to diagnose MAC Activity / telemetry readiness
+purview-dlp-integration  ← standalone; add a Purview DLP gate that blocks sensitive prompts before the LLM
 ```
 
 `a365-setup` writes `.a365-workspace-detection.local.json`. All downstream skills read this file to skip re-detection.
@@ -133,6 +134,7 @@ The file is safe to delete — the next `a365-setup` run rebuilds it. Skills als
 "Add observability to this agent"   → instrument-observability
 "Validate A365 code"                → a365-code-validator    (diagnostics + optional guided fixes)
 "Add WorkIQ tools to this agent"    → add-workiq-tools
+"Add Purview DLP to this agent"     → purview-dlp-integration
 "Test this agent locally"           → test-local
 ```
 
@@ -279,6 +281,35 @@ change permissions, mutate Graph, or publish manifests.
 "Check A365 observability code"      "Debug MAC Activity for this agent"
 "Check why Agent Activity is empty"  "Validate gen_ai agent id"
 "Check A365 exporter flags"          "Check A365 span types"
+```
+
+---
+
+### `purview-dlp-integration` — Block Sensitive Data with Purview DLP
+
+Adds a Microsoft Purview **data-loss-prevention gate** around your agent's LLM call. Every turn's
+prompt (and optionally the response) is evaluated via the Graph `processContent` API and **blocked**
+when a DLP policy matches — the LLM is never called on a blocked turn, and `processContent` also
+writes the Purview audit event. **Additive and reversible:** it copies one generic, env-driven guard
+(`purview.ts` / `purview.py` / `purview.cs`) next to your agent class and applies minimal INPUT/OUTPUT
+gate wiring. The guard uses the agent's own **agentic delegated** token evaluated as `/me` (never
+app-only client credentials), always sets `contentEntry.name`, and fails closed by default.
+
+It auto-discovers the app id, display name, and blueprint id from `a365.config.json` /
+`a365.generated.config.json`, guides the delegated `Content.Process.User` scope grant (appends —
+never `admin-consent` on the blueprint app), and lets you **create a new** DLP policy, **reuse an
+existing** one, or **skip**. Works with Node.js (`@microsoft/agents-hosting`), Python
+(`microsoft-agents-hosting-*`), and .NET (`Microsoft.Agents.*`, best-effort guard port).
+
+> **Prerequisite:** an A365 agent with a blueprint (run `a365-setup` first for auto-discovery).
+> Works standalone on a non-A365 project if you supply the app id, display name, and tenant id.
+
+**Trigger phrases:**
+```
+"Add Purview DLP to my agent"            "Add data loss prevention to my A365 agent"
+"Block credit cards before the LLM"      "Block SSNs / PII in my agent turns"
+"Enforce compliance on agent prompts"    "Wire a DLP gate into my agent code"
+"Call the Graph processContent API"      "Add Purview blocking to my Python agent"
 ```
 
 ---

--- a/evals/README.md
+++ b/evals/README.md
@@ -20,6 +20,8 @@ evals/
     │   └── evals.json                # 5 test cases
     ├── a365-code-validator/
     │   └── evals.json                # 10 test cases
+    ├── purview-dlp-integration/
+    │   └── evals.json                # 4 test cases
     └── test-local/
         └── evals.json                # 5 test cases
 ```
@@ -48,6 +50,8 @@ Exceptions:
 - `test-local` can run without the cache.
 - `a365-code-validator` can run without the cache because it is read-only and performs its own
   static inspection.
+- `purview-dlp-integration` can run without the cache — it reads `a365.config.json` /
+  `a365.generated.config.json` directly (or takes the app id / display name / tenant id from you).
 
 ---
 
@@ -63,6 +67,7 @@ To manually test a skill against an eval:
    - `add-workiq-tools`: An agent already transformed by `make-ai-teammate` (has `.a365-workspace-detection.local.json`)
    - `instrument-observability`: An agent already transformed by `make-ai-teammate`
    - `a365-code-validator`: Any existing agent project; no setup prerequisite, read-only
+   - `purview-dlp-integration`: An A365 agent with a blueprint (for auto-discovery), or supply the app id / display name / tenant id
    - `test-local`: Any agent with a build script or `dotnet run` / `uv run`
 
 2. **Start Claude** with the plugin loaded:

--- a/evals/agent365/purview-dlp-integration/evals.json
+++ b/evals/agent365/purview-dlp-integration/evals.json
@@ -1,0 +1,93 @@
+{
+  "skill_name": "purview-dlp-integration",
+  "eval_instructions": "Run these evals against existing A365 agent projects or minimal fixtures. This skill is additive and reversible: it copies one guard file, applies minimal handler wiring (an INPUT gate before the LLM and an optional OUTPUT gate before the reply), appends env vars, and guides the delegated Graph scope grant + DLP policy choice. Verify it uses the agent's own agentic delegated token evaluated as /me (never app-only client credentials, never admin-consent on the blueprint app), always sets contentEntry.name, fails closed by default, and picks the guard/wiring matching the detected language. It must ask which DLP policy to use (new / existing / skip) unless the user already specified it.",
+  "trigger_tests": {
+    "instructions": "Run each prompt in a fresh session with the full agent365 skill library loaded. should_trigger prompts must activate purview-dlp-integration. should_not_trigger prompts must activate the named sibling (or no skill) and must NOT activate purview-dlp-integration — they guard the DLP-vs-observability/tools boundary. Report hit rate in each direction (>=2 runs each).",
+    "should_trigger": [
+      "Add Purview DLP to my A365 agent",
+      "Block credit cards before my agent's LLM sees them",
+      "Add data loss prevention to my Node.js agent",
+      "Enforce compliance and audit on my agent's prompts and responses",
+      "Wire a DLP gate into my agent code",
+      "Block SSNs and PII in my agent turns",
+      "Call the Graph processContent API to block sensitive data in my agent",
+      "Add Purview blocking to my Python agent",
+      "Stop my agent from sending credit card numbers to the model"
+    ],
+    "should_not_trigger": [
+      { "prompt": "Instrument observability for this agent", "expected_skill": "instrument-observability" },
+      { "prompt": "Debug why MAC Activity is empty for this agent", "expected_skill": "a365-code-validator" },
+      { "prompt": "Add WorkIQ mail and calendar tools to my agent", "expected_skill": "add-workiq-tools" },
+      { "prompt": "Register this agent with Agent 365 and create a blueprint", "expected_skill": "make-a365-agent" },
+      { "prompt": "Turn my agent into an AI Teammate", "expected_skill": "make-ai-teammate" },
+      { "prompt": "Run my agent locally in AgentsPlayground", "expected_skill": "test-local" },
+      { "prompt": "Set up the A365 CLI and Azure prerequisites", "expected_skill": "a365-setup" }
+    ]
+  },
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Add Purview DLP to my A365 agent and block credit card numbers before the LLM",
+      "description": "Node.js @microsoft/agents-hosting agent with a365.config.json + a365.generated.config.json present; user wants a new DLP policy.",
+      "expected_output": "The skill detects Node.js, reads the a365 config for app id/display name/blueprint id, copies assets/purview.ts next to the agent class, applies the wiring snippet (INPUT gate before the LLM, OUTPUT gate before the reply) passing this.authorization, appends PURVIEW_DLP_ENABLED=true to .env, guides Grant-DelegatedGraphScope.ps1 to append Content.Process.User, asks which policy to use and (default) runs New-AiAppDlpPolicy.ps1, then explains the [purview] BLOCKED verify log.",
+      "files": [],
+      "expectations": [
+        "Step 0: Detects Node.js/TypeScript via package.json (@microsoft/agents-hosting)",
+        "Before-you-start: Reads a365.config.json / a365.generated.config.json for app id, display name, blueprint id, and current Graph scopes",
+        "Step 2: Copies assets/purview.ts (the guard) into the agent source unchanged",
+        "Step 3: Wires the INPUT gate before the LLM call and the OUTPUT gate before the reply, passing this.authorization + turn context",
+        "Step 4: Appends PURVIEW_DLP_ENABLED=true to .env",
+        "Step 5: Runs Grant-DelegatedGraphScope.ps1 to APPEND Content.Process.User (never az ad app permission admin-consent on the blueprint app)",
+        "Step 6: Asks new / existing / skip, then runs New-AiAppDlpPolicy.ps1 for the new policy (default SIT Credit Card Number)",
+        "Constraints: Uses the agentic delegated token evaluated as /me; always sets contentEntry.name; fails closed by default",
+        "Step 8: Verifies with a Luhn-valid test value and judges success by the [purview] uploadText -> BLOCKED (errors=0) log, not DistributionStatus"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Add data loss prevention to this Python agent using my existing 'Corp PII' policy",
+      "description": "Python microsoft-agents-hosting-core agent; user already has a DLP policy and does NOT want a new one.",
+      "expected_output": "The skill detects Python, copies assets/purview.py, wires evaluate_prompt/evaluate_response passing auth, auth_handler_name, and context, appends the env vars, and for the existing-policy path runs New-AiAppDlpPolicy.ps1 -ListExisting to confirm the app id is covered — creating nothing new. It does not create a new policy.",
+      "files": [],
+      "expectations": [
+        "Step 0: Detects Python via pyproject.toml / requirements.txt (microsoft-agents-hosting-*)",
+        "Step 2: Copies assets/purview.py (the guard) into the agent source",
+        "Step 3: Wires the gates in process_user_message passing auth, auth_handler_name, context (already handler parameters)",
+        "Step 6 Option B: Runs ./New-AiAppDlpPolicy.ps1 -ListExisting and checks whether the chosen policy COVERS THIS APP",
+        "Step 6 Option B: If the policy already covers the app id, creates nothing and confirms Mode=Enable + a RestrictAccess/Block rule on UploadText",
+        "Does NOT create a new DLP policy",
+        "Constraints: agentic delegated token via authorization.exchange_token(...); fail-closed default"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Wire a Purview DLP gate into my .NET agent but I'll add the policy myself later",
+      "description": ".NET Microsoft.Agents.* agent; user chooses to skip policy creation (Option C).",
+      "expected_output": "The skill detects .NET, warns the .NET guard is a best-effort port, copies assets/purview.cs, wires OnMessageAsync (PurviewGuard.Instance.EvaluatePromptAsync/EvaluateResponseAsync passing UserAuthorization + agentic handler name + turnContext), appends PURVIEW_DLP_ENABLED, and for Option C creates no policy — explaining the guard stays enabled but logs 'allowed ... 0 policyAction(s)' until the user adds a matching Applications/Managed-cloud-apps policy with a RestrictAccess=Block rule and EnforcementPlanes=Application.",
+      "files": [],
+      "expectations": [
+        "Step 0: Detects .NET via *.csproj (Microsoft.Agents.*) and flags the .NET guard as best-effort (verify ITurnContext / UserAuthorization namespaces)",
+        "Step 2: Copies assets/purview.cs into the agent source",
+        "Step 3: Wires OnMessageAsync passing UserAuthorization, the agentic auth handler name, and turnContext",
+        "Step 6 Option C: Creates no policy; explains the guard logs 'allowed ... 0 policyAction(s)' until a matching policy exists",
+        "Step 6 Option C: Lists the 6 required policy properties (Applications location, EnforcementPlanes=Application, SIT condition, RestrictAccess=Block on UploadText, Mode=Enable, optional notify)",
+        "Constraints: Never runs az ad app permission admin-consent on the blueprint app",
+        "Marks best-effort wiring with the A365 DLP best-effort comment"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Block sensitive data in my agent — it's a plain Node.js bot, not provisioned with Agent 365 yet",
+      "description": "Non-A365 project with no a365.config.json; the auto-discovery path has nothing to read.",
+      "expected_output": "The skill recognizes there is no a365 config, so it asks the customer for the Entra app (client) id, display name, and tenant id, and passes them explicitly to PURVIEW_APP_ID / PURVIEW_APP_NAME and the scripts. It still copies the guard, wires the gates, and guides the scope + policy steps.",
+      "files": [],
+      "expectations": [
+        "Before-you-start: Detects there is no a365.config.json / a365.generated.config.json",
+        "Before-you-start: Asks for app id, display name, and tenant id directly and passes them explicitly to env + scripts",
+        "Step 2: Copies the guard and Step 3 wires the gates as usual",
+        "Step 4: Sets PURVIEW_APP_ID and PURVIEW_APP_NAME explicitly (no auto-discovery available)",
+        "Does not fabricate an app id or blueprint id"
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agent365-skills",
   "version": "1.0.2",
   "private": true,
-  "description": "Skills for Microsoft Agent 365 — transform agents into AI Teammates, register blueprints, add WorkIQ MCP servers, instrument observability, validate telemetry readiness, and test locally. Supports .NET (AgentFramework, Semantic Kernel) and Node.js (LangChain, OpenAI Agents SDK, Claude SDK, Semantic Kernel, Google ADK) and Python (AgentFramework, LangChain, OpenAI, Claude, Semantic Kernel, Google ADK).",
+  "description": "Skills for Microsoft Agent 365 — transform agents into AI Teammates, register blueprints, add WorkIQ MCP servers, instrument observability, validate telemetry readiness, integrate Purview DLP, and test locally. Supports .NET (AgentFramework, Semantic Kernel) and Node.js (LangChain, OpenAI Agents SDK, Claude SDK, Semantic Kernel, Google ADK) and Python (AgentFramework, LangChain, OpenAI, Claude, Semantic Kernel, Google ADK).",
   "license": "MIT",
   "author": {
     "name": "Microsoft",
@@ -28,11 +28,14 @@
     "blueprint",
     "s2s",
     "msal",
-    "ai-teammate"
+    "ai-teammate",
+    "purview",
+    "dlp",
+    "compliance"
   ],
   "scripts": {
     "test": "node --test tests/*.test.js",
-    "validate": "node plugins/agent365/hooks/stop/validate-a365-setup.js && node plugins/agent365/hooks/stop/validate-make-a365-agent.js && node plugins/agent365/hooks/stop/validate-make-ai-teammate.js && node plugins/agent365/hooks/stop/validate-instrument-observability.js && node plugins/agent365/hooks/stop/validate-a365-code-validator.js && node plugins/agent365/hooks/stop/validate-add-workiq-tools.js && node plugins/agent365/hooks/stop/validate-test-local.js"
+    "validate": "node plugins/agent365/hooks/stop/validate-a365-setup.js && node plugins/agent365/hooks/stop/validate-make-a365-agent.js && node plugins/agent365/hooks/stop/validate-make-ai-teammate.js && node plugins/agent365/hooks/stop/validate-instrument-observability.js && node plugins/agent365/hooks/stop/validate-a365-code-validator.js && node plugins/agent365/hooks/stop/validate-add-workiq-tools.js && node plugins/agent365/hooks/stop/validate-test-local.js && node plugins/agent365/hooks/stop/validate-purview-dlp-integration.js"
   },
   "engines": {
     "node": ">=18"

--- a/plugins/agent365/.claude-plugin/plugin.json
+++ b/plugins/agent365/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "agent365",
   "version": "1.0.2",
-  "description": "Skills for Microsoft Agent 365 — transform agents into AI Teammates, register blueprints, add WorkIQ MCP servers, instrument observability, and test locally. Supports .NET (AgentFramework, Semantic Kernel) and Node.js (LangChain, OpenAI Agents SDK, Claude SDK, Semantic Kernel, Google ADK) and Python (AgentFramework, LangChain, OpenAI, Claude, Semantic Kernel, Google ADK).",
+  "description": "Skills for Microsoft Agent 365 — transform agents into AI Teammates, register blueprints, add WorkIQ MCP servers, instrument observability, integrate Purview DLP, and test locally. Supports .NET (AgentFramework, Semantic Kernel) and Node.js (LangChain, OpenAI Agents SDK, Claude SDK, Semantic Kernel, Google ADK) and Python (AgentFramework, LangChain, OpenAI, Claude, Semantic Kernel, Google ADK).",
   "author": {
     "name": "Microsoft",
     "url": "https://github.com/microsoft"
@@ -9,7 +9,7 @@
   "repository": "https://github.com/microsoft/agent365-skills/",
   "homepage": "https://github.com/microsoft/agent365-skills",
   "license": "MIT",
-  "keywords": ["agent365", "microsoft", "observability", "opentelemetry", "workiq", "mcp", "langchain", "dotnet", "python", "semantic-kernel", "google-adk", "blueprint", "s2s", "msal", "ai-teammate"],
+  "keywords": ["agent365", "microsoft", "observability", "opentelemetry", "workiq", "mcp", "langchain", "dotnet", "python", "semantic-kernel", "google-adk", "blueprint", "s2s", "msal", "ai-teammate", "purview", "dlp"],
   "skills": "./skills/",
   "hooks": {
     "SessionStart": [

--- a/plugins/agent365/hooks/stop/validate-purview-dlp-integration.js
+++ b/plugins/agent365/hooks/stop/validate-purview-dlp-integration.js
@@ -38,7 +38,6 @@ const allFiles = scanProject(cwd, { maxDepth: 7 })
   .filter(f => !path.basename(f).includes('validate-purview-dlp-integration'))
   .filter(f => !f.includes(path.join('plugins', 'agent365', 'hooks')))
   .filter(f => !f.includes(path.join('plugins', 'agent365', 'skills', 'purview-dlp-integration')))
-  .filter(f => !f.includes(path.join('.github copy', 'skills', 'purview-dlp-integration')))
   .filter(f => !isTestPath(f));
 
 const codeFiles = filterByName(allFiles, '.ts', '.js', '.py', '.cs');

--- a/plugins/agent365/hooks/stop/validate-purview-dlp-integration.js
+++ b/plugins/agent365/hooks/stop/validate-purview-dlp-integration.js
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+/**
+ * validate-purview-dlp-integration.js
+ *
+ * Read-only static scanner for the purview-dlp-integration skill. It reports
+ * whether the Purview DLP guard was copied in, wired into a message handler,
+ * and enabled — but it deliberately returns ok:true (report-first) because the
+ * findings are advisory: the skill supports a legitimate "skip policy" / "start
+ * with PURVIEW_DLP_ENABLED=false" bring-up state, and it is additive to the
+ * customer's agent. Blocking here would punish valid partial integrations.
+ *
+ * Output: { ok: true, findingCount, findings } — same shape as
+ * validate-a365-code-validator.js.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const {
+  scanProject,
+  filterByName,
+} = require('../lib/project-scan');
+
+const cwd = process.cwd();
+
+function isTestPath(filePath) {
+  const parts = filePath.split(path.sep).map(p => p.toLowerCase());
+  return parts.includes('tests') || parts.includes('test') || parts.includes('__tests__');
+}
+
+// When the validator runs against this repo (npm run validate) rather than a
+// customer agent project, exclude the skill's own template assets and the hooks
+// tree so it never reports on itself.
+const allFiles = scanProject(cwd, { maxDepth: 7 })
+  .filter(f => !path.basename(f).includes('validate-purview-dlp-integration'))
+  .filter(f => !f.includes(path.join('plugins', 'agent365', 'hooks')))
+  .filter(f => !f.includes(path.join('plugins', 'agent365', 'skills', 'purview-dlp-integration')))
+  .filter(f => !f.includes(path.join('.github copy', 'skills', 'purview-dlp-integration')))
+  .filter(f => !isTestPath(f));
+
+const codeFiles = filterByName(allFiles, '.ts', '.js', '.py', '.cs');
+const csprojFiles = filterByName(allFiles, '.csproj');
+const envFiles = filterByName(allFiles, '.env', '.env.local', '.env.production', '.env.development');
+const appSettingsFiles = filterByName(allFiles, 'appsettings.json', 'appsettings.Development.json', 'appsettings.Production.json');
+
+const findings = [];
+
+function read(filePath) {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function rel(filePath) {
+  return path.relative(cwd, filePath).replace(/\\/g, '/');
+}
+
+function add(severity, id, message, filePath = '') {
+  findings.push({
+    severity,
+    id,
+    message,
+    file: filePath ? rel(filePath) : undefined,
+  });
+}
+
+function envHasTruthy(name) {
+  const truthy = new RegExp(`^\\s*${name}\\s*=\\s*(true|1|yes)\\s*$`, 'im');
+  return envFiles.some(f => truthy.test(read(f)));
+}
+
+function envHasFalsy(name) {
+  const falsy = new RegExp(`^\\s*${name}\\s*=\\s*(false|0|no)\\s*$`, 'im');
+  return envFiles.some(f => falsy.test(read(f)));
+}
+
+function envHasAny(name) {
+  const any = new RegExp(`^\\s*${name}\\s*=`, 'im');
+  return envFiles.some(f => any.test(read(f)));
+}
+
+// The guard is the ONLY module that calls the Graph `processContent` API, so a
+// code file containing `processContent` + a Purview marker is the guard itself.
+// A file that references the guard symbol but does NOT call processContent is a
+// wiring / handler site.
+const GUARD_SYMBOL = /\b(purviewGuard|purview_guard|PurviewGuard)\b/;
+
+const guardFiles = codeFiles.filter(f => {
+  const c = read(f);
+  return c.includes('processContent') && (
+    c.includes('PURVIEW_DLP_ENABLED') || c.includes('[purview]') || GUARD_SYMBOL.test(c)
+  );
+});
+
+const wiredFiles = codeFiles.filter(f => {
+  if (guardFiles.includes(f)) return false;
+  const c = read(f);
+  return GUARD_SYMBOL.test(c);
+});
+
+const envHasPurview = envHasAny('PURVIEW_DLP_ENABLED') || envFiles.some(f => /PURVIEW_/i.test(read(f)));
+
+const purviewPresent = guardFiles.length > 0 || wiredFiles.length > 0 || envHasPurview;
+
+// Detect the customer agent language (for tailored messages only).
+const isDotnet = csprojFiles.length > 0;
+
+if (purviewPresent) {
+  // 1) Guard copied in?
+  if (guardFiles.length === 0) {
+    add(
+      'high',
+      'purview-guard-file-missing',
+      'Purview wiring or env vars are present but no guard module (the file that calls the Graph processContent API) was found. Copy assets/purview.ts | purview.py | purview.cs into the agent source.'
+    );
+  }
+
+  // 2) Guard wired into a handler?
+  if (guardFiles.length > 0 && wiredFiles.length === 0) {
+    add(
+      'high',
+      'purview-guard-not-wired',
+      'The Purview guard module was added but no message handler references purviewGuard / purview_guard / PurviewGuard. Add the INPUT gate before the LLM call (and the OUTPUT gate before the reply) per the wiring snippet.',
+      guardFiles[0]
+    );
+  }
+
+  // 3) DLP flag configured?
+  if (!envHasAny('PURVIEW_DLP_ENABLED')) {
+    if (isDotnet) {
+      add(
+        'medium',
+        'purview-env-flag-missing-dotnet',
+        'PURVIEW_DLP_ENABLED was not found in any .env file. For .NET this may be set in launchSettings.json / appsettings / the host app settings instead — confirm the DLP gate is switched on where this agent reads configuration.'
+      );
+    } else {
+      add(
+        'medium',
+        'purview-env-flag-missing',
+        'PURVIEW_DLP_ENABLED was not appended to any .env file. Add it (start with false, flip to true once the DLP policy exists) so the guard can turn the gate on.'
+      );
+    }
+  } else if (envHasFalsy('PURVIEW_DLP_ENABLED') && !envHasTruthy('PURVIEW_DLP_ENABLED')) {
+    add(
+      'low',
+      'purview-dlp-disabled',
+      'PURVIEW_DLP_ENABLED is set to false. This is the expected initial "bring-up" state — flip it to true once a matching Purview DLP policy exists and has propagated.'
+    );
+  }
+
+  // 4) Guidance-only heads-up for .NET best-effort port.
+  if (isDotnet && guardFiles.length > 0) {
+    add(
+      'low',
+      'purview-dotnet-best-effort',
+      'The .NET guard is a best-effort port — verify the ITurnContext / UserAuthorization namespaces (and PurviewGuard.EvaluatePromptAsync signature) against your SDK version before production.'
+    );
+  }
+}
+
+const severityOrder = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
+findings.sort((a, b) => (severityOrder[a.severity] ?? 99) - (severityOrder[b.severity] ?? 99));
+
+process.stdout.write(JSON.stringify({
+  ok: true,
+  findingCount: findings.length,
+  findings,
+}, null, 2));

--- a/plugins/agent365/skills/purview-dlp-integration/README.md
+++ b/plugins/agent365/skills/purview-dlp-integration/README.md
@@ -1,0 +1,221 @@
+# Microsoft Purview DLP for your Agent 365 agent
+
+**In one sentence:** this adds a safety checkpoint in front of your agent's AI so that
+sensitive information (credit card numbers, SSNs, personal data, and anything your
+organization's data policies cover) can be **blocked and audited before the AI model ever
+sees it**.
+
+It is a small, reversible add-on for an existing **Microsoft Agent 365** agent
+(Node.js, Python, or .NET). It does not change what your agent *does* — it just adds a
+guard around the AI call.
+
+---
+
+## Why you might want this
+
+AI agents pass whatever a person types straight to a large language model (LLM). If a user
+pastes a credit-card number, a customer's personal data, or a confidential document, that
+sensitive text is sent to the model — and possibly to logs, analytics, or a third-party
+model provider along the way.
+
+If your organization has **data-protection or compliance obligations**, you usually need to:
+
+- **Block** sensitive content from leaving your boundary, and
+- **Record** an audit trail of what was checked.
+
+This integration does both, using **Microsoft Purview** — the same data-loss-prevention
+(DLP) engine your organization already uses for email and files — now applied to your
+agent's conversations.
+
+---
+
+## What it does (the checkpoint)
+
+Every time a user sends your agent a message, the message is checked by Microsoft Purview
+**first**. Only if it passes does the AI model get to answer. Optionally, the AI's reply is
+checked too before it's sent back.
+
+```mermaid
+flowchart LR
+    U[User sends a message] --> IN{Purview checks<br/>the message}
+    IN -- Sensitive data found --> BLK[Agent replies:<br/>blocked by policy]
+    IN -- Looks fine --> LLM[AI model answers]
+    LLM --> OUT{Purview checks the reply<br/>optional}
+    OUT -- Sensitive data found --> WH[Reply withheld]
+    OUT -- Looks fine --> SEND[User receives the reply]
+    style BLK fill:#ffe0e0,stroke:#cc0000
+    style WH fill:#ffe0e0,stroke:#cc0000
+    style SEND fill:#e0f5e0,stroke:#22aa22
+```
+
+> **Key point:** when a message is blocked, **the AI model is never called** — the
+> sensitive text never leaves your agent. Every checked message is also written to
+> Microsoft Purview's audit log, so you get compliance records automatically.
+
+---
+
+## Is this for you?
+
+Use this quick check to decide.
+
+```mermaid
+flowchart TD
+    Q1{Does your agent handle user text<br/>that could contain sensitive data?} -- No --> N1[You probably don't need this]
+    Q1 -- Yes --> Q2{Do you need to block or audit<br/>that data for compliance?}
+    Q2 -- No --> N1
+    Q2 -- Yes --> Q3{Is it a Microsoft Agent 365 agent<br/>in Node.js, Python, or .NET?}
+    Q3 -- No --> N2[Not a fit today —<br/>this targets Agent 365 agents]
+    Q3 -- Yes --> Q4{Can an admin turn on<br/>Purview DLP for AI in your tenant?}
+    Q4 -- No --> N3[You can wire it now, but it<br/>won't block until that's enabled]
+    Q4 -- Yes --> Y[Good fit — use this]
+    style Y fill:#e0f5e0,stroke:#22aa22
+    style N1 fill:#eeeeee,stroke:#999999
+    style N2 fill:#eeeeee,stroke:#999999
+```
+
+**A good fit if you:**
+
+- Build an Agent 365 agent that people chat with, and
+- Must keep sensitive data (PII, financial data, secrets) out of the AI, or need an audit
+  trail for compliance/regulatory reasons.
+
+**You probably don't need it if you:**
+
+- Only build internal demos or agents that never touch sensitive data, or
+- Already enforce this some other way, or
+- Aren't on Microsoft Agent 365.
+
+---
+
+## How it works (a bit more detail)
+
+The check runs **as your agent's own Microsoft 365 identity** (not a shared admin account),
+so Purview evaluates it just like it would for a real user. The example below shows a
+blocked message.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Agent as Your agent
+    participant Purview as Microsoft Purview
+    participant LLM as AI model
+    User->>Agent: "My card is 4111 1111 1111 1111"
+    Agent->>Purview: Check this message
+    Purview-->>Agent: Blocked — matches your DLP policy
+    Agent-->>User: "I can't help with that (blocked by policy)"
+    Note over LLM: The AI model is never called
+```
+
+Under the hood, a small **guard** file sits between your message handler and the AI model,
+and asks Microsoft Purview (through Microsoft Graph) whether the text is allowed. Purview
+decides based on a **DLP policy** scoped to your agent.
+
+```mermaid
+flowchart TB
+    subgraph Your Agent
+        H[Message handler] --> G[Purview guard]
+    end
+    G -- "checks text, as the agent identity" --> GR[Microsoft Graph]
+    GR --> P[Your Purview DLP policy<br/>credit cards, PII, etc.]
+    H -- "only if allowed" --> M[AI model / LLM]
+    style G fill:#e8eefc,stroke:#33bb66
+    style P fill:#fff3d6,stroke:#e0a000
+```
+
+By default it **fails safe**: if Purview can't be reached, the message is blocked rather
+than let through. You can change that if you prefer.
+
+---
+
+## What gets added to your agent
+
+The changes are small and easy to undo.
+
+| Change | What it is |
+|---|---|
+| **1 new file** | The DLP guard — a drop-in file, no editing needed. |
+| **A few lines in your message handler** | The two checkpoints (before the AI, and optionally before the reply). |
+| **A few settings** | Mainly a single on/off switch: `PURVIEW_DLP_ENABLED`. |
+| **1 Microsoft Graph permission** | `Content.Process.User`, added to your agent's existing permissions (nothing broadened). |
+| **1 Purview DLP policy** | Created for you, or reuse one you already have, or skip and add it later. |
+
+**Turning it off is easy:** set `PURVIEW_DLP_ENABLED=false` to disable it, or remove the one
+file and the few lines to revert completely. Your agent keeps working either way.
+
+---
+
+## What it does **not** do
+
+- It does **not** change your AI's answers — it only allows or blocks a turn.
+- It does **not** send your data to any third party — the check goes to **Microsoft
+  Purview** through Microsoft Graph.
+- It does **not** set up your agent, your Microsoft 365 licensing, or Purview billing — an
+  admin does that once (see Requirements).
+- It is **not** a network firewall — it inspects the agent's prompt/response *text*.
+
+---
+
+## Requirements
+
+| You need | Why |
+|---|---|
+| A **Microsoft Agent 365** agent (Node.js, Python, or .NET) | This wires into that agent's message handling. |
+| **Microsoft Purview DLP for AI** enabled in your tenant | The blocking/audit engine. This is a paid Purview capability — it needs licensing, pay-as-you-go billing, and "DSPM for AI" onboarding. |
+| An **admin** who can create a DLP policy and approve one permission | To define what counts as "sensitive" and to grant `Content.Process.User`. |
+
+> Until Purview DLP for AI is enabled and a matching policy exists, the guard runs but simply
+> **allows** everything (and says so in its logs). Nothing breaks — it just doesn't block yet.
+
+---
+
+## Supported agents
+
+| Language | Status |
+|---|---|
+| **Node.js / TypeScript** | ✅ Supported |
+| **Python** | ✅ Supported |
+| **.NET (C#)** | ✅ Supported (guard is a best-effort port — verify against your SDK version) |
+
+---
+
+## Example
+
+**Blocked** (a credit card number):
+
+```text
+User:  My credit card is 4111 1111 1111 1111
+Agent: 🚫 I can't help with that — your request was blocked by your
+       organization's data-loss-prevention policy.
+```
+
+**Allowed** (an ordinary question) — passes straight through to the AI as normal:
+
+```text
+User:  What's the weather policy for our Seattle office?
+Agent: (normal AI answer)
+```
+
+---
+
+## What's in this folder
+
+| Item | For you if you want to… |
+|---|---|
+| `SKILL.md` | Have the assistant wire this in for you automatically (the guided setup). |
+| `assets/` | See or hand-place the guard files and the exact code wiring. |
+| `scripts/` | Create or list the Purview DLP policy from PowerShell. |
+| `references/purview-portal-guide.md` | Turn on Purview DLP for AI and build the policy in the portal, step by step. |
+| `references/troubleshooting.md` | Fix it if a block isn't happening (a symptom → cause → fix table). |
+
+---
+
+## In short
+
+- **What:** a Purview data-loss-prevention checkpoint in front of your agent's AI.
+- **Why:** stop sensitive data from reaching the model, and get an audit trail — for
+  compliance.
+- **Cost of adoption:** one small file, a few lines, one permission, one policy — reversible.
+- **Prerequisite:** an Agent 365 agent + Purview DLP for AI enabled by an admin.
+
+If that matches what you need, this is for you. If your agent never touches sensitive data,
+you can safely skip it.

--- a/plugins/agent365/skills/purview-dlp-integration/SKILL.md
+++ b/plugins/agent365/skills/purview-dlp-integration/SKILL.md
@@ -98,6 +98,37 @@ user turn ─► [INPUT gate] processContent(uploadText, /me)  ─► block? ─
 - **Policy:** a dedicated Purview DLP policy scoped to the agent's **Entra app id** (portal:
   "Managed cloud apps" / `Applications` workload) with a **RestrictAccess=Block** rule.
 
+### S2S / app-only agents (autonomous, no AgentApplication)
+
+For an agent that authenticates **service-to-service** (no signed-in user, no
+`@microsoft/agents-hosting` AgentApplication — e.g. an Express / worker-loop agent using the A365
+FMI client-credentials chain), use the **S2S guard** [`assets/purview-s2s.ts`](./assets/purview-s2s.ts)
+instead of `purview.ts`.
+
+**Verified 2026-08-26 (tenant 01eed126-…):** app-only DLP *is* supported — the "blueprint app-only
+tokens get stripped" rule is true for the **blueprint** app but **not** for the **agent identity**:
+
+| Token source | `roles` in the Graph token |
+|---|---|
+| Blueprint app-only (client-credentials) | `AgentIdentity.CreateAsManager` — **Content.Process.* STRIPPED** |
+| Agent identity via the FMI 3-hop chain | **`Content.Process.All` RETAINED** ✅ |
+
+So the S2S guard (1) mints the **agent identity's** Graph token through the FMI chain
+(Blueprint → `fmi_path` → Agent Identity → Graph), (2) calls the app-only endpoint
+`POST /beta/users/{sponsorUserId}/dataSecurityAndGovernance/processContent` (app-only can't use
+`/me`), and (3) passes an `agents:[{"@odata.type":"aiAgentInfo", blueprintId, identifier, name}]`
+entry plus `protectedAppMetadata.applicationLocation` = the agent app id (the DLP policy scope).
+
+**Two steps differ from the delegated path:**
+- **Permission:** grant `Content.Process.All` (**Application**) to the **agent identity** SP (not the
+  blueprint) — run [`scripts/Grant-ContentProcessAppRole.ps1`](./scripts/Grant-ContentProcessAppRole.ps1)
+  instead of `Grant-DelegatedGraphScope.ps1`.
+- **Wiring:** import `purviewGuard` from `./purview-s2s.js` and call `evaluatePrompt(text)` /
+  `evaluateResponse(text)` directly around the LLM call (no TurnContext / Authorization args). The
+  guard reuses the `agent365Observability__*` S2S credentials already stamped by `a365 setup all`.
+
+Everything else — the DLP policy (Step 6), the `[purview]` log format, fail-closed semantics — is identical.
+
 ---
 
 ## Before you start — read the A365 config, then ask for the rest
@@ -280,7 +311,7 @@ own agentic auth handler + a plain HTTPS POST.
 - **.NET:** `Microsoft.Agents.*` hosting packages (standard); uses `System.Net.Http` + `System.Text.Json` (no extra NuGet).
 
 ## Non-negotiable constraints (why it's built this way)
-1. **Agentic delegated token + `/me`** — app-only client-credentials on a blueprint app is stripped of data-plane roles by Graph. Use the agent's agentic delegated token (Node.js `AgenticAuthenticationService.GetAgenticUserToken`, Python `authorization.exchange_token(…)`, .NET `UserAuthorization.GetTurnTokenAsync(…)`). Do not "fix" this by switching to client-credentials.
+1. **Agentic delegated token + `/me` (AgentApplication agents); agent-identity FMI token (S2S agents)** — a *blueprint* app-only token is stripped of data-plane roles (Content.Process.*) by Graph, so an AgentApplication agent must use its agentic delegated token (Node.js `AgenticAuthenticationService.GetAgenticUserToken`, Python `authorization.exchange_token(…)`, .NET `UserAuthorization.GetTurnTokenAsync(…)`). **But an S2S / autonomous agent CAN do app-only DLP** — using the **agent identity's** FMI-minted Graph token (not the blueprint's) against `/users/{sponsor}/…` instead of `/me`. See "S2S / app-only agents" above. Do not "fix" the AgentApplication path by switching *it* to client-credentials.
 2. **`contentEntry.name` is required** — omitting it returns a permanent `BadRequest` that looks like a clean allow. The guard always sets it and treats `processingErrors` as fail-closed.
 3. **Dedicated AI-app policy** — the `Applications`/Managed-cloud-apps location can't be combined with Exchange/SharePoint/OneDrive/Teams in one policy.
 4. **`RestrictAccess` block, `EnforcementPlanes=Application`** — not `BlockAccess`, not `CopilotExperiences` (that's first-party Copilot).
@@ -292,9 +323,11 @@ own agentic auth handler + a plain HTTPS POST.
 | File | Purpose |
 |------|---------|
 | [`assets/purview.ts`](./assets/purview.ts) · [`purview.py`](./assets/purview.py) · [`purview.cs`](./assets/purview.cs) | Drop-in DLP guard (Node.js / Python / .NET — generic, env-driven). |
+| [`assets/purview-s2s.ts`](./assets/purview-s2s.ts) | **S2S (app-only)** DLP guard for autonomous Node.js agents — agent-identity FMI Graph token, `/users/{sponsor}` endpoint. |
 | [`assets/wiring-snippet.ts`](./assets/wiring-snippet.ts) · [`.py`](./assets/wiring-snippet.py) · [`.cs`](./assets/wiring-snippet.cs) | The minimal handler edits (Node.js / Python / .NET). |
 | [`assets/purview.env.example`](./assets/purview.env.example) | Environment variables (same for all three languages). |
 | [`scripts/Grant-DelegatedGraphScope.ps1`](./scripts/Grant-DelegatedGraphScope.ps1) | Append the delegated Graph scope (surgical, no admin-consent). |
+| [`scripts/Grant-ContentProcessAppRole.ps1`](./scripts/Grant-ContentProcessAppRole.ps1) | **S2S:** grant `Content.Process.All` (Application) to the agent identity SP. |
 | [`scripts/New-AiAppDlpPolicy.ps1`](./scripts/New-AiAppDlpPolicy.ps1) | Create the AI-app DLP policy + block rule. |
 | [`references/purview-portal-guide.md`](./references/purview-portal-guide.md) | Tenant enablement (billing/DSPM) + manual portal policy steps. |
 | [`references/troubleshooting.md`](./references/troubleshooting.md) | Log reference + symptom→cause→fix table. |

--- a/plugins/agent365/skills/purview-dlp-integration/SKILL.md
+++ b/plugins/agent365/skills/purview-dlp-integration/SKILL.md
@@ -35,19 +35,22 @@ hooks:
         covers only the items the JS validator can't inspect.
 
         Verify:
-        1. The agent language was detected and the MATCHING guard was copied
-           (Node.js → assets/purview.ts, Python → assets/purview.py,
-           .NET → assets/purview.cs) — not a cross-language mix.
+            1. The agent language was detected and the MATCHING guard was copied
+              (Node.js → assets/purview.ts, Python → assets/purview.py,
+              .NET → assets/purview.cs) — not a cross-language mix.
+              For Node.js S2S, use assets/purview-s2s.ts instead.
         2. Both gates are wired in the message handler: the INPUT gate runs
            BEFORE the LLM call and the OUTPUT gate runs before the reply is sent
            (only when PURVIEW_CHECK_OUTPUT=true).
-        3. The guard is passed the agent's own agentic auth handler + auth-handler
-           name + turn context/id — NOT app-only client credentials.
+            3. Delegated guards use the agent's own agentic auth handler + auth-handler
+              name + turn context/id. Node.js S2S uses the existing AGENT365_*
+              client-secret FMI settings, not a delegated auth handler.
         4. `PURVIEW_DLP_ENABLED` was appended to the agent's `.env` (or host app
            settings for .NET).
-        5. The DLP policy choice (new / existing / skip) was resolved with the
-           user, and the delegated `Content.Process.User` scope grant step was
-           surfaced (Grant-DelegatedGraphScope.ps1) — never
+            5. The DLP policy choice (new / existing / skip) was resolved with the
+              user, and the delegated `Content.Process.User` scope grant step was
+              surfaced (Grant-DelegatedGraphScope.ps1), or Content.Process.All via
+              Grant-ContentProcessAppRole.ps1 for S2S — never
            `az ad app permission admin-consent` on the blueprint app.
 
         Return {"ok": false, "reason": "<item>"} if any required item is
@@ -125,7 +128,13 @@ entry plus `protectedAppMetadata.applicationLocation` = the agent app id (the DL
   instead of `Grant-DelegatedGraphScope.ps1`.
 - **Wiring:** import `purviewGuard` from `./purview-s2s.js` and call `evaluatePrompt(text)` /
   `evaluateResponse(text)` directly around the LLM call (no TurnContext / Authorization args). The
-  guard reuses the `agent365Observability__*` S2S credentials already stamped by `a365 setup all`.
+  guard prefers the existing `AGENT365_TENANT_ID`, `AGENT365_AGENT_ID`, `AGENT365_CLIENT_ID`, and
+  `AGENT365_CLIENT_SECRET` credentials; `AGENT365_BLUEPRINT_ID` sets the default policy app ID.
+  Confirm these are configured: `a365 setup all` does not populate the lowercase
+  `agent365Observability__clientId` / `agent365Observability__clientSecret` credentials.
+  Use a real directory user object ID for `PURVIEW_SPONSOR_USER_ID`. Configure secrets directly
+  in the environment or secret store, never in chat. This variant requires client-secret FMI;
+  do not switch managed-identity-only agents to it.
 
 Everything else — the DLP policy (Step 6), the `[purview]` log format, fail-closed semantics — is identical.
 
@@ -165,8 +174,9 @@ project root, read `a365.config.json` and `a365.generated.config.json`:
 ## Procedure
 
 ### 0. Detect the agent language
-Pick the guard/wiring by the agent's stack (all three share the SAME env vars, PowerShell scripts,
-policy, and `[purview]` log format — only the guard file + wiring differ):
+For delegated agents, pick the guard/wiring by the agent's stack (all three share the SAME env vars,
+PowerShell scripts, policy, and `[purview]` log format). For Node.js S2S, follow the S2S variant above
+instead of the delegated guard/wiring steps below.
 
 | Language | Detect by | Guard asset | Wiring |
 |----------|-----------|-------------|--------|
@@ -204,11 +214,15 @@ handler that calls the LLM): import the guard, add the **input gate** before the
 
 ### 4. Add environment variables
 Append the keys from [`assets/purview.env.example`](./assets/purview.env.example) to the agent's
-`.env`. On an A365 project the only key you **must** set is `PURVIEW_DLP_ENABLED=true` — the guard
+`.env`. On a delegated A365 project the only key you **must** set is `PURVIEW_DLP_ENABLED=true` — the guard
 auto-reads `PURVIEW_APP_ID` / `PURVIEW_APP_NAME` / blueprint id from `a365.config.json` +
 `a365.generated.config.json`. Set them explicitly only to override or for a non-A365 project.
 
+For Node.js S2S, confirm the canonical credentials listed above instead of relying on config auto-discovery.
+
 ### 5. Grant the delegated Graph scope
+For Node.js S2S, use `Grant-ContentProcessAppRole.ps1` as described above and skip this delegated step.
+
 Run [`scripts/Grant-DelegatedGraphScope.ps1`](./scripts/Grant-DelegatedGraphScope.ps1) from the
 agent project folder (needs `az login`). `-AppId` is **auto-discovered** from
 `a365.generated.config.json` (pass `-AppId <app-id>` to override, or `-ConfigDir <path>` if the

--- a/plugins/agent365/skills/purview-dlp-integration/SKILL.md
+++ b/plugins/agent365/skills/purview-dlp-integration/SKILL.md
@@ -105,7 +105,7 @@ For an agent that authenticates **service-to-service** (no signed-in user, no
 FMI client-credentials chain), use the **S2S guard** [`assets/purview-s2s.ts`](./assets/purview-s2s.ts)
 instead of `purview.ts`.
 
-**Verified 2026-08-26 (tenant 01eed126-…):** app-only DLP *is* supported — the "blueprint app-only
+**Verified 2026-08-26:** app-only DLP *is* supported — the "blueprint app-only
 tokens get stripped" rule is true for the **blueprint** app but **not** for the **agent identity**:
 
 | Token source | `roles` in the Graph token |

--- a/plugins/agent365/skills/purview-dlp-integration/SKILL.md
+++ b/plugins/agent365/skills/purview-dlp-integration/SKILL.md
@@ -1,0 +1,300 @@
+---
+name: purview-dlp-integration
+description: >
+  Integrate Microsoft Purview DLP (data loss prevention) + audit into an existing Microsoft
+  Agent 365 (A365 SDK) agent, so sensitive prompts/responses are blocked before the LLM. Use
+  when a user wants to add Purview DLP to an AI agent, block sensitive data (credit cards, SSNs,
+  PII) in agent turns, enforce data protection/compliance on an A365 AgentApplication, call the
+  Graph processContent API, or wire a DLP gate into agent code. Bundles drop-in guards for
+  Node.js/TypeScript, Python, and .NET, minimal wiring for each, a PowerShell script to create
+  the AI-apps DLP policy, a Purview portal/tenant enablement guide, and verification +
+  troubleshooting. Works with A365 agents in Node.js (@microsoft/agents-hosting), Python
+  (microsoft-agents-hosting-*), and .NET (Microsoft.Agents.*).
+compatibility:
+  - claude-code
+  - vscode-copilot
+  - github-copilot-cli
+user-invocable: true
+argument-hint: "Add Purview DLP blocking to my A365 agent"
+allowed-tools: Read, Write, Edit, Grep, Glob, Bash, AskUserQuestion, TaskCreate, TaskUpdate, TaskList
+model: sonnet
+hooks:
+  preToolUse:
+    - type: command
+      command: node ${CLAUDE_PLUGIN_ROOT}/hooks/preToolUse/path-guard.js
+      timeout: 5000
+  stop:
+    - type: command
+      command: node ${CLAUDE_PLUGIN_ROOT}/hooks/stop/validate-purview-dlp-integration.js
+      timeout: 30000
+    - type: prompt
+      prompt: |
+        The DLP guard file, wiring, env var, and marker comments are scanned by
+        validate-purview-dlp-integration.js (report-first — findings are advisory
+        because the skill supports a legitimate "skip policy" state). This prompt
+        covers only the items the JS validator can't inspect.
+
+        Verify:
+        1. The agent language was detected and the MATCHING guard was copied
+           (Node.js → assets/purview.ts, Python → assets/purview.py,
+           .NET → assets/purview.cs) — not a cross-language mix.
+        2. Both gates are wired in the message handler: the INPUT gate runs
+           BEFORE the LLM call and the OUTPUT gate runs before the reply is sent
+           (only when PURVIEW_CHECK_OUTPUT=true).
+        3. The guard is passed the agent's own agentic auth handler + auth-handler
+           name + turn context/id — NOT app-only client credentials.
+        4. `PURVIEW_DLP_ENABLED` was appended to the agent's `.env` (or host app
+           settings for .NET).
+        5. The DLP policy choice (new / existing / skip) was resolved with the
+           user, and the delegated `Content.Process.User` scope grant step was
+           surfaced (Grant-DelegatedGraphScope.ps1) — never
+           `az ad app permission admin-consent` on the blueprint app.
+
+        Return {"ok": false, "reason": "<item>"} if any required item is
+        missing, otherwise {"ok": true}.
+      timeout: 30000
+---
+
+# Microsoft Purview DLP Integration for Agent 365
+
+> **Trigger phrases** — any of these will activate this skill automatically:
+> - "add Purview DLP to my agent"
+> - "add data loss prevention to my A365 agent"
+> - "block credit cards / SSNs / PII before my agent's LLM sees them"
+> - "enforce compliance / audit on agent prompts and responses"
+> - "wire a DLP gate into my agent code"
+> - "call the Graph processContent API from my agent"
+> - "add Purview blocking to my Node.js / Python / .NET agent"
+
+---
+
+Add a Purview data-loss-prevention **gate** around an existing A365 agent's LLM call: every turn's
+prompt (and optionally the response) is evaluated by Microsoft Purview via the Graph
+`processContent` API and **blocked** when a DLP policy matches. `processContent` also writes the
+Purview **audit** event. Designed for **minimal, reversible changes** to the customer's agent.
+
+## When to use
+- "Add Purview DLP / data loss prevention to my agent."
+- "Block credit cards / SSNs / PII before my agent's LLM sees them."
+- "Enforce compliance / audit on agent prompts and responses."
+- Any A365 agent — **Node.js, Python, or .NET** — that needs inline DLP.
+
+## When NOT to use
+- Adding OpenTelemetry tracing / MAC Activity telemetry → use `instrument-observability`.
+- Diagnosing why telemetry isn't reaching MAC Activity / Defender → use `a365-code-validator`.
+- Provisioning the blueprint / Entra permissions from scratch → use `a365-setup` /
+  `make-a365-agent` first, then return here.
+
+## How it works
+```
+user turn ─► [INPUT gate] processContent(uploadText, /me)  ─► block? ─► reply "blocked", STOP (LLM never called)
+                                                            └─ allow ─► LLM ─► [OUTPUT gate] processContent(downloadText) ─► block? ─► withhold
+```
+- **Token:** the agent's **agentic delegated** Graph token, evaluated as **`/me`** (the agent
+  identity) — acquired via the agent's own auth handler: Node.js `GetAgenticUserToken`, Python
+  `authorization.exchange_token(…)`, .NET `UserAuthorization.GetTurnTokenAsync(…)`. *A365 blueprint
+  apps cannot use app-only client-credentials here — Graph strips data-plane roles from that token.*
+- **Fail-closed** by default: any Purview error/timeout blocks the turn.
+- **Policy:** a dedicated Purview DLP policy scoped to the agent's **Entra app id** (portal:
+  "Managed cloud apps" / `Applications` workload) with a **RestrictAccess=Block** rule.
+
+---
+
+## Before you start — read the A365 config, then ask for the rest
+
+**First, auto-discover from the project's A365 config.** The guard and both scripts read these
+automatically, but read them yourself to confirm values and drive the workflow. From the agent
+project root, read `a365.config.json` and `a365.generated.config.json`:
+
+| Value | Config source |
+|-------|---------------|
+| App (client) id → `PURVIEW_APP_ID` | `a365.generated.config.json` → `agentBlueprintId` (or `botMsaAppId`) |
+| Blueprint id → `PURVIEW_BLUEPRINT_ID` | `a365.generated.config.json` → `agentBlueprintId` |
+| Agent SP object id (for the consent script) | `a365.generated.config.json` → `agentBlueprintServicePrincipalObjectId` |
+| Display name → `PURVIEW_APP_NAME` | `a365.config.json` → `agentBlueprintDisplayName` / `agentDescription` |
+| Tenant id | `a365.config.json` → `tenantId` |
+| Current Graph scopes (is `Content.Process.User` already granted?) | `a365.generated.config.json` → `resourceConsents[]` where `resourceName == "Microsoft Graph"` → `scopes` |
+
+**Then ask the customer only for what's *not* in config** (use the ask-questions tool):
+
+| Ask | Notes / default |
+|-----|-----------------|
+| **DLP policy — new, existing, or skip** | **Always ask (unless the user specified it when invoking the skill):** **create a new** policy (default), **use an existing** one, or **skip** (they'll add it manually / already have it). Drives Step 6. |
+| **Sensitive info type(s) to block** | Default `Credit Card Number`. Any Purview SIT. Only needed when creating a **new** policy. |
+| **Admin UPN for alerts** | Optional; recommended (agents are unaware of blocks). |
+| **Agentic auth handler name** | The `static authHandlerName` on their `AgentApplication` (usually `agentic`). |
+| **Entry/handler file + LLM call site** | Where the message handler + LLM call live (locate in code when possible). |
+| **Who does Purview admin?** | Confirm they (or an admin) can enable billing/DSPM-for-AI + run the scripts. |
+
+> If the project has **no** a365 config (non-A365 or not yet provisioned), ask for the app id,
+> display name, and tenant id directly and pass them explicitly to the scripts/env.
+
+---
+
+## Procedure
+
+### 0. Detect the agent language
+Pick the guard/wiring by the agent's stack (all three share the SAME env vars, PowerShell scripts,
+policy, and `[purview]` log format — only the guard file + wiring differ):
+
+| Language | Detect by | Guard asset | Wiring |
+|----------|-----------|-------------|--------|
+| **Node.js / TypeScript** | `package.json` (`@microsoft/agents-hosting`) | `assets/purview.ts` | `assets/wiring-snippet.ts` |
+| **Python** | `pyproject.toml` / `requirements.txt` (`microsoft-agents-hosting-*`) | `assets/purview.py` | `assets/wiring-snippet.py` |
+| **.NET** | `*.csproj` (`Microsoft.Agents.*`) | `assets/purview.cs` | `assets/wiring-snippet.cs` |
+
+> Node.js and Python guards are verified against a live agent; the **.NET** guard is a **best-effort**
+> port — verify the `ITurnContext` / `UserAuthorization` namespaces against your SDK version.
+
+### 1. Locate the agent code
+Find the message handler (the method that calls the LLM) and the LLM call:
+- **Node.js:** the `AgentApplication` subclass, `onActivity(ActivityTypes.Message, …)`.
+- **Python:** the `AgentInterface` implementation's `process_user_message` (or the aiohttp host's `on_message`).
+- **.NET:** the `AgentApplication` subclass's `OnMessageAsync`.
+
+Confirm the A365 runtime/hosting package is present (Node.js `@microsoft/agents-a365-runtime`,
+Python `microsoft-agents-hosting-core`, .NET `Microsoft.Agents.*`) — standard for A365 agents.
+
+### 2. Add the guard (1 new file)
+Copy the guard for your language into the agent's source folder (next to the agent class) — it is
+generic and env-driven, no edits needed:
+- **Node.js:** [`assets/purview.ts`](./assets/purview.ts)
+- **Python:** [`assets/purview.py`](./assets/purview.py)
+- **.NET:** [`assets/purview.cs`](./assets/purview.cs) (adjust the `using` namespaces for
+  `ITurnContext` / `UserAuthorization` to your SDK version)
+
+### 3. Wire the two gates (minimal edits)
+Apply the wiring snippet for your language to the message handler (and any notification/email
+handler that calls the LLM): import the guard, add the **input gate** before the LLM and the
+**output gate** before the reply is sent. Pass the agent's authorization handler + auth-handler name + turn context/id.
+- **Node.js:** [`assets/wiring-snippet.ts`](./assets/wiring-snippet.ts) — passes `this.authorization`.
+- **Python:** [`assets/wiring-snippet.py`](./assets/wiring-snippet.py) — passes `auth`, `auth_handler_name`, `context` (already parameters of `process_user_message`).
+- **.NET:** [`assets/wiring-snippet.cs`](./assets/wiring-snippet.cs) — passes `UserAuthorization`, the agentic handler name, `turnContext`.
+
+### 4. Add environment variables
+Append the keys from [`assets/purview.env.example`](./assets/purview.env.example) to the agent's
+`.env`. On an A365 project the only key you **must** set is `PURVIEW_DLP_ENABLED=true` — the guard
+auto-reads `PURVIEW_APP_ID` / `PURVIEW_APP_NAME` / blueprint id from `a365.config.json` +
+`a365.generated.config.json`. Set them explicitly only to override or for a non-A365 project.
+
+### 5. Grant the delegated Graph scope
+Run [`scripts/Grant-DelegatedGraphScope.ps1`](./scripts/Grant-DelegatedGraphScope.ps1) from the
+agent project folder (needs `az login`). `-AppId` is **auto-discovered** from
+`a365.generated.config.json` (pass `-AppId <app-id>` to override, or `-ConfigDir <path>` if the
+config lives elsewhere). It **appends** `Content.Process.User` to the agent's existing agentic
+consent. **Never** run `az ad app permission admin-consent` on the blueprint app.
+
+### 6. Choose the DLP policy — new, existing, or skip
+
+**Ask the user which policy to use** (skip the prompt only if they already told you when invoking
+the skill, e.g. "use my existing 'Corp PII' policy", "create a new one", or "I'll add it manually"):
+
+> "Which Purview DLP policy should gate this agent?
+>   1. **Create a new** dedicated AI-app policy (default),
+>   2. **Use an existing** DLP policy you already have, or
+>   3. **Skip** — don't create one now; I'll add it manually (or already have one)."
+
+The guard is **policy-name-agnostic** — it calls `processContent` with the agent's app id as the
+`applicationLocation`, and Purview evaluates *every* policy whose Applications location includes
+that app id. So this choice affects only this step, never the guard code.
+
+**Option A — Create a new policy (default):**
+Run [`scripts/New-AiAppDlpPolicy.ps1`](./scripts/New-AiAppDlpPolicy.ps1) from the agent project
+folder (needs the `ExchangeOnlineManagement` module). `-AppId` / `-AppName` are **auto-discovered**
+from the a365 config; typically you only pass `-SensitiveInfoType "Credit Card Number" -NotifyUser
+<admin-upn>`. Override with `-AppId` / `-AppName` for a non-A365 project. Or follow
+[`references/purview-portal-guide.md`](./references/purview-portal-guide.md) to do it in the portal.
+
+**Option B — Use an existing policy:**
+1. **List candidates** (read-only) to see which policies already cover this agent's app id:
+   ```powershell
+   ./scripts/New-AiAppDlpPolicy.ps1 -ListExisting
+   ```
+   It connects to Security & Compliance and prints every DLP policy, flagging whether the agent's
+   app id is already **COVERS THIS APP**.
+2. **If the chosen policy already covers the app id** — nothing to create; the guard will match it.
+   Confirm its `Mode` is `Enable` and it has a `RestrictAccess`/`Block` rule on `UploadText`.
+3. **If the chosen policy does *not* cover the app id** — add this agent's app id to that policy's
+   Applications (Managed cloud apps) location in the portal
+   ([purview-portal-guide.md](./references/purview-portal-guide.md)), or fall back to Option A.
+
+**Option C — Skip (add the policy manually, or handle it later):**
+Create nothing now. The guard stays wired and enabled — it just won't *block* until a matching
+policy exists (until then it logs `allowed … 0 policyAction(s)`). To add the policy yourself, it
+**must** have ALL of the following or the guard won't block (full portal walkthrough:
+[purview-portal-guide.md](./references/purview-portal-guide.md)):
+
+| # | Requirement | Value / note |
+|---|-------------|--------------|
+| 1 | **Location = Applications** (portal: **"Managed cloud apps"**) | scoped to the agent's **Entra app (client) id** (`PURVIEW_APP_ID`). Do **not** combine Exchange/SharePoint/OneDrive/Teams in the same policy — Purview rejects that mix for this workload. |
+| 2 | **Enforcement plane = `Application`** | NOT "Copilot experiences" (that's first-party Copilot). |
+| 3 | **Rule condition** = Content contains **sensitive info type** | your SIT(s), e.g. `Credit Card Number`. |
+| 4 | **Rule action = Restrict access → Block** on the **prompt** (`UploadText`) | blocking the response (`DownloadText`) isn't supported for this workload → prompt/input gate only. |
+| 5 | **Mode = Enable** | turn the policy on. |
+| 6 | *(optional)* **Notify** an admin UPN | agents don't surface a block to a human. |
+
+Equivalent Security & Compliance PowerShell (exactly what Option A automates — run it by hand if you prefer):
+
+```powershell
+Connect-IPPSSession
+$loc = '[{"Workload":"Applications","Location":"<APP_ID>","LocationDisplayName":"<name>","LocationSource":"Entra","LocationType":"Individual","Inclusions":[{"Type":"Tenant","Identity":"All"}]}]'
+New-DlpCompliancePolicy -Name "<policy>" -Mode Enable -Locations $loc -EnforcementPlanes @('Application')
+New-DlpComplianceRule   -Name "<rule>" -Policy "<policy>" `
+  -ContentContainsSensitiveInformation @(@{ Name = 'Credit Card Number' }) `
+  -RestrictAccess @(@{ setting = 'UploadText'; value = 'Block' })
+```
+
+Judge success only by the agent's `[purview] uploadText -> BLOCKED (… 1 policyAction(s) … errors=0)`
+log line — **not** by `DistributionStatus` (shows `Pending` even for live policies). Allow up to ~1 hour to propagate.
+
+### 7. Confirm tenant prerequisites
+DLP-for-AI is metered. If everything is configured but nothing blocks (with `errors=0`), verify
+**pay-as-you-go billing** + **DSPM-for-AI onboarding** + licensing — see
+[`references/purview-portal-guide.md`](./references/purview-portal-guide.md) §0.
+
+### 8. Build, run, verify
+Rebuild/restart the agent so it reloads `.env` (**Node.js:** `npm run build && npm start`;
+**Python:** restart `python …`; **.NET:** `dotnet run`). Send a message containing a **Luhn-valid**
+test value, e.g. `My credit card is 4111 1111 1111 1111`. Watch the console.
+
+---
+
+## Verify — expected logs
+```
+[turn] in  <- ... text="My credit card is 4111 1111 1111 1111"
+[purview] uploadText -> BLOCKED (HTTP 200, 1 policyAction(s), scopeState=modified, errors=0)
+```
+- ✅ `BLOCKED` + `1 policyAction(s)` + `errors=0` → working; the agent replies with the block message and the LLM is never called.
+- `allowed (… 0 policyAction(s) … errors=0)` → request fine, but no policy matched yet (scope/propagation/tenant enablement).
+- `REQUEST ERROR (… errors=1 …)` → malformed request (usually the `name` field) — see troubleshooting.
+
+Full symptom→fix table: [`references/troubleshooting.md`](./references/troubleshooting.md).
+
+---
+
+## Dependencies (customer agent)
+No extra Graph SDK / `@azure/identity` / MSAL needed for any language — the guard uses the agent's
+own agentic auth handler + a plain HTTPS POST.
+- **Node.js:** `@microsoft/agents-hosting` + `@microsoft/agents-a365-runtime`, Node 18+ (global `fetch`), `dotenv`.
+- **Python:** `microsoft-agents-hosting-core` + `httpx` (both standard in A365 Python agents), `python-dotenv`.
+- **.NET:** `Microsoft.Agents.*` hosting packages (standard); uses `System.Net.Http` + `System.Text.Json` (no extra NuGet).
+
+## Non-negotiable constraints (why it's built this way)
+1. **Agentic delegated token + `/me`** — app-only client-credentials on a blueprint app is stripped of data-plane roles by Graph. Use the agent's agentic delegated token (Node.js `AgenticAuthenticationService.GetAgenticUserToken`, Python `authorization.exchange_token(…)`, .NET `UserAuthorization.GetTurnTokenAsync(…)`). Do not "fix" this by switching to client-credentials.
+2. **`contentEntry.name` is required** — omitting it returns a permanent `BadRequest` that looks like a clean allow. The guard always sets it and treats `processingErrors` as fail-closed.
+3. **Dedicated AI-app policy** — the `Applications`/Managed-cloud-apps location can't be combined with Exchange/SharePoint/OneDrive/Teams in one policy.
+4. **`RestrictAccess` block, `EnforcementPlanes=Application`** — not `BlockAccess`, not `CopilotExperiences` (that's first-party Copilot).
+5. **Never `admin-consent` the blueprint app** — it can narrow the agentic consent and break the agent's sign-in. Append the scope instead.
+6. **Trust the `[purview]` log, not `DistributionStatus`** (which reads `Pending` even for live policies).
+
+## Files in this skill
+
+| File | Purpose |
+|------|---------|
+| [`assets/purview.ts`](./assets/purview.ts) · [`purview.py`](./assets/purview.py) · [`purview.cs`](./assets/purview.cs) | Drop-in DLP guard (Node.js / Python / .NET — generic, env-driven). |
+| [`assets/wiring-snippet.ts`](./assets/wiring-snippet.ts) · [`.py`](./assets/wiring-snippet.py) · [`.cs`](./assets/wiring-snippet.cs) | The minimal handler edits (Node.js / Python / .NET). |
+| [`assets/purview.env.example`](./assets/purview.env.example) | Environment variables (same for all three languages). |
+| [`scripts/Grant-DelegatedGraphScope.ps1`](./scripts/Grant-DelegatedGraphScope.ps1) | Append the delegated Graph scope (surgical, no admin-consent). |
+| [`scripts/New-AiAppDlpPolicy.ps1`](./scripts/New-AiAppDlpPolicy.ps1) | Create the AI-app DLP policy + block rule. |
+| [`references/purview-portal-guide.md`](./references/purview-portal-guide.md) | Tenant enablement (billing/DSPM) + manual portal policy steps. |
+| [`references/troubleshooting.md`](./references/troubleshooting.md) | Log reference + symptom→cause→fix table. |

--- a/plugins/agent365/skills/purview-dlp-integration/assets/purview-s2s.ts
+++ b/plugins/agent365/skills/purview-dlp-integration/assets/purview-s2s.ts
@@ -1,0 +1,280 @@
+// ────────────────────────────────────────────────────────────────────────────
+// Microsoft Purview DLP + Audit guard — S2S (app-only) variant for A365 agents.
+//
+// Use this instead of purview.ts when the agent is an S2S / autonomous agent with NO
+// signed-in user and NO @microsoft/agents-hosting AgentApplication (e.g. an Express or
+// worker-loop agent authenticating via the A365 FMI client-credentials chain).
+//
+// ── WHY A SEPARATE GUARD (verified 2026-08-26, tenant 01eed126-…) ─────────────
+//  The delegated guard (purview.ts) needs an agentic `/me` token, which an S2S agent does
+//  not have. The blocker in the base skill — "blueprint app-only tokens get Content.Process
+//  stripped" — is REAL for the *blueprint* app, but NOT for the *agent identity*:
+//    • Blueprint app-only Graph token  → roles: AgentIdentity.CreateAsManager   (STRIPPED)
+//    • Agent-identity FMI Graph token  → roles: Content.Process.All             (RETAINED)
+//  So this guard mints the AGENT IDENTITY's Graph token via the FMI 3-hop chain and calls
+//  the app-only endpoint  POST /beta/users/{sponsorUserId}/dataSecurityAndGovernance/processContent
+//  with an `agents:[aiAgentInfo]` entry (blueprintId) — the "AI Agent" shape from the Graph docs.
+//
+// ── PREREQUISITE ─────────────────────────────────────────────────────────────
+//  Grant the `Content.Process.All` (Application) Graph role to the AGENT IDENTITY service
+//  principal (NOT the blueprint) — see scripts/Grant-ContentProcessAppRole.ps1.
+//
+// ── REQUIRED ENV (auto-read from the A365 `agent365Observability__*` S2S vars) ─
+//   PURVIEW_DLP_ENABLED=true
+//   agent365Observability__tenantId / __clientId (blueprint) / __agentId (agent identity)
+//     / __clientSecret / __agentBlueprintId / __sponsorUserId / __agentName
+// ── OPTIONAL ENV ─────────────────────────────────────────────────────────────
+//   PURVIEW_APP_ID=<app id the DLP policy is scoped to>  // default: __agentBlueprintId
+//   PURVIEW_SPONSOR_USER_ID=<user object id>            // default: __sponsorUserId
+//   PURVIEW_FAIL_MODE=closed|open (default closed) / PURVIEW_CHECK_OUTPUT=true
+//   PURVIEW_TIMEOUT_MS=5000 / PURVIEW_DEBUG=false
+//
+// ⚠️ Every contentEntry MUST have a non-empty `name`, else Graph returns a permanent
+//    BadRequest that looks like a clean allow. This guard always sets it and treats any
+//    `processingErrors` as fail-closed.
+// ────────────────────────────────────────────────────────────────────────────
+
+import "dotenv/config";
+import { randomUUID } from "node:crypto";
+
+const TOKEN_HOST = "https://login.microsoftonline.com";
+const GRAPH_BASE = "https://graph.microsoft.com/beta";
+const FMI_SCOPE = "api://AzureADTokenExchange/.default";
+const GRAPH_SCOPE = "https://graph.microsoft.com/.default";
+const TOKEN_TTL_MS = 50 * 60 * 1000; // refresh at 50 min
+
+type DlpActivity = "uploadText" | "downloadText";
+type DlpDecision = "allowed" | "blocked" | "error" | "disabled";
+
+export interface DlpVerdict {
+  /** True => stop the turn. */
+  blocked: boolean;
+  decision: DlpDecision;
+  detail?: string;
+}
+
+interface ProcessContentResponse {
+  protectionScopeState?: string;
+  policyActions?: Array<Record<string, unknown>>;
+  processingErrors?: Array<Record<string, unknown>>;
+}
+
+function envBool(name: string, def: boolean): boolean {
+  const v = process.env[name];
+  if (v === undefined || v === "") return def;
+  return /^(1|true|yes|on)$/i.test(v.trim());
+}
+
+/** A block is any restrictAccess action whose restrictionAction === "block". */
+function isBlock(actions?: Array<Record<string, unknown>>): boolean {
+  return !!actions?.some((a) => String(a.restrictionAction ?? "").toLowerCase() === "block");
+}
+
+export class PurviewS2SGuard {
+  private readonly enabled: boolean;
+  private readonly failClosed: boolean;
+  private readonly checkOutput: boolean;
+  private readonly timeoutMs: number;
+  private readonly debug: boolean;
+
+  private readonly tenantId: string;
+  private readonly blueprintId: string; // FMI Hop 1+2 client
+  private readonly agentId: string; // FMI path + Hop 3 client (agent identity)
+  private readonly clientSecret: string;
+  private readonly appId: string; // applicationLocation / DLP policy scope
+  private readonly sponsorUserId: string; // /users/{id} target
+  private readonly agentName: string;
+
+  private cachedToken: string | null = null;
+  private tokenExpiresAt = 0;
+
+  constructor() {
+    this.enabled = envBool("PURVIEW_DLP_ENABLED", false);
+    this.failClosed = (process.env.PURVIEW_FAIL_MODE ?? "closed").trim().toLowerCase() !== "open";
+    this.checkOutput = envBool("PURVIEW_CHECK_OUTPUT", true);
+    this.timeoutMs = Number(process.env.PURVIEW_TIMEOUT_MS) || 5000;
+    this.debug = envBool("PURVIEW_DEBUG", false);
+
+    this.tenantId = process.env.agent365Observability__tenantId ?? "";
+    this.blueprintId = process.env.agent365Observability__clientId ?? "";
+    this.agentId = process.env.agent365Observability__agentId ?? "";
+    this.clientSecret = process.env.agent365Observability__clientSecret ?? "";
+    this.appId =
+      process.env.PURVIEW_APP_ID ?? process.env.agent365Observability__agentBlueprintId ?? this.blueprintId;
+    this.sponsorUserId =
+      process.env.PURVIEW_SPONSOR_USER_ID ?? process.env.agent365Observability__sponsorUserId ?? "";
+    this.agentName = (process.env.agent365Observability__agentName ?? "AI Agent").trim() || "AI Agent";
+
+    if (this.enabled && (!this.tenantId || !this.agentId || !this.blueprintId || !this.sponsorUserId)) {
+      console.warn(
+        "[purview] PURVIEW_DLP_ENABLED=true but S2S config incomplete (need tenantId, agentId, " +
+          "blueprintId, sponsorUserId). Every turn will fail-closed.",
+      );
+    }
+  }
+
+  get isEnabled(): boolean {
+    return this.enabled;
+  }
+  get isCheckOutput(): boolean {
+    return this.checkOutput;
+  }
+
+  /** Evaluate the user's prompt BEFORE it reaches the LLM. */
+  evaluatePrompt(text: string): Promise<DlpVerdict> {
+    return this.evaluate("uploadText", text);
+  }
+  /** Evaluate the model's response BEFORE it's used/sent. */
+  evaluateResponse(text: string): Promise<DlpVerdict> {
+    return this.evaluate("downloadText", text);
+  }
+
+  private failVerdict(detail: string): DlpVerdict {
+    return { blocked: this.failClosed, decision: "error", detail };
+  }
+
+  // ── FMI 3-hop token (Blueprint → FMI path → Agent Identity → Graph) ─────────
+  private async getGraphToken(): Promise<string> {
+    if (this.cachedToken && Date.now() < this.tokenExpiresAt) return this.cachedToken;
+    const authority = `${TOKEN_HOST}/${this.tenantId}/oauth2/v2.0/token`;
+
+    // Hop 1+2: Blueprint (client secret) → T1 via FMI path. MSAL doesn't serialize fmi_path,
+    // so use a direct form POST (same workaround as the observability token service).
+    const r12 = await fetch(authority, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_id: this.blueprintId,
+        client_secret: this.clientSecret,
+        scope: FMI_SCOPE,
+        grant_type: "client_credentials",
+        fmi_path: this.agentId,
+      }).toString(),
+    });
+    if (!r12.ok) throw new Error(`FMI hop1+2 failed (${r12.status}): ${await r12.text()}`);
+    const t1 = ((await r12.json()) as { access_token?: string }).access_token;
+    if (!t1) throw new Error("FMI hop1+2 returned no access_token");
+
+    // Hop 3: Agent Identity uses T1 as a client assertion → Graph app-only token.
+    const r3 = await fetch(authority, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_id: this.agentId,
+        client_assertion: t1,
+        client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+        scope: GRAPH_SCOPE,
+        grant_type: "client_credentials",
+      }).toString(),
+    });
+    if (!r3.ok) throw new Error(`FMI hop3 (Graph) failed (${r3.status}): ${await r3.text()}`);
+    const token = ((await r3.json()) as { access_token?: string }).access_token;
+    if (!token) throw new Error("FMI hop3 returned no access_token");
+
+    this.cachedToken = token;
+    this.tokenExpiresAt = Date.now() + TOKEN_TTL_MS;
+    return token;
+  }
+
+  private async evaluate(activity: DlpActivity, text: string): Promise<DlpVerdict> {
+    if (!this.enabled) return { blocked: false, decision: "disabled" };
+    if (!text?.trim()) return { blocked: false, decision: "allowed" };
+
+    let token: string;
+    try {
+      token = await this.getGraphToken();
+    } catch (err) {
+      const detail = `token acquisition failed: ${(err as Error).message}`;
+      console.error(`[purview] ${activity} -> ${this.failClosed ? "BLOCKED" : "allowed"} (${detail})`);
+      return this.failVerdict(detail);
+    }
+
+    const now = new Date().toISOString().replace(/\.\d+Z$/, "");
+    const body = {
+      contentToProcess: {
+        contentEntries: [
+          {
+            "@odata.type": "microsoft.graph.processConversationMetadata",
+            identifier: randomUUID(),
+            content: { "@odata.type": "microsoft.graph.textContent", data: text },
+            agents: [
+              {
+                "@odata.type": "microsoft.graph.aiAgentInfo",
+                blueprintId: this.appId,
+                identifier: this.agentId,
+                name: this.agentName,
+                version: "1.0",
+              },
+            ],
+            name: `${this.agentName} ${activity}`, // REQUIRED non-empty name
+            correlationId: randomUUID(),
+            sequenceNumber: activity === "uploadText" ? 0 : 1,
+            isTruncated: false,
+            createdDateTime: now,
+            modifiedDateTime: now,
+          },
+        ],
+        activityMetadata: { activity },
+        deviceMetadata: {
+          operatingSystemSpecifications: { operatingSystemPlatform: "Linux", operatingSystemVersion: "unknown" },
+          ipAddress: "127.0.0.1",
+        },
+        protectedAppMetadata: {
+          name: this.agentName,
+          version: "1.0",
+          applicationLocation: { "@odata.type": "microsoft.graph.policyLocationApplication", value: this.appId },
+        },
+        integratedAppMetadata: { name: this.agentName, version: "1.0" },
+      },
+    };
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const res = await fetch(`${GRAPH_BASE}/users/${this.sponsorUserId}/dataSecurityAndGovernance/processContent`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          "Client-Request-Id": randomUUID(),
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        const detail = `HTTP ${res.status}: ${(await res.text()).slice(0, 300)}`;
+        console.error(`[purview] ${activity} -> ${this.failClosed ? "BLOCKED" : "allowed"} (${detail})`);
+        return this.failVerdict(detail);
+      }
+
+      const json = (await res.json()) as ProcessContentResponse;
+      if (this.debug) console.log(`[purview] ${activity} raw:`, JSON.stringify(json));
+
+      if (json.processingErrors && json.processingErrors.length > 0) {
+        const detail = `processingErrors=${JSON.stringify(json.processingErrors)}`;
+        console.error(`[purview] ${activity} -> ${this.failClosed ? "BLOCKED" : "allowed"} (${detail})`);
+        return this.failVerdict(detail);
+      }
+
+      const actions = json.policyActions ?? [];
+      const blocked = isBlock(actions);
+      console.log(
+        `[purview] ${activity} -> ${blocked ? "BLOCKED" : "allowed"} ` +
+          `(HTTP 200, ${actions.length} policyAction(s), scopeState=${json.protectionScopeState ?? "?"}, errors=0)`,
+      );
+      return blocked
+        ? { blocked: true, decision: "blocked", detail: `${actions.length} policyAction(s)` }
+        : { blocked: false, decision: "allowed" };
+    } catch (err) {
+      const detail =
+        (err as Error).name === "AbortError" ? `timeout after ${this.timeoutMs}ms` : (err as Error).message;
+      console.error(`[purview] ${activity} -> ${this.failClosed ? "BLOCKED" : "allowed"} (${detail})`);
+      return this.failVerdict(detail);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+export const purviewGuard = new PurviewS2SGuard();

--- a/plugins/agent365/skills/purview-dlp-integration/assets/purview-s2s.ts
+++ b/plugins/agent365/skills/purview-dlp-integration/assets/purview-s2s.ts
@@ -95,15 +95,16 @@ export class PurviewS2SGuard {
     this.timeoutMs = Number(process.env.PURVIEW_TIMEOUT_MS) || 5000;
     this.debug = envBool("PURVIEW_DEBUG", false);
 
-    this.tenantId = process.env.agent365Observability__tenantId ?? "";
-    this.blueprintId = process.env.agent365Observability__clientId ?? "";
-    this.agentId = process.env.agent365Observability__agentId ?? "";
-    this.clientSecret = process.env.agent365Observability__clientSecret ?? "";
-    this.appId =
-      process.env.PURVIEW_APP_ID ?? process.env.agent365Observability__agentBlueprintId ?? this.blueprintId;
-    this.sponsorUserId =
-      process.env.PURVIEW_SPONSOR_USER_ID ?? process.env.agent365Observability__sponsorUserId ?? "";
-    this.agentName = (process.env.agent365Observability__agentName ?? "AI Agent").trim() || "AI Agent";
+    this.tenantId = process.env.agent365Observability__tenantId ?? process.env.AGENT365_TENANT_ID ?? "";
+    this.blueprintId = process.env.agent365Observability__clientId ?? process.env.AGENT365_CLIENT_ID ?? "";
+    this.agentId = process.env.agent365Observability__agentId ?? process.env.AGENT365_AGENT_ID ?? "";
+    this.clientSecret = process.env.agent365Observability__clientSecret ?? process.env.AGENT365_CLIENT_SECRET ?? "";
+
+    const blueprintIdForPolicyScope = process.env.AGENT365_BLUEPRINT_ID ?? process.env.agent365Observability__agentBlueprintId;
+    this.appId = process.env.PURVIEW_APP_ID ?? blueprintIdForPolicyScope ?? this.blueprintId;
+
+    this.sponsorUserId = process.env.PURVIEW_SPONSOR_USER_ID ?? process.env.agent365Observability__sponsorUserId ?? "";
+    this.agentName = (process.env.agent365Observability__agentName ?? process.env.AGENT365_AGENT_NAME ?? "AI Agent").trim() || "AI Agent";
 
     if (this.enabled && (!this.tenantId || !this.agentId || !this.blueprintId || !this.sponsorUserId)) {
       console.warn(

--- a/plugins/agent365/skills/purview-dlp-integration/assets/purview-s2s.ts
+++ b/plugins/agent365/skills/purview-dlp-integration/assets/purview-s2s.ts
@@ -5,7 +5,7 @@
 // signed-in user and NO @microsoft/agents-hosting AgentApplication (e.g. an Express or
 // worker-loop agent authenticating via the A365 FMI client-credentials chain).
 //
-// ── WHY A SEPARATE GUARD (verified 2026-08-26, tenant 01eed126-…) ─────────────
+// ── WHY A SEPARATE GUARD (verified 2026-08-26 in a live tenant) ─────────────
 //  The delegated guard (purview.ts) needs an agentic `/me` token, which an S2S agent does
 //  not have. The blocker in the base skill — "blueprint app-only tokens get Content.Process
 //  stripped" — is REAL for the *blueprint* app, but NOT for the *agent identity*:

--- a/plugins/agent365/skills/purview-dlp-integration/assets/purview-s2s.ts
+++ b/plugins/agent365/skills/purview-dlp-integration/assets/purview-s2s.ts
@@ -19,10 +19,11 @@
 //  Grant the `Content.Process.All` (Application) Graph role to the AGENT IDENTITY service
 //  principal (NOT the blueprint) — see scripts/Grant-ContentProcessAppRole.ps1.
 //
-// ── REQUIRED ENV (auto-read from the A365 `agent365Observability__*` S2S vars) ─
+// ── REQUIRED ENV (existing canonical S2S client-secret configuration) ───────
 //   PURVIEW_DLP_ENABLED=true
-//   agent365Observability__tenantId / __clientId (blueprint) / __agentId (agent identity)
-//     / __clientSecret / __agentBlueprintId / __sponsorUserId / __agentName
+//   AGENT365_TENANT_ID / AGENT365_CLIENT_ID (blueprint) / AGENT365_AGENT_ID (agent identity)
+//   AGENT365_CLIENT_SECRET / PURVIEW_SPONSOR_USER_ID (real directory user object id)
+//   Configure these explicitly; do not assume setup-all populated client credentials.
 // ── OPTIONAL ENV ─────────────────────────────────────────────────────────────
 //   PURVIEW_APP_ID=<app id the DLP policy is scoped to>  // default: __agentBlueprintId
 //   PURVIEW_SPONSOR_USER_ID=<user object id>            // default: __sponsorUserId
@@ -95,10 +96,10 @@ export class PurviewS2SGuard {
     this.timeoutMs = Number(process.env.PURVIEW_TIMEOUT_MS) || 5000;
     this.debug = envBool("PURVIEW_DEBUG", false);
 
-    this.tenantId = process.env.agent365Observability__tenantId ?? process.env.AGENT365_TENANT_ID ?? "";
-    this.blueprintId = process.env.agent365Observability__clientId ?? process.env.AGENT365_CLIENT_ID ?? "";
-    this.agentId = process.env.agent365Observability__agentId ?? process.env.AGENT365_AGENT_ID ?? "";
-    this.clientSecret = process.env.agent365Observability__clientSecret ?? process.env.AGENT365_CLIENT_SECRET ?? "";
+    this.tenantId = process.env.AGENT365_TENANT_ID || process.env.agent365Observability__tenantId || "";
+    this.blueprintId = process.env.AGENT365_CLIENT_ID || process.env.agent365Observability__clientId || "";
+    this.agentId = process.env.AGENT365_AGENT_ID || process.env.agent365Observability__agentId || "";
+    this.clientSecret = process.env.AGENT365_CLIENT_SECRET || process.env.agent365Observability__clientSecret || "";
 
     const blueprintIdForPolicyScope = process.env.AGENT365_BLUEPRINT_ID ?? process.env.agent365Observability__agentBlueprintId;
     this.appId = process.env.PURVIEW_APP_ID ?? blueprintIdForPolicyScope ?? this.blueprintId;

--- a/plugins/agent365/skills/purview-dlp-integration/assets/purview.cs
+++ b/plugins/agent365/skills/purview-dlp-integration/assets/purview.cs
@@ -1,7 +1,7 @@
 // ────────────────────────────────────────────────────────────────────────────
 // Microsoft Purview DLP + Audit guard for Microsoft Agent 365 (A365) agents — .NET.
 //
-// A365 WorkIQ / DLP — best-effort wiring (verify against SDK source before production).
+// A365 DLP — best-effort wiring (verify against SDK source before production).
 // Node.js and Python variants of this guard are verified against a live agent; this .NET
 // port mirrors their logic and the verified UserAuthorization.GetTurnTokenAsync pattern from
 // instrument-observability/references/dotnet-observability.md, but the exact SDK namespaces

--- a/plugins/agent365/skills/purview-dlp-integration/assets/purview.cs
+++ b/plugins/agent365/skills/purview-dlp-integration/assets/purview.cs
@@ -1,0 +1,294 @@
+// ────────────────────────────────────────────────────────────────────────────
+// Microsoft Purview DLP + Audit guard for Microsoft Agent 365 (A365) agents — .NET.
+//
+// A365 WorkIQ / DLP — best-effort wiring (verify against SDK source before production).
+// Node.js and Python variants of this guard are verified against a live agent; this .NET
+// port mirrors their logic and the verified UserAuthorization.GetTurnTokenAsync pattern from
+// instrument-observability/references/dotnet-observability.md, but the exact SDK namespaces
+// (ITurnContext, UserAuthorization) may differ across SDK versions — adjust the usings.
+//
+// Drop-in class: evaluates every agent turn (prompt-in and/or response-out) against
+// Microsoft Purview DLP policies via the Microsoft Graph beta `processContent` API and
+// BLOCKS the turn when a policy matches. `processContent` also writes the Purview audit event.
+//
+// ── HOW IT WORKS ─────────────────────────────────────────────────────────────
+//  • Token : the agent's AGENTIC DELEGATED Graph token via
+//            `UserAuthorization.GetTurnTokenAsync(turnContext, handlerName, …)`, evaluated as
+//            `/me` (the agent identity). The agentic auth handler MUST be configured with
+//            Microsoft Graph `.default` scopes (which carries the delegated Content.Process.User
+//            granted on the agent's agentic consent). A365 blueprint apps CANNOT use app-only
+//            client-credentials — Graph strips data-plane roles from that token.
+//  • Fail  : FAIL-CLOSED by default (PURVIEW_FAIL_MODE=closed) — any error/timeout blocks.
+//  • Policy: a Purview DLP policy scoped to THIS agent's Entra app id ("Applications" workload),
+//            RestrictAccess=Block. See scripts/New-AiAppDlpPolicy.ps1.
+//
+// ── REQUIRED ENV ─────────────────────────────────────────────────────────────
+//   PURVIEW_DLP_ENABLED=true   (app id / name / blueprint auto-discovered from a365 config)
+// See purview.env.example for the full list.
+//
+// ⚠️ CRITICAL: every processContent contentEntry MUST include a non-empty `name`. Omitting it
+//    returns a PERMANENT BadRequest as HTTP 200 with 0 policyActions — identical to a clean
+//    "allowed". This guard always sets `name` and treats any processingErrors as fail-closed.
+// ────────────────────────────────────────────────────────────────────────────
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Agents.Builder;          // ITurnContext — adjust to your SDK version
+using Microsoft.Agents.Builder.App;      // UserAuthorization — adjust to your SDK version
+
+namespace Agent365.Purview;
+
+public sealed record DlpVerdict(bool Blocked, string Decision, string? Detail = null);
+
+public sealed class PurviewGuard
+{
+    // Zero-DI drop-in singleton. (You can also register it as a DI singleton instead.)
+    public static readonly PurviewGuard Instance = new();
+
+    private static readonly HttpClient Http = new();
+    private const string GraphBase = "https://graph.microsoft.com/beta";
+    private const int MaxContentChars = 100_000;
+
+    private readonly bool _enabled;
+    private readonly bool _failClosed;
+    private readonly bool _checkOutput;
+    private readonly int _timeoutMs;
+    private readonly bool _debug;
+    private readonly string _appId;
+    private readonly string _appName;
+    private readonly string _blueprintId;
+    private readonly string _authHandlerName;
+
+    public bool IsEnabled => _enabled;
+    public bool IsCheckOutput => _checkOutput;
+
+    public PurviewGuard()
+    {
+        _enabled = EnvBool("PURVIEW_DLP_ENABLED", false);
+        _failClosed = !string.Equals(Env("PURVIEW_FAIL_MODE", "closed"), "open", StringComparison.OrdinalIgnoreCase);
+        _checkOutput = EnvBool("PURVIEW_CHECK_OUTPUT", true);
+        _timeoutMs = int.TryParse(Env("PURVIEW_TIMEOUT_MS", ""), out var t) && t > 0 ? t : 2000;
+        _debug = EnvBool("PURVIEW_DEBUG", false);
+
+        var cfg = LoadA365Config();
+        _appId = FirstNonEmpty(
+            Environment.GetEnvironmentVariable("PURVIEW_APP_ID"),
+            cfg.GetValueOrDefault("appId"),
+            Environment.GetEnvironmentVariable("CONNECTIONS__SERVICE_CONNECTION__SETTINGS__CLIENTID"),
+            Environment.GetEnvironmentVariable("AGENT_ID")) ?? "";
+        _appName = FirstNonEmpty(Environment.GetEnvironmentVariable("PURVIEW_APP_NAME"), cfg.GetValueOrDefault("appName")) is { Length: > 0 } n ? n : "AI Agent";
+        _blueprintId = FirstNonEmpty(
+            Environment.GetEnvironmentVariable("PURVIEW_BLUEPRINT_ID"),
+            cfg.GetValueOrDefault("blueprintId"),
+            Environment.GetEnvironmentVariable("AGENT365OBSERVABILITY__AGENTBLUEPRINTID")) ?? _appId;
+        _authHandlerName = FirstNonEmpty(
+            Environment.GetEnvironmentVariable("PURVIEW_AUTH_HANDLER"),
+            Environment.GetEnvironmentVariable("AUTH_HANDLER_NAME")) ?? "agentic";
+
+        if (_enabled && string.IsNullOrEmpty(_appId))
+            Console.Error.WriteLine("[purview] PURVIEW_DLP_ENABLED=true but no app id resolved — set PURVIEW_APP_ID " +
+                "or run from a folder containing a365.generated.config.json. Every turn will fail-closed.");
+    }
+
+    /// <summary>Evaluate the user's prompt BEFORE it reaches the LLM.</summary>
+    public Task<DlpVerdict> EvaluatePromptAsync(UserAuthorization authorization, string authHandlerName, ITurnContext turnContext, string text, CancellationToken ct = default)
+        => EvaluateAsync(authorization, authHandlerName, "uploadText", 0, text, turnContext, ct);
+
+    /// <summary>Evaluate the model's response BEFORE it's sent back to the user.</summary>
+    public Task<DlpVerdict> EvaluateResponseAsync(UserAuthorization authorization, string authHandlerName, ITurnContext turnContext, string text, CancellationToken ct = default)
+        => EvaluateAsync(authorization, authHandlerName, "downloadText", 1, text, turnContext, ct);
+
+    private DlpVerdict Fail(string detail) => new(_failClosed, "error", detail);
+
+    private async Task<DlpVerdict> EvaluateAsync(UserAuthorization authorization, string authHandlerName, string activity, int seq, string text, ITurnContext turnContext, CancellationToken ct)
+    {
+        if (!_enabled) return new DlpVerdict(false, "disabled");
+        if (string.IsNullOrEmpty(_appId)) return Fail("missing PURVIEW_APP_ID");
+
+        var reqId = Guid.NewGuid().ToString();
+        try
+        {
+            var token = await GetTokenAsync(authorization, authHandlerName, turnContext, ct);
+            var body = BuildBody(activity, seq, text, turnContext);
+
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            cts.CancelAfter(_timeoutMs);
+            using var req = new HttpRequestMessage(HttpMethod.Post, $"{GraphBase}/me/dataSecurityAndGovernance/processContent");
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            req.Headers.TryAddWithoutValidation("Client-Request-Id", reqId);
+            req.Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json");
+
+            using var res = await Http.SendAsync(req, cts.Token);
+            if (!res.IsSuccessStatusCode)
+            {
+                Console.Error.WriteLine($"[purview] {activity} HTTP {(int)res.StatusCode} reqId={reqId}: {Trunc(await SafeRead(res), 300)}");
+                return Fail($"graph {(int)res.StatusCode}");
+            }
+            if (res.StatusCode is HttpStatusCode.Accepted or HttpStatusCode.NoContent)
+            {
+                Console.WriteLine($"[purview] {activity} -> allowed (HTTP {(int)res.StatusCode}, no content) reqId={reqId}");
+                return new DlpVerdict(false, "allowed");
+            }
+
+            var json = await res.Content.ReadAsStringAsync(cts.Token);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            var actions = root.TryGetProperty("policyActions", out var pa) && pa.ValueKind == JsonValueKind.Array ? pa : default;
+            var errs = root.TryGetProperty("processingErrors", out var pe) && pe.ValueKind == JsonValueKind.Array ? pe : default;
+            int actionCount = actions.ValueKind == JsonValueKind.Array ? actions.GetArrayLength() : 0;
+            int errCount = errs.ValueKind == JsonValueKind.Array ? errs.GetArrayLength() : 0;
+            var scopeState = root.TryGetProperty("protectionScopeState", out var ss) ? ss.GetString() : "n/a";
+            var summary = $"HTTP {(int)res.StatusCode}, {actionCount} policyAction(s), scopeState={scopeState}, errors={errCount}";
+
+            // A permanent BadRequest here means OUR REQUEST is malformed — fail-closed, don't silently allow.
+            if (errCount > 0)
+            {
+                Console.Error.WriteLine($"[purview] {activity} -> REQUEST ERROR ({summary}) errors={Trunc(errs.GetRawText(), 500)} reqId={reqId}");
+                return Fail($"processingErrors: {Trunc(errs.GetRawText(), 200)}");
+            }
+            if (IsBlock(actions))
+            {
+                Console.WriteLine($"[purview] {activity} -> BLOCKED ({summary}) reqId={reqId}");
+                return new DlpVerdict(true, "blocked", "restrictAccess/block");
+            }
+            Console.WriteLine($"[purview] {activity} -> allowed ({summary}){(_debug ? $" raw={Trunc(json, 700)}" : "")} reqId={reqId}");
+            return new DlpVerdict(false, "allowed");
+        }
+        catch (OperationCanceledException)
+        {
+            Console.Error.WriteLine($"[purview] {activity} error reqId={reqId}: timeout after {_timeoutMs}ms");
+            return Fail($"timeout after {_timeoutMs}ms");
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[purview] {activity} error reqId={reqId}: {ex.Message}");
+            return Fail(ex.Message);
+        }
+    }
+
+    private async Task<string> GetTokenAsync(UserAuthorization authorization, string authHandlerName, ITurnContext turnContext, CancellationToken ct)
+    {
+        // Agent-identity (agentic delegated) Graph token. The token uses the agentic auth handler's
+        // CONFIGURED scopes — that handler MUST include Microsoft Graph .default (carrying the delegated
+        // Content.Process.User granted on the agent's agentic consent). Mirrors the verified
+        // UserAuthorization.GetTurnTokenAsync signature from instrument-observability.
+        var handler = string.IsNullOrEmpty(authHandlerName) ? _authHandlerName : authHandlerName;
+        var token = await authorization.GetTurnTokenAsync(turnContext, handler, cancellationToken: ct);
+        if (string.IsNullOrEmpty(token))
+            throw new InvalidOperationException("failed to acquire agentic Graph token (is the agentic auth handler name correct?)");
+        return token;
+    }
+
+    private object BuildBody(string activity, int seq, string text, ITurnContext turnContext)
+    {
+        // For per-instance MAC grouping resolve turnContext.Activity.GetAgenticInstanceId(); the app id is a safe default.
+        var agentId = _appId;
+        var convId = turnContext?.Activity?.Conversation?.Id ?? Guid.NewGuid().ToString();
+        bool truncated = text.Length > MaxContentChars;
+        var nowIso = DateTime.UtcNow.ToString("o");
+        var data = truncated ? text.Substring(0, MaxContentChars) : text;
+
+        // Dictionary (not anonymous type) so JSON keys can be "@odata.type".
+        return new Dictionary<string, object?>
+        {
+            ["contentToProcess"] = new Dictionary<string, object?>
+            {
+                ["contentEntries"] = new object[]
+                {
+                    new Dictionary<string, object?>
+                    {
+                        ["@odata.type"] = "microsoft.graph.processConversationMetadata",
+                        ["identifier"] = Guid.NewGuid().ToString(),
+                        ["content"] = new Dictionary<string, object?>
+                        {
+                            ["@odata.type"] = "microsoft.graph.textContent",
+                            ["data"] = data,
+                        },
+                        ["agents"] = new object[]
+                        {
+                            new Dictionary<string, object?>
+                            {
+                                ["@odata.type"] = "microsoft.graph.aiAgentInfo",
+                                ["blueprintId"] = _blueprintId,
+                                ["identifier"] = agentId,
+                                ["name"] = _appName,
+                                ["version"] = "1.0",
+                            },
+                        },
+                        // ⚠️ REQUIRED non-empty name — omitting it => permanent BadRequest "Name is invalid".
+                        ["name"] = $"{_appName} message",
+                        ["correlationId"] = convId,
+                        ["sequenceNumber"] = seq,
+                        ["isTruncated"] = truncated,
+                        ["createdDateTime"] = nowIso,
+                        ["modifiedDateTime"] = nowIso,
+                        ["contentCategory"] = "ai",
+                    },
+                },
+                ["activityMetadata"] = new Dictionary<string, object?> { ["activity"] = activity }, // input=uploadText, output=downloadText
+                ["integratedAppMetadata"] = new Dictionary<string, object?> { ["name"] = _appName, ["version"] = "1.0.0" },
+                ["protectedAppMetadata"] = new Dictionary<string, object?>
+                {
+                    ["name"] = _appName,
+                    ["version"] = "1.0.0",
+                    ["applicationLocation"] = new Dictionary<string, object?>
+                    {
+                        ["@odata.type"] = "microsoft.graph.policyLocationApplication",
+                        ["value"] = _appId, // must match the app id in your DLP policy location
+                    },
+                },
+            },
+        };
+    }
+
+    private static bool IsBlock(JsonElement actions)
+    {
+        if (actions.ValueKind != JsonValueKind.Array) return false;
+        foreach (var a in actions.EnumerateArray())
+            if (a.ValueKind == JsonValueKind.Object && a.TryGetProperty("restrictionAction", out var ra)
+                && string.Equals(ra.GetString(), "block", StringComparison.OrdinalIgnoreCase))
+                return true;
+        return false;
+    }
+
+    private static Dictionary<string, string?> LoadA365Config()
+    {
+        var outp = new Dictionary<string, string?>();
+        foreach (var file in new[] { "a365.generated.config.json", "a365.config.json" })
+        {
+            try
+            {
+                if (!File.Exists(file)) continue;
+                using var doc = JsonDocument.Parse(File.ReadAllText(file));
+                var r = doc.RootElement;
+                outp["appId"] = outp.GetValueOrDefault("appId") ?? Str(r, "agentBlueprintId") ?? Str(r, "botMsaAppId") ?? Str(r, "botId");
+                outp["blueprintId"] = outp.GetValueOrDefault("blueprintId") ?? Str(r, "agentBlueprintId");
+                outp["appName"] = outp.GetValueOrDefault("appName") ?? Str(r, "agentBlueprintDisplayName") ?? Str(r, "agentDescription") ?? Str(r, "agentIdentityDisplayName");
+                outp["tenantId"] = outp.GetValueOrDefault("tenantId") ?? Str(r, "tenantId");
+            }
+            catch { /* missing / unreadable — ignore */ }
+        }
+        return outp;
+    }
+
+    private static string? Str(JsonElement e, string k) => e.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+    private static string? FirstNonEmpty(params string?[] vals) => vals.FirstOrDefault(v => !string.IsNullOrWhiteSpace(v));
+    private static string Env(string name, string def) { var v = Environment.GetEnvironmentVariable(name); return string.IsNullOrEmpty(v) ? def : v; }
+    private static bool EnvBool(string name, bool def)
+    {
+        var v = Environment.GetEnvironmentVariable(name);
+        if (string.IsNullOrWhiteSpace(v)) return def;
+        return v.Trim().ToLowerInvariant() is "1" or "true" or "yes" or "on";
+    }
+    private static async Task<string> SafeRead(HttpResponseMessage r) { try { return await r.Content.ReadAsStringAsync(); } catch { return ""; } }
+    private static string Trunc(string s, int n) => string.IsNullOrEmpty(s) || s.Length <= n ? s ?? "" : s.Substring(0, n);
+}

--- a/plugins/agent365/skills/purview-dlp-integration/assets/purview.cs
+++ b/plugins/agent365/skills/purview-dlp-integration/assets/purview.cs
@@ -43,7 +43,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Agents.Builder;          // ITurnContext — adjust to your SDK version
-using Microsoft.Agents.Builder.App;      // UserAuthorization — adjust to your SDK version
+using Microsoft.Agents.Builder.App.UserAuth;
 
 namespace Agent365.Purview;
 

--- a/plugins/agent365/skills/purview-dlp-integration/assets/purview.env.example
+++ b/plugins/agent365/skills/purview-dlp-integration/assets/purview.env.example
@@ -1,0 +1,39 @@
+# ── Microsoft Purview DLP guard — environment variables ─────────────────────
+# Same keys for all languages (Node.js / Python / .NET). Node.js & Python read them from .env
+# (git-ignored, via dotenv); .NET reads them as environment variables
+# (Environment.GetEnvironmentVariable) — set them in .env + a loader, launchSettings.json, or the
+# host's app settings.
+# On an A365 project the ONLY required key is PURVIEW_DLP_ENABLED — the guard auto-reads the
+# app id, display name and blueprint id from a365.config.json / a365.generated.config.json.
+
+# Turn the DLP gate on/off. Start with false, flip to true once the policy exists.
+PURVIEW_DLP_ENABLED=true
+
+# ── Optional (auto-discovered from a365 config; set only to override / non-A365) ─────────────
+# The agent's Entra application (client) id — the SAME id you scope the DLP policy to.
+# Auto-read from a365.generated.config.json (agentBlueprintId / botMsaAppId); falls back to
+# connections__service_connection__settings__clientId or agent_id. Set to override.
+# PURVIEW_APP_ID=<agent-app-client-id>
+
+# Display name used in the processContent request (MUST be non-empty).
+# Auto-read from a365.config.json (agentBlueprintDisplayName / agentDescription). Set to override.
+# PURVIEW_APP_NAME=<your agent display name>
+
+# ── Optional (sensible defaults shown) ──────────────────────────────────────
+# Agent blueprint id (for aiAgentInfo.blueprintId). Auto-read from a365 config; else PURVIEW_APP_ID.
+# PURVIEW_BLUEPRINT_ID=<agent-blueprint-id>
+
+# The agentic auth handler name registered on your AgentApplication (static authHandlerName).
+# PURVIEW_AUTH_HANDLER=agentic
+
+# closed = block the turn on any Purview error/timeout (recommended). open = allow on error.
+# PURVIEW_FAIL_MODE=closed
+
+# Also evaluate the model's RESPONSE, not just the prompt.
+# PURVIEW_CHECK_OUTPUT=true
+
+# Per-call hard timeout (ms).
+# PURVIEW_TIMEOUT_MS=2000
+
+# true = log Purview's full raw JSON response on every allowed turn (verbose; use while testing).
+# PURVIEW_DEBUG=false

--- a/plugins/agent365/skills/purview-dlp-integration/assets/purview.py
+++ b/plugins/agent365/skills/purview-dlp-integration/assets/purview.py
@@ -1,0 +1,274 @@
+# ────────────────────────────────────────────────────────────────────────────
+# Microsoft Purview DLP + Audit guard for Microsoft Agent 365 (A365) agents — PYTHON.
+#
+# Drop-in module: evaluates every agent turn (prompt-in and/or response-out) against
+# Microsoft Purview data-loss-prevention (DLP) policies via the Microsoft Graph beta
+# `processContent` API, and BLOCKS the turn when a policy says so. `processContent`
+# also writes the Purview audit event, so a successful call satisfies auditing too.
+#
+# This template is generic and driven entirely by environment variables — copy it into
+# your agent's source folder (next to your AgentApplication / AgentInterface) and wire
+# the two gates in (see the skill's wiring-snippet.py). No values are hard-coded.
+#
+# ── HOW IT WORKS ─────────────────────────────────────────────────────────────
+#  • Token : the agent's AGENTIC DELEGATED Graph token, acquired via the A365
+#            Authorization handler — `await authorization.exchange_token(context,
+#            scopes=[GRAPH_SCOPE], auth_handler_id=<handler>)` — evaluated as `/me`
+#            (the agent identity). A365 blueprint apps CANNOT use app-only
+#            client-credentials for this — Microsoft Graph strips data-plane roles
+#            (e.g. Content.Process.All) from a blueprint app's app-only token.
+#  • Scope : input (uploadText) and, if PURVIEW_CHECK_OUTPUT=true, output (downloadText).
+#  • Fail  : FAIL-CLOSED by default (PURVIEW_FAIL_MODE=closed) — any error/timeout blocks
+#            the turn so content is never processed unverified. Set to `open` to fail-open.
+#  • Policy: a Purview DLP policy scoped to THIS agent's Entra app id, under the
+#            "Applications" workload (portal: "Managed cloud apps"), with a
+#            RestrictAccess=Block rule. See scripts/New-AiAppDlpPolicy.ps1.
+#
+# ── REQUIRED ENV ─────────────────────────────────────────────────────────────
+#   PURVIEW_DLP_ENABLED=true
+# The agent app id + display name are AUTO-DISCOVERED from a365.config.json /
+# a365.generated.config.json in the project root (cwd) when present — so on an A365 project
+# you usually only need PURVIEW_DLP_ENABLED. Override / supply explicitly with
+# PURVIEW_APP_ID / PURVIEW_APP_NAME. See purview.env.example for the full list.
+#
+# ⚠️ CRITICAL: every processContent `contentEntry` MUST include a non-empty `name`. If it is
+#    missing, Graph rejects the request with a PERMANENT BadRequest returned as HTTP 200 with
+#    0 policyActions — which looks IDENTICAL to a clean "allowed". This guard therefore (a)
+#    always sets `name`, and (b) treats any `processingErrors` as a hard failure (fail-closed)
+#    and logs them loudly. Do not remove.
+#
+# Dependencies: httpx (already present in A365 Python agents). No azure-identity / Graph SDK.
+# ────────────────────────────────────────────────────────────────────────────
+
+import json
+import logging
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+GRAPH_BASE = "https://graph.microsoft.com/beta"
+GRAPH_SCOPE = "https://graph.microsoft.com/.default"
+MAX_CONTENT_CHARS = 100_000
+
+
+@dataclass
+class DlpVerdict:
+    blocked: bool          # True => stop the turn
+    decision: str          # "allowed" | "blocked" | "error" | "disabled"
+    detail: str | None = None
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    v = os.getenv(name)
+    if v is None or v == "":
+        return default
+    return v.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _load_a365_config() -> dict:
+    """Best-effort read of A365 project config from cwd so an A365 agent needs almost no env."""
+    out: dict = {}
+    for file in ("a365.generated.config.json", "a365.config.json"):
+        try:
+            with open(file, "r", encoding="utf-8-sig") as f:
+                j = json.load(f)
+        except Exception:
+            continue
+        out.setdefault("appId", j.get("agentBlueprintId") or j.get("botMsaAppId") or j.get("botId"))
+        out.setdefault("blueprintId", j.get("agentBlueprintId"))
+        out.setdefault("appName", j.get("agentBlueprintDisplayName") or j.get("agentDescription") or j.get("agentIdentityDisplayName"))
+        out.setdefault("tenantId", j.get("tenantId"))
+    return out
+
+
+class PurviewGuard:
+    def __init__(self) -> None:
+        self.enabled = _env_bool("PURVIEW_DLP_ENABLED", False)
+        # Fail-closed unless explicitly set to "open".
+        self.fail_closed = (os.getenv("PURVIEW_FAIL_MODE", "closed").strip().lower() != "open")
+        self.check_output = _env_bool("PURVIEW_CHECK_OUTPUT", True)
+        self.timeout_ms = int(os.getenv("PURVIEW_TIMEOUT_MS") or 2000)
+        self.debug = _env_bool("PURVIEW_DEBUG", False)
+
+        cfg = _load_a365_config()
+        self.app_id = (
+            os.getenv("PURVIEW_APP_ID")
+            or cfg.get("appId")
+            or os.getenv("CONNECTIONS__SERVICE_CONNECTION__SETTINGS__CLIENTID")
+            or os.getenv("AGENT_ID")
+            or ""
+        )
+        self.app_name = (os.getenv("PURVIEW_APP_NAME") or cfg.get("appName") or "").strip() or "AI Agent"
+        self.blueprint_id = (
+            os.getenv("PURVIEW_BLUEPRINT_ID")
+            or cfg.get("blueprintId")
+            or os.getenv("AGENT365OBSERVABILITY__AGENTBLUEPRINTID")
+            or self.app_id
+        )
+        self.auth_handler_name = os.getenv("PURVIEW_AUTH_HANDLER") or os.getenv("AUTH_HANDLER_NAME") or "agentic"
+
+        if self.enabled and not self.app_id:
+            logger.warning(
+                "[purview] PURVIEW_DLP_ENABLED=true but no app id resolved — set PURVIEW_APP_ID or run from a "
+                "folder containing a365.generated.config.json (agentBlueprintId). Every turn will fail-closed."
+            )
+
+    @property
+    def is_enabled(self) -> bool:
+        return self.enabled
+
+    @property
+    def is_check_output(self) -> bool:
+        return self.check_output
+
+    async def evaluate_prompt(self, authorization, auth_handler_name, user_id, text, context) -> DlpVerdict:
+        """Evaluate the user's prompt BEFORE it reaches the LLM."""
+        return await self._evaluate(authorization, auth_handler_name, "uploadText", 0, user_id, text, context)
+
+    async def evaluate_response(self, authorization, auth_handler_name, user_id, text, context) -> DlpVerdict:
+        """Evaluate the model's response BEFORE it's sent back to the user."""
+        return await self._evaluate(authorization, auth_handler_name, "downloadText", 1, user_id, text, context)
+
+    def _fail(self, detail: str) -> DlpVerdict:
+        # Fail-closed => block; fail-open => allow.
+        return DlpVerdict(blocked=self.fail_closed, decision="error", detail=detail)
+
+    @staticmethod
+    def _is_block(actions) -> bool:
+        return any(
+            str(a.get("restrictionAction", "")).lower() == "block"
+            for a in (actions or [])
+            if isinstance(a, dict)
+        )
+
+    async def _evaluate(self, authorization, auth_handler_name, activity, sequence_number, _user_id, text, context) -> DlpVerdict:
+        if not self.enabled:
+            return DlpVerdict(blocked=False, decision="disabled")
+        if not self.app_id:
+            return self._fail("missing PURVIEW_APP_ID")
+
+        req_id = str(uuid.uuid4())
+        try:
+            token = await self._get_token(authorization, auth_handler_name, context)
+            body = self._build_body(activity, sequence_number, text, context)
+            async with httpx.AsyncClient(timeout=self.timeout_ms / 1000.0) as client:
+                res = await client.post(
+                    f"{GRAPH_BASE}/me/dataSecurityAndGovernance/processContent",
+                    headers={
+                        "Authorization": f"Bearer {token}",
+                        "Content-Type": "application/json",
+                        "Client-Request-Id": req_id,
+                    },
+                    json=body,
+                )
+
+            if res.status_code >= 400:
+                err_text = (res.text or "")[:300]
+                logger.error("[purview] %s HTTP %s reqId=%s: %s", activity, res.status_code, req_id, err_text)
+                return self._fail(f"graph {res.status_code}")
+
+            # 202/204 => accepted, no inline decision.
+            if res.status_code in (202, 204):
+                logger.info("[purview] %s -> allowed (HTTP %s, no content) reqId=%s", activity, res.status_code, req_id)
+                return DlpVerdict(blocked=False, decision="allowed")
+
+            data = res.json()
+            actions = data.get("policyActions") or []
+            errs = data.get("processingErrors") or []
+            summary = (
+                f"HTTP {res.status_code}, {len(actions)} policyAction(s), "
+                f"scopeState={data.get('protectionScopeState', 'n/a')}, errors={len(errs)}"
+            )
+
+            # A permanent BadRequest here means OUR REQUEST is malformed — fail-closed, don't silently allow.
+            if errs:
+                logger.error("[purview] %s -> REQUEST ERROR (%s) errors=%s reqId=%s",
+                             activity, summary, json.dumps(errs)[:500], req_id)
+                return self._fail(f"processingErrors: {json.dumps(errs)[:200]}")
+
+            if self._is_block(actions):
+                logger.warning("[purview] %s -> BLOCKED (%s) reqId=%s", activity, summary, req_id)
+                return DlpVerdict(blocked=True, decision="blocked", detail="restrictAccess/block")
+
+            raw = f" raw={json.dumps(data)[:700]}" if self.debug else ""
+            logger.info("[purview] %s -> allowed (%s)%s reqId=%s", activity, summary, raw, req_id)
+            return DlpVerdict(blocked=False, decision="allowed")
+
+        except httpx.TimeoutException:
+            logger.error("[purview] %s error reqId=%s: timeout after %sms", activity, req_id, self.timeout_ms)
+            return self._fail(f"timeout after {self.timeout_ms}ms")
+        except Exception as err:  # noqa: BLE001
+            logger.error("[purview] %s error reqId=%s: %s", activity, req_id, err)
+            return self._fail(str(err))
+
+    async def _get_token(self, authorization, auth_handler_name, context) -> str:
+        """Agent-identity (agentic delegated) Graph token — carries the delegated
+        Content.Process.User scope granted on the agent's agentic consent. Uses the same
+        exchange_token call the A365 host uses for observability."""
+        handler = auth_handler_name or self.auth_handler_name
+        resp = await authorization.exchange_token(context, scopes=[GRAPH_SCOPE], auth_handler_id=handler)
+        token = getattr(resp, "token", None) or (resp if isinstance(resp, str) else None)
+        if not token:
+            raise RuntimeError("failed to acquire agentic Graph token (is the agentic auth handler name correct?)")
+        return token
+
+    def _build_body(self, activity, sequence_number, text, context) -> dict:
+        recipient = getattr(getattr(context, "activity", None), "recipient", None)
+        agent_id = getattr(recipient, "agentic_app_id", None) or self.app_id
+        blueprint_id = self.blueprint_id or getattr(recipient, "agentic_app_blueprint_id", None) or self.app_id
+
+        truncated = len(text) > MAX_CONTENT_CHARS
+        now = datetime.now(timezone.utc).isoformat()
+        conv = getattr(getattr(context, "activity", None), "conversation", None)
+        correlation_id = getattr(conv, "id", None) or str(uuid.uuid4())
+
+        return {
+            "contentToProcess": {
+                "contentEntries": [
+                    {
+                        "@odata.type": "microsoft.graph.processConversationMetadata",
+                        "identifier": str(uuid.uuid4()),
+                        "content": {
+                            "@odata.type": "microsoft.graph.textContent",
+                            "data": text[:MAX_CONTENT_CHARS] if truncated else text,
+                        },
+                        "agents": [
+                            {
+                                "@odata.type": "microsoft.graph.aiAgentInfo",
+                                "blueprintId": blueprint_id,
+                                "identifier": agent_id,
+                                "name": self.app_name,
+                                "version": "1.0",
+                            }
+                        ],
+                        # ⚠️ REQUIRED non-empty name — omitting it => permanent BadRequest "Name is invalid".
+                        "name": f"{self.app_name} message",
+                        "correlationId": correlation_id,
+                        "sequenceNumber": sequence_number,
+                        "isTruncated": truncated,
+                        "createdDateTime": now,
+                        "modifiedDateTime": now,
+                        "contentCategory": "ai",
+                    }
+                ],
+                "activityMetadata": {"activity": activity},  # input=uploadText, output=downloadText
+                "integratedAppMetadata": {"name": self.app_name, "version": "1.0.0"},
+                "protectedAppMetadata": {
+                    "name": self.app_name,
+                    "version": "1.0.0",
+                    "applicationLocation": {
+                        "@odata.type": "microsoft.graph.policyLocationApplication",
+                        "value": self.app_id,  # must match the app id in your DLP policy location
+                    },
+                },
+            }
+        }
+
+
+# Singleton — import: from purview import purview_guard
+purview_guard = PurviewGuard()

--- a/plugins/agent365/skills/purview-dlp-integration/assets/purview.py
+++ b/plugins/agent365/skills/purview-dlp-integration/assets/purview.py
@@ -48,6 +48,9 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 
 import httpx
+from dotenv import load_dotenv
+
+load_dotenv(dotenv_path=os.path.join(os.getcwd(), ".env"), override=False)
 
 logger = logging.getLogger(__name__)
 

--- a/plugins/agent365/skills/purview-dlp-integration/assets/purview.ts
+++ b/plugins/agent365/skills/purview-dlp-integration/assets/purview.ts
@@ -1,0 +1,348 @@
+// ────────────────────────────────────────────────────────────────────────────
+// Microsoft Purview DLP + Audit guard for Microsoft Agent 365 (A365) agents.
+//
+// Drop-in module: evaluates every agent turn (prompt-in and/or response-out) against
+// Microsoft Purview data-loss-prevention (DLP) policies via the Microsoft Graph beta
+// `processContent` API, and BLOCKS the turn when a policy says so. `processContent`
+// also writes the Purview audit event, so a successful call satisfies auditing too.
+//
+// This template is generic and driven entirely by environment variables — copy it into
+// your agent's source folder (next to your AgentApplication) and wire the two gates in
+// (see the skill's SKILL.md "Wire into the agent" step). No values are hard-coded.
+//
+// ── HOW IT WORKS ─────────────────────────────────────────────────────────────
+//  • Token : the agent's AGENTIC DELEGATED Graph token (GetAgenticUserToken), evaluated
+//            as `/me` (the agent identity). A365 blueprint apps CANNOT use app-only
+//            client-credentials for this — Microsoft Graph strips data-plane roles
+//            (e.g. Content.Process.All) from a blueprint app's app-only token.
+//  • Scope : input (uploadText) and, if PURVIEW_CHECK_OUTPUT=true, output (downloadText).
+//  • Fail  : FAIL-CLOSED by default (PURVIEW_FAIL_MODE=closed) — any error/timeout blocks
+//            the turn so content is never processed unverified. Set to `open` to fail-open.
+//  • Policy: a Purview DLP policy scoped to THIS agent's Entra app id, under the
+//            "Applications" workload (portal: "Managed cloud apps"), with a
+//            RestrictAccess=Block rule. See scripts/New-AiAppDlpPolicy.ps1.
+//
+// ── REQUIRED ENV ─────────────────────────────────────────────────────────────
+//   PURVIEW_DLP_ENABLED=true
+// The agent app id + display name are AUTO-DISCOVERED from a365.config.json /
+// a365.generated.config.json in the project root (cwd) when present — so on an A365 project
+// you usually only need PURVIEW_DLP_ENABLED. Override / supply explicitly with:
+//   PURVIEW_APP_ID=<agent Entra app (client) id>   // else: a365 config, then A365 connection envs
+//   PURVIEW_APP_NAME=<non-empty display name>       // else: a365 config; must be non-empty (see ⚠️ below)
+// ── OPTIONAL ENV ─────────────────────────────────────────────────────────────
+//   PURVIEW_BLUEPRINT_ID=<agent blueprint id>       // default: PURVIEW_APP_ID
+//   PURVIEW_AUTH_HANDLER=agentic                    // the agentic auth handler name on your AgentApplication
+//   PURVIEW_FAIL_MODE=closed|open                   // default closed
+//   PURVIEW_CHECK_OUTPUT=true|false                 // default true (also gate the model's response)
+//   PURVIEW_TIMEOUT_MS=2000                         // per-call hard timeout
+//   PURVIEW_DEBUG=false                             // true = log Purview's raw JSON response every turn
+//
+// ⚠️ CRITICAL: every processContent `contentEntry` MUST include a non-empty `name`. If it is
+//    missing, Graph rejects the request with a PERMANENT BadRequest ("The provided data for
+//    Name is invalid") returned as HTTP 200 with 0 policyActions — which looks IDENTICAL to a
+//    clean "allowed". This guard therefore (a) always sets `name`, and (b) treats any
+//    `processingErrors` as a hard failure (fail-closed) and logs them loudly. Do not remove.
+// ────────────────────────────────────────────────────────────────────────────
+
+import 'dotenv/config';
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { Authorization, TurnContext } from '@microsoft/agents-hosting';
+import { AgenticAuthenticationService } from '@microsoft/agents-a365-runtime';
+
+const GRAPH_BASE = 'https://graph.microsoft.com/beta';
+const GRAPH_SCOPE = 'https://graph.microsoft.com/.default';
+const MAX_CONTENT_CHARS = 100_000;
+
+type DlpActivity = 'uploadText' | 'downloadText';
+type DlpDecision = 'allowed' | 'blocked' | 'error' | 'disabled';
+
+export interface DlpVerdict {
+  /** True => stop the turn. */
+  blocked: boolean;
+  decision: DlpDecision;
+  detail?: string;
+}
+
+interface ProcessContentResponse {
+  protectionScopeState?: string;
+  policyActions?: Array<Record<string, unknown>>;
+  processingErrors?: Array<Record<string, unknown>>;
+}
+
+function envBool(name: string, def: boolean): boolean {
+  const v = process.env[name];
+  if (v === undefined || v === '') return def;
+  return /^(1|true|yes|on)$/i.test(v.trim());
+}
+
+/** A block is any restrictAccess action whose restrictionAction === "block". */
+function isBlock(actions?: Array<Record<string, unknown>>): boolean {
+  return !!actions?.some(
+    (a) => String((a as Record<string, unknown>).restrictionAction ?? '').toLowerCase() === 'block',
+  );
+}
+
+async function safeText(res: Response): Promise<string> {
+  try {
+    return await res.text();
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Best-effort read of A365 project config so an A365 agent needs almost no extra env.
+ * Reads a365.generated.config.json + a365.config.json from the current working directory
+ * (the project root the agent starts from). Missing/unreadable files are ignored.
+ */
+interface A365Discovered {
+  appId?: string;
+  appName?: string;
+  blueprintId?: string;
+  tenantId?: string;
+}
+function loadA365Config(): A365Discovered {
+  const out: A365Discovered = {};
+  for (const file of ['a365.generated.config.json', 'a365.config.json']) {
+    try {
+      const j = JSON.parse(readFileSync(resolve(process.cwd(), file), 'utf8')) as Record<string, unknown>;
+      out.appId ??= (j.agentBlueprintId ?? j.botMsaAppId ?? j.botId) as string | undefined;
+      out.blueprintId ??= j.agentBlueprintId as string | undefined;
+      out.appName ??= (j.agentBlueprintDisplayName ?? j.agentDescription ?? j.agentIdentityDisplayName) as string | undefined;
+      out.tenantId ??= j.tenantId as string | undefined;
+    } catch {
+      /* file missing or unreadable — ignore */
+    }
+  }
+  return out;
+}
+
+export class PurviewGuard {
+  private readonly enabled: boolean;
+  private readonly failClosed: boolean;
+  private readonly checkOutput: boolean;
+  private readonly timeoutMs: number;
+  private readonly debug: boolean;
+  private readonly appId: string;
+  private readonly appName: string;
+  private readonly blueprintId: string;
+  private readonly authHandlerName: string;
+
+  constructor() {
+    this.enabled = envBool('PURVIEW_DLP_ENABLED', false);
+    // Fail-closed unless explicitly set to "open".
+    this.failClosed = (process.env.PURVIEW_FAIL_MODE ?? 'closed').trim().toLowerCase() !== 'open';
+    this.checkOutput = envBool('PURVIEW_CHECK_OUTPUT', true);
+    this.timeoutMs = Number(process.env.PURVIEW_TIMEOUT_MS) || 2000;
+    this.debug = envBool('PURVIEW_DEBUG', false);
+
+    // The agent's Entra app (client) id. Used as the DLP applicationLocation AND as the
+    // aiAgentInfo.identifier fallback. Precedence: explicit env > a365 config > A365 connection env.
+    const cfg = loadA365Config();
+    this.appId =
+      process.env.PURVIEW_APP_ID ??
+      cfg.appId ??
+      process.env.connections__service_connection__settings__clientId ??
+      process.env.agent_id ??
+      '';
+    // MUST be non-empty (used for the required content-entry `name`).
+    this.appName = (process.env.PURVIEW_APP_NAME ?? cfg.appName ?? '').trim() || 'AI Agent';
+    this.blueprintId =
+      process.env.PURVIEW_BLUEPRINT_ID ??
+      cfg.blueprintId ??
+      process.env.agent365Observability__agentBlueprintId ??
+      this.appId;
+    this.authHandlerName = process.env.PURVIEW_AUTH_HANDLER ?? 'agentic';
+
+    if (this.enabled && !this.appId) {
+      console.warn(
+        '[purview] PURVIEW_DLP_ENABLED=true but no app id resolved — set PURVIEW_APP_ID or run from a ' +
+          'folder containing a365.generated.config.json (agentBlueprintId). Every turn will fail-closed.',
+      );
+    }
+  }
+
+  get isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  get isCheckOutput(): boolean {
+    return this.checkOutput;
+  }
+
+  /** Evaluate the user's prompt BEFORE it reaches the LLM. */
+  evaluatePrompt(
+    authorization: Authorization,
+    userId: string,
+    text: string,
+    ctx: TurnContext,
+  ): Promise<DlpVerdict> {
+    return this.evaluate(authorization, 'uploadText', 0, userId, text, ctx);
+  }
+
+  /** Evaluate the model's response BEFORE it's sent back to the user. */
+  evaluateResponse(
+    authorization: Authorization,
+    userId: string,
+    text: string,
+    ctx: TurnContext,
+  ): Promise<DlpVerdict> {
+    return this.evaluate(authorization, 'downloadText', 1, userId, text, ctx);
+  }
+
+  private failVerdict(detail: string): DlpVerdict {
+    // Fail-closed => block; fail-open => allow. Decision captured either way.
+    return { blocked: this.failClosed, decision: 'error', detail };
+  }
+
+  private async evaluate(
+    authorization: Authorization,
+    activity: DlpActivity,
+    sequenceNumber: number,
+    _userId: string,
+    text: string,
+    ctx: TurnContext,
+  ): Promise<DlpVerdict> {
+    if (!this.enabled) return { blocked: false, decision: 'disabled' };
+    if (!this.appId) return this.failVerdict('missing PURVIEW_APP_ID');
+
+    const reqId = randomUUID();
+    try {
+      const token = await this.getToken(authorization, ctx);
+      const body = this.buildBody(activity, sequenceNumber, text, ctx);
+      // Evaluate under the AGENT identity (/me). The agentic delegated token represents the
+      // agent, so /users/{other} would be unauthorized.
+      const res = await this.postWithTimeout(
+        `${GRAPH_BASE}/me/dataSecurityAndGovernance/processContent`,
+        token,
+        reqId,
+        body,
+      );
+
+      if (!res.ok) {
+        const errText = await safeText(res);
+        console.error(`[purview] ${activity} HTTP ${res.status} reqId=${reqId}: ${errText.slice(0, 300)}`);
+        return this.failVerdict(`graph ${res.status}`);
+      }
+      // 202/204 => accepted, no inline decision.
+      if (res.status === 202 || res.status === 204) {
+        console.log(`[purview] ${activity} -> allowed (HTTP ${res.status}, no content) reqId=${reqId}`);
+        return { blocked: false, decision: 'allowed' };
+      }
+
+      const json = (await res.json()) as ProcessContentResponse;
+      const actions = json.policyActions ?? [];
+      const errs = json.processingErrors ?? [];
+      const summary = `HTTP ${res.status}, ${actions.length} policyAction(s), scopeState=${json.protectionScopeState ?? 'n/a'}, errors=${errs.length}`;
+
+      // ⚠️ A permanent BadRequest here means OUR REQUEST is malformed — Purview did NOT evaluate
+      // the content. Treat as a failure (fail-closed) instead of a silent "allow", and log it.
+      if (errs.length) {
+        console.error(`[purview] ${activity} -> REQUEST ERROR (${summary}) errors=${JSON.stringify(errs).slice(0, 500)} reqId=${reqId}`);
+        return this.failVerdict(`processingErrors: ${JSON.stringify(errs).slice(0, 200)}`);
+      }
+
+      if (isBlock(actions)) {
+        console.warn(`[purview] ${activity} -> BLOCKED (${summary}) reqId=${reqId}`);
+        return { blocked: true, decision: 'blocked', detail: 'restrictAccess/block' };
+      }
+
+      console.log(
+        `[purview] ${activity} -> allowed (${summary})${this.debug ? ` raw=${JSON.stringify(json).slice(0, 700)}` : ''} reqId=${reqId}`,
+      );
+      return { blocked: false, decision: 'allowed' };
+    } catch (err) {
+      const msg = (err as Error).name === 'AbortError' ? `timeout after ${this.timeoutMs}ms` : (err as Error).message;
+      console.error(`[purview] ${activity} error reqId=${reqId}: ${msg}`);
+      return this.failVerdict(msg);
+    }
+  }
+
+  private async getToken(authorization: Authorization, ctx: TurnContext): Promise<string> {
+    // Agent-identity (agentic delegated) Graph token — carries the delegated
+    // Content.Process.User scope granted on the agent's agentic consent.
+    const token = await AgenticAuthenticationService.GetAgenticUserToken(
+      authorization,
+      this.authHandlerName,
+      ctx,
+      [GRAPH_SCOPE],
+    );
+    if (!token) throw new Error('failed to acquire agentic Graph token (is the agentic auth handler name correct?)');
+    return token;
+  }
+
+  private async postWithTimeout(url: string, token: string, reqId: string, body: unknown): Promise<Response> {
+    const ac = new AbortController();
+    const timer = setTimeout(() => ac.abort(), this.timeoutMs);
+    try {
+      return await fetch(url, {
+        method: 'POST',
+        signal: ac.signal,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          'Client-Request-Id': reqId,
+        },
+        body: JSON.stringify(body),
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private buildBody(activity: DlpActivity, sequenceNumber: number, text: string, ctx: TurnContext) {
+    const recipient = ctx.activity?.recipient as Record<string, unknown> | undefined;
+    const agentId = (recipient?.agenticAppId as string) ?? this.appId;
+    const blueprintId = this.blueprintId || (recipient?.agenticAppBlueprintId as string) || this.appId;
+
+    const truncated = text.length > MAX_CONTENT_CHARS;
+    const now = new Date().toISOString();
+
+    return {
+      contentToProcess: {
+        contentEntries: [
+          {
+            '@odata.type': 'microsoft.graph.processConversationMetadata',
+            identifier: randomUUID(),
+            content: {
+              '@odata.type': 'microsoft.graph.textContent',
+              data: truncated ? text.slice(0, MAX_CONTENT_CHARS) : text,
+            },
+            agents: [
+              {
+                '@odata.type': 'microsoft.graph.aiAgentInfo',
+                blueprintId,
+                identifier: agentId,
+                name: this.appName,
+                version: '1.0',
+              },
+            ],
+            // ⚠️ REQUIRED non-empty name — omitting it => permanent BadRequest "Name is invalid".
+            name: `${this.appName} message`,
+            correlationId: (ctx.activity?.conversation?.id as string) ?? randomUUID(),
+            sequenceNumber,
+            isTruncated: truncated,
+            createdDateTime: now,
+            modifiedDateTime: now,
+            contentCategory: 'ai',
+          },
+        ],
+        activityMetadata: { activity }, // input=uploadText, output=downloadText
+        integratedAppMetadata: { name: this.appName, version: '1.0.0' },
+        protectedAppMetadata: {
+          name: this.appName,
+          version: '1.0.0',
+          applicationLocation: {
+            '@odata.type': 'microsoft.graph.policyLocationApplication',
+            value: this.appId, // must match the app id in your DLP policy location
+          },
+        },
+      },
+    };
+  }
+}
+
+/** Singleton — import { purviewGuard } from './purview.js'. */
+export const purviewGuard = new PurviewGuard();

--- a/plugins/agent365/skills/purview-dlp-integration/assets/wiring-snippet.cs
+++ b/plugins/agent365/skills/purview-dlp-integration/assets/wiring-snippet.cs
@@ -1,0 +1,56 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// WIRING SNIPPET (.NET) — how to add the two DLP gates to an existing A365 agent.
+//
+// A365 DLP — best-effort wiring (verify against SDK source before production).
+// This is a REFERENCE, not a compiled file. Apply these MINIMAL edits to your
+// AgentApplication's message handler (OnMessageAsync — the method that calls the LLM),
+// and any notification/email handler that also calls the LLM.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// 1) Add a using for the guard's namespace at the top of your agent file:
+using Agent365.Purview;
+
+// 2) Inside OnMessageAsync you have `turnContext` (ITurnContext), `this.UserAuthorization`
+//    (the AgentApplication authorization handler) and the agentic auth handler name (usually
+//    from configuration: AgentApplication:AgenticAuthHandlerName, e.g. "agentic"). Resolve the
+//    text + caller id:
+//
+//    var userMessage = turnContext.Activity.Text ?? string.Empty;
+//    var authHandlerName = _configuration["AgentApplication:AgenticAuthHandlerName"] ?? "agentic";
+
+// 3) INPUT GATE — evaluate the prompt BEFORE calling the LLM:
+if (PurviewGuard.Instance.IsEnabled)
+{
+    var gate = await PurviewGuard.Instance.EvaluatePromptAsync(
+        UserAuthorization, authHandlerName, turnContext, userMessage, cancellationToken);
+    if (gate.Blocked)
+    {
+        await turnContext.SendActivityAsync(
+            gate.Decision == "blocked"
+                ? "🚫 I can't help with that — your request was blocked by your organization's data-loss-prevention policy."
+                : "🚫 I couldn't check this against your organization's data policy, so I've stopped the request. Please try again shortly.",
+            cancellationToken: cancellationToken);
+        return; // ← the LLM is never called
+    }
+}
+
+// 4) ... your existing LLM call, e.g.:
+//    var answer = await _chatClient.CompleteAsync(userMessage, cancellationToken);
+
+// 5) OUTPUT GATE — evaluate the model's answer BEFORE sending it:
+if (PurviewGuard.Instance.IsEnabled && PurviewGuard.Instance.IsCheckOutput)
+{
+    var outGate = await PurviewGuard.Instance.EvaluateResponseAsync(
+        UserAuthorization, authHandlerName, turnContext, answer, cancellationToken);
+    if (outGate.Blocked)
+    {
+        await turnContext.SendActivityAsync(
+            outGate.Decision == "blocked"
+                ? "🚫 My response was withheld by your organization's data-loss-prevention policy."
+                : "🚫 I couldn't check my response against your organization's data policy, so I've withheld it.",
+            cancellationToken: cancellationToken);
+        return;
+    }
+}
+
+// 6) ... your existing `await turnContext.SendActivityAsync(answer, cancellationToken: cancellationToken);`

--- a/plugins/agent365/skills/purview-dlp-integration/assets/wiring-snippet.py
+++ b/plugins/agent365/skills/purview-dlp-integration/assets/wiring-snippet.py
@@ -1,0 +1,51 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# WIRING SNIPPET (PYTHON) — how to add the two DLP gates to an existing A365 agent.
+#
+# This is a REFERENCE, not an importable module. Apply these MINIMAL edits to your
+# agent's message handler (the method that calls the LLM — e.g. process_user_message
+# on your AgentInterface, or the on_message handler), and any notification/email
+# handler that also calls the LLM. Everything else stays the same.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# 1) Import the guard at the top of your agent file:
+from purview import purview_guard  # noqa: E402
+
+# 2) Inside your message handler you already receive the A365 Authorization handler, the
+#    auth-handler name, and the TurnContext. (In the AgentInterface pattern the signature is
+#    `process_user_message(self, message, auth, auth_handler_name, context)`.) Resolve the caller id:
+#
+#    from_prop = getattr(getattr(context, "activity", None), "from_property", None)
+#    user_id = (getattr(from_prop, "aad_object_id", None) or getattr(from_prop, "id", None) or "") if from_prop else ""
+
+
+# Optional helper for the user-facing block/withhold messages:
+def _dlp_block_message(verdict, phase: str) -> str:
+    if verdict.decision == "blocked":
+        return (
+            "🚫 I can't help with that — your request was blocked by your organization's data-loss-prevention policy."
+            if phase == "input"
+            else "🚫 My response was withheld by your organization's data-loss-prevention policy."
+        )
+    return (
+        "🚫 I couldn't check this against your organization's data policy, so I've stopped the request. Please try again shortly."
+        if phase == "input"
+        else "🚫 I couldn't check my response against your organization's data policy, so I've withheld it."
+    )
+
+
+# 3) INPUT GATE — evaluate the prompt BEFORE calling the LLM:
+if purview_guard.is_enabled:
+    gate = await purview_guard.evaluate_prompt(auth, auth_handler_name, user_id, message, context)
+    if gate.blocked:
+        return _dlp_block_message(gate, "input")  # ← the LLM is never called
+
+# 4) ... your existing LLM call, e.g.:
+#    reply = await self._agent.run(session_id, message)
+
+# 5) OUTPUT GATE — evaluate the model's answer BEFORE returning / sending it:
+if purview_guard.is_enabled and purview_guard.is_check_output:
+    out_gate = await purview_guard.evaluate_response(auth, auth_handler_name, user_id, reply, context)
+    if out_gate.blocked:
+        return _dlp_block_message(out_gate, "output")
+
+# 6) ... your existing `return reply` (or `await context.send_activity(reply)`).

--- a/plugins/agent365/skills/purview-dlp-integration/assets/wiring-snippet.ts
+++ b/plugins/agent365/skills/purview-dlp-integration/assets/wiring-snippet.ts
@@ -1,0 +1,47 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// WIRING SNIPPET — how to add the two DLP gates to an existing A365 agent.
+//
+// This is a REFERENCE, not a compiled file. Apply these MINIMAL edits to your
+// AgentApplication's message handler (and any notification/email handler that
+// calls the LLM). Everything else stays the same.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// 1) Import the guard at the top of your agent file:
+import { purviewGuard } from './purview.js';
+
+// 2) Inside your message handler, `context` is the TurnContext and `this.authorization`
+//    is the AgentApplication's authorization handler. Resolve the caller id once:
+//
+//    const userId = context.activity.from?.aadObjectId ?? '';
+//    const userMessage = context.activity.text?.trim() ?? '';
+
+// 3) INPUT GATE — evaluate the prompt BEFORE calling the LLM:
+if (purviewGuard.isEnabled) {
+  const gate = await purviewGuard.evaluatePrompt(this.authorization, userId, userMessage, context);
+  if (gate.blocked) {
+    await context.sendActivity(
+      gate.decision === 'blocked'
+        ? "🚫 I can't help with that — your request was blocked by your organization's data-loss-prevention policy."
+        : "🚫 I couldn't check this against your organization's data policy, so I've stopped the request. Please try again shortly.",
+    );
+    return; // ← the LLM is never called
+  }
+}
+
+// 4) ... your existing LLM call, e.g.:
+//    const answer = await model.invoke(userMessage);
+
+// 5) OUTPUT GATE — evaluate the model's answer BEFORE sending it:
+if (purviewGuard.isEnabled && purviewGuard.isCheckOutput) {
+  const outGate = await purviewGuard.evaluateResponse(this.authorization, userId, answer, context);
+  if (outGate.blocked) {
+    await context.sendActivity(
+      outGate.decision === 'blocked'
+        ? "🚫 My response was withheld by your organization's data-loss-prevention policy."
+        : "🚫 I couldn't check my response against your organization's data policy, so I've withheld it.",
+    );
+    return;
+  }
+}
+
+// 6) ... your existing `await context.sendActivity(answer);`

--- a/plugins/agent365/skills/purview-dlp-integration/references/purview-portal-guide.md
+++ b/plugins/agent365/skills/purview-dlp-integration/references/purview-portal-guide.md
@@ -1,0 +1,80 @@
+# Purview Portal Enablement Guide (Agent 365 DLP)
+
+Steps that must (or can) be done in the Microsoft Purview portal / Entra, for the parts that
+aren't covered by the scripts in `../scripts/`. Hand this to whoever holds **Compliance
+Administrator** + **Global/Application Administrator** in the customer tenant.
+
+---
+
+## 0. Tenant prerequisites (do these first)
+
+DLP for AI apps is a metered Purview capability. If these aren't in place, `processContent`
+returns a clean **`0 policyAction(s)`** and nothing ever blocks — with no obvious error.
+
+1. **Licensing** — Microsoft 365 E5 / E5 Compliance (or equivalent) for the users/agents.
+2. **Purview pay‑as‑you‑go billing** — an Azure subscription linked to Purview for the metered
+   AI/DSPM features. Purview portal → **Settings → Billing** (or DSPM for AI onboarding prompts).
+3. **DSPM for AI onboarded** — Purview portal → **DSPM** → **AI observability** (the current
+   version, *not* "DSPM for AI (classic)"). Confirm your agent instance appears here.
+
+> Rule of thumb: if you've verified the agent code, the delegated scope, and the policy config,
+> and it *still* returns `0 policyAction(s)` with **no `processingErrors`**, the cause is almost
+> always one of the three items above.
+
+---
+
+## 1. Delegated Graph scope on the agent (usually via script)
+
+The guard needs the delegated **`Content.Process.User`** scope on the agent's Graph consent.
+Preferred: run [`../scripts/Grant-DelegatedGraphScope.ps1`](../scripts/Grant-DelegatedGraphScope.ps1).
+
+If you must do it by hand, **do not** use "Grant admin consent" on the blueprint app's API
+permissions page — that can wipe the agent's broad agentic consent and break sign‑in
+(`AADSTS65001`). Instead add the delegated permission and consent **only that scope**, or use the
+script which appends it to the existing grant.
+
+---
+
+## 2. Create the DLP policy
+
+Preferred: run [`../scripts/New-AiAppDlpPolicy.ps1`](../scripts/New-AiAppDlpPolicy.ps1). To do it
+in the portal instead:
+
+1. Purview portal → **Data Loss Prevention → Policies → + Create policy** (or **DSPM → Policies**).
+2. **Category/Template:** Custom → Custom policy.
+3. **Locations:** turn on **only** the AI‑app location and turn everything else **off**:
+   - The location is surfaced as **"Managed cloud apps"** (it maps to the `Applications`
+     workload). Edit it and scope to **your agent's Entra app** (search by app name / id).
+   - ❗ Do **not** also enable Exchange / SharePoint / OneDrive / Teams in the same policy — the
+     portal rejects mixing them with the AI‑app location
+     (`ErrorUnsupportedEnforcementPlanesException`). Make it a **dedicated** policy.
+4. **Rule → Conditions:** *Content contains* → **Sensitive info types** → e.g. **Credit Card Number**.
+5. **Rule → Actions:** **Restrict access or encrypt the content** → **Block**.
+   (An *audit / alert‑only* action will **not** block. In the API this shows as
+   `RestrictAccess`, not `BlockAccess`.)
+6. **Policy mode:** **Turn it on / Enforce** (not simulation/test).
+7. Save. Allow up to ~1 hour to propagate.
+
+> The "Microsoft 365 Copilot and Copilot Chat" location is **first‑party Copilot only** — it is
+> *not* your custom agent. Use **Managed cloud apps** scoped to your app.
+
+---
+
+## 3. Verify in the portal (optional)
+
+- **Purview → Audit** and **DSPM → AI activities**: prompts/responses evaluated by the agent
+  appear here (audit is written by every `processContent` call).
+- Don't rely on a policy's **`DistributionStatus`** — many tenants show **`Pending`** even for
+  policies that are fully live. Judge success by the agent's `[purview]` log line.
+
+---
+
+## What can / can't be automated
+
+| Task | CLI/script | Portal only |
+|------|-----------|-------------|
+| Grant delegated `Content.Process.User` | ✅ `Grant-DelegatedGraphScope.ps1` | ✅ |
+| Create the AI‑app DLP policy + block rule | ✅ `New-AiAppDlpPolicy.ps1` | ✅ |
+| Enable pay‑as‑you‑go billing | ❌ | ✅ Settings → Billing |
+| Onboard DSPM for AI | ❌ | ✅ DSPM → AI observability |
+| Assign E5/Compliance licenses | ❌ (admin center) | ✅ |

--- a/plugins/agent365/skills/purview-dlp-integration/references/troubleshooting.md
+++ b/plugins/agent365/skills/purview-dlp-integration/references/troubleshooting.md
@@ -1,0 +1,36 @@
+# Troubleshooting — Agent 365 Purview DLP
+
+Read the agent's console. Every `processContent` call logs a `[purview] …` line. Judge success
+by that line, not by the Purview portal.
+
+## The logs you'll see
+
+| Log line | Meaning |
+|----------|---------|
+| `[purview] uploadText -> allowed (HTTP 200, 0 policyAction(s), scopeState=notModified, errors=0)` | Request accepted, **no policy matched** (or not propagated / tenant not enabled). |
+| `[purview] uploadText -> BLOCKED (HTTP 200, 1 policyAction(s), scopeState=modified, errors=0)` | ✅ Working — content blocked, LLM not called. |
+| `[purview] uploadText -> REQUEST ERROR (… errors=1) errors=[{"code":"BadRequest",…}]` | Our **request is malformed** — Purview didn't evaluate. Fix the request (see below). |
+| `[purview] uploadText HTTP 403 …InsufficientGraphPermissions` | Token is missing the DLP scope. See "403" below. |
+| `[purview] … error … timeout` | Network/timeout → fail‑closed (blocked). |
+
+## Symptom → cause → fix
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `errors=1`, message *"The provided data for Name is invalid"* | The `contentEntry.name` field is missing/empty. | Keep the `name` field in the guard's request body (the template already sets it to `"<AppName> message"`); ensure `PURVIEW_APP_NAME` is non‑empty. |
+| `HTTP 403 InsufficientGraphPermissions` | Agentic token lacks `Content.Process.User`, **or** you tried app‑only client‑credentials (blueprint app‑only tokens drop data‑plane roles). | Run `Grant-DelegatedGraphScope.ps1`; ensure the guard uses the **agentic delegated** token (it does — Node.js `GetAgenticUserToken`, Python `exchange_token`, .NET `GetTurnTokenAsync`). Restart the agent. |
+| Agent stopped signing in after granting permissions (`AADSTS65001 consent_required`) | Someone ran `az ad app permission admin-consent` on the blueprint app and narrowed the agentic consent. | Re‑run your A365 setup (`a365 setup all …`) to restore consent. Grant the DLP scope with the script (append), never admin‑consent. |
+| `0 policyAction(s)`, `errors=0`, forever | Policy not scoped to this app / not propagated / tenant not enabled. | 1) Confirm the policy's **Managed cloud apps** location = this app id. 2) Wait ~1h. 3) Check tenant prerequisites (billing + DSPM for AI) — see the portal guide. |
+| Policy `DistributionStatus: Pending` | Unreliable field — shows Pending even for live policies in many tenants. | Ignore it. Judge by the `[purview]` log. |
+| Portal won't let you add the AI‑app location to your existing DLP policy | You're mixing it with Exchange/SharePoint/OneDrive/Teams. | Create a **dedicated** AI‑app policy (the script does this). |
+| Rule creation fails: `BlockAccess … not allowed for Applications workload` | Wrong action param for AI apps. | Use `-RestrictAccess @(@{setting='UploadText';value='Block'})`, not `-BlockAccess`. |
+| Teams shows "This message was blocked" but the agent still replies | That's **Teams message DLP** (a different policy), not the agent gate. | Unrelated to this integration — judge the agent gate by the `[purview]` log. |
+| The agent's own LLM refuses (e.g. "I can't repeat card numbers") | Model safety behavior, not the DLP gate. | Not this integration. |
+
+## Fast isolation checklist
+1. `PURVIEW_DLP_ENABLED=true`? Agent restarted after env change?
+2. `[purview]` line present at all? If not, the gate isn't wired into that handler.
+3. `errors=0`? If not, fix the request (usually the `name` field).
+4. Token OK (no 403)? If 403, grant the delegated scope.
+5. Use a **Luhn‑valid** test value (e.g. credit card `4111 1111 1111 1111`) — invalid numbers won't match the SIT.
+6. Still `0 policyAction(s)` with `errors=0`? → policy scope / propagation / tenant enablement (portal guide).

--- a/plugins/agent365/skills/purview-dlp-integration/scripts/Grant-ContentProcessAppRole.ps1
+++ b/plugins/agent365/skills/purview-dlp-integration/scripts/Grant-ContentProcessAppRole.ps1
@@ -1,0 +1,88 @@
+<#
+.SYNOPSIS
+  Grants the `Content.Process.All` (Application) Microsoft Graph role to an A365 agent's
+  AGENT IDENTITY service principal — the prerequisite for the S2S (app-only) Purview DLP guard
+  (assets/purview-s2s.ts).
+
+.DESCRIPTION
+  The delegated Purview guard uses the agent's `/me` agentic token. An S2S / autonomous agent
+  has no signed-in user, so it must call the app-only endpoint
+  `/users/{sponsor}/dataSecurityAndGovernance/processContent` with an app-only Graph token.
+
+  Verified 2026-08-26: a *blueprint* app-only token has `Content.Process.*` STRIPPED by Graph,
+  but the *agent identity* token minted through the FMI 3-hop chain RETAINS it. So the role must
+  be assigned to the AGENT IDENTITY service principal (agenticAppId), NOT the blueprint.
+
+  This adds a single surgical appRoleAssignment (it does NOT run admin-consent, which could
+  narrow the agent's existing delegated consent). Idempotent — a re-run is a no-op.
+
+  Requires: az login as an Application Administrator / Privileged Role Administrator (or GA)
+  with rights to create appRoleAssignments.
+
+.PARAMETER AgentIdentityAppId
+  The agent identity app id (a365.generated.config.json -> `agenticAppId`). Auto-discovered if omitted.
+
+.PARAMETER ConfigDir
+  Folder containing a365.generated.config.json (default: current directory).
+
+.EXAMPLE
+  ./Grant-ContentProcessAppRole.ps1                 # from the agent project folder
+  ./Grant-ContentProcessAppRole.ps1 -AgentIdentityAppId 1a9e680d-....
+#>
+[CmdletBinding()]
+param(
+  [string] $AgentIdentityAppId,
+  [string] $ConfigDir = '.'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Microsoft Graph resource app id + the Content.Process.All application app-role id (fixed, first-party).
+$GraphAppId = '00000003-0000-0000-c000-000000000000'
+$ContentProcessAllRoleId = '5ad511bf-571c-4ef6-8c3c-85b94b85df98'
+
+# ── Auto-discover the agent identity app id from a365 config ─────────────────
+if (-not $AgentIdentityAppId) {
+  $genPath = Join-Path $ConfigDir 'a365.generated.config.json'
+  if (Test-Path $genPath) {
+    try {
+      $gen = Get-Content $genPath -Raw | ConvertFrom-Json
+      if ($gen.agenticAppId) { $AgentIdentityAppId = [string]$gen.agenticAppId }
+    } catch { }
+  }
+}
+if (-not $AgentIdentityAppId) {
+  throw "AgentIdentityAppId not provided and 'agenticAppId' not found in a365.generated.config.json under '$ConfigDir'. Pass -AgentIdentityAppId."
+}
+Write-Host "Agent identity app id: $AgentIdentityAppId"
+
+# ── Resolve service principal object ids ────────────────────────────────────
+$agentSpId = az ad sp show --id $AgentIdentityAppId --query id -o tsv 2>$null
+if (-not $agentSpId) { throw "No service principal found for app id $AgentIdentityAppId (is the agent identity provisioned?)." }
+$graphSpId = az ad sp show --id $GraphAppId --query id -o tsv
+Write-Host "Agent identity SP objectId: $agentSpId"
+Write-Host "Microsoft Graph SP objectId: $graphSpId"
+
+# ── Idempotency: is the role already assigned? ──────────────────────────────
+$existing = az rest --method GET `
+  --uri "https://graph.microsoft.com/v1.0/servicePrincipals/$agentSpId/appRoleAssignments" `
+  --query "value[?appRoleId=='$ContentProcessAllRoleId' && resourceId=='$graphSpId'] | [0].id" -o tsv 2>$null
+if ($existing) {
+  Write-Host "Content.Process.All already assigned (assignment id: $existing). Nothing to do."
+  return
+}
+
+# ── Create the surgical appRoleAssignment ───────────────────────────────────
+$tmp = New-TemporaryFile
+@{ principalId = $agentSpId; resourceId = $graphSpId; appRoleId = $ContentProcessAllRoleId } |
+  ConvertTo-Json | Set-Content -Path $tmp -Encoding utf8
+try {
+  Write-Host "Granting Content.Process.All to the agent identity SP..."
+  az rest --method POST `
+    --uri "https://graph.microsoft.com/v1.0/servicePrincipals/$agentSpId/appRoleAssignments" `
+    --headers "Content-Type=application/json" `
+    --body "@$tmp" | Out-String | Write-Host
+  Write-Host "Done. The agent identity's FMI Graph token will now carry Content.Process.All."
+} finally {
+  Remove-Item $tmp -ErrorAction SilentlyContinue
+}

--- a/plugins/agent365/skills/purview-dlp-integration/scripts/Grant-DelegatedGraphScope.ps1
+++ b/plugins/agent365/skills/purview-dlp-integration/scripts/Grant-DelegatedGraphScope.ps1
@@ -1,0 +1,105 @@
+<#
+.SYNOPSIS
+  Grants the delegated Microsoft Graph scope(s) the DLP guard needs
+  (Content.Process.User) onto the agent's EXISTING agentic consent — surgically,
+  without disturbing the agent's broad agentic permissions.
+
+.DESCRIPTION
+  The guard calls `processContent` with the agent's AGENTIC DELEGATED token, so the agent's
+  Graph consent must include `Content.Process.User` (delegated). This script APPENDS that
+  scope to the existing AllPrincipals oauth2PermissionGrant for Microsoft Graph on the agent
+  app's service principal.
+
+  ⚠️ Why not `az ad app permission admin-consent`?
+     Because that rebuilds the delegated grant from the app manifest and can NARROW / wipe the
+     agent's broad agentic consent → the agent stops authenticating (AADSTS65001 consent_required).
+     Appending to the existing grant (as this script does) is safe and reversible.
+
+  Requires: Azure CLI (az), signed in as an admin who can consent for the tenant
+    az login --tenant <tenant-id>
+
+.PARAMETER AppId
+  The agent's Entra application (client) id (the blueprint app). Auto-discovered from
+  a365.generated.config.json (agentBlueprintId) if omitted; the agent SP object id is likewise
+  read from a365.generated.config.json (agentBlueprintServicePrincipalObjectId) to skip an az lookup.
+
+.EXAMPLE
+  # From an A365 project folder — app id + SP object id read from a365 config:
+  ./Grant-DelegatedGraphScope.ps1
+
+.EXAMPLE
+  ./Grant-DelegatedGraphScope.ps1 -AppId 00000000-1111-2222-3333-444444444444
+#>
+[CmdletBinding()]
+param(
+  [string]   $AppId,                            # auto-discovered from a365 config if omitted
+  [string[]] $Scope     = @('Content.Process.User', 'ProtectionScopes.Compute.User'),
+  [string]   $ConfigDir = '.'                    # folder containing a365.config.json / a365.generated.config.json
+)
+
+$ErrorActionPreference = 'Stop'
+$graphAppId = '00000003-0000-0000-c000-000000000000'
+
+# ── Auto-discover from A365 project config when values aren't passed ──────────
+function Get-A365Value {
+  param([string]$Dir, [string[]]$Files, [string[]]$Keys)
+  foreach ($f in $Files) {
+    $p = Join-Path $Dir $f
+    if (Test-Path $p) {
+      try { $j = Get-Content $p -Raw | ConvertFrom-Json } catch { continue }
+      foreach ($k in $Keys) { if (($j.PSObject.Properties.Name -contains $k) -and $j.$k) { return [string]$j.$k } }
+    }
+  }
+  return $null
+}
+if (-not $AppId) { $AppId = Get-A365Value $ConfigDir @('a365.generated.config.json','a365.config.json') @('agentBlueprintId','botMsaAppId','botId') }
+if (-not $AppId) { throw "AppId not provided and not found in a365 config under '$ConfigDir'. Pass -AppId." }
+
+# Prefer the agent SP object id straight from a365.generated.config.json (saves an az lookup).
+$bpSpId    = Get-A365Value $ConfigDir @('a365.generated.config.json') @('agentBlueprintServicePrincipalObjectId')
+if (-not $bpSpId) { $bpSpId = az ad sp show --id $AppId --query id -o tsv }
+$graphSpId = az ad sp show --id $graphAppId --query id -o tsv
+if (-not $bpSpId)    { throw "Could not resolve service principal for app $AppId. Is it provisioned in this tenant?" }
+if (-not $graphSpId) { throw "Could not resolve the Microsoft Graph service principal." }
+Write-Host "Agent SP objectId : $bpSpId"
+Write-Host "Graph SP objectId : $graphSpId"
+
+# Find the existing delegated (AllPrincipals) grant to Microsoft Graph.
+$grants = (az rest --method GET --url "https://graph.microsoft.com/v1.0/servicePrincipals/$bpSpId/oauth2PermissionGrants" | ConvertFrom-Json).value
+$g = $grants | Where-Object { $_.resourceId -eq $graphSpId } | Select-Object -First 1
+
+if (-not $g) {
+  Write-Host "No existing Graph delegated grant found — creating a new AllPrincipals grant."
+  $body = @{ clientId = $bpSpId; consentType = 'AllPrincipals'; resourceId = $graphSpId; scope = ($Scope -join ' ') } | ConvertTo-Json -Compress
+  $tmp = New-TemporaryFile; Set-Content -Path $tmp -Value $body -Encoding utf8
+  az rest --method POST --url "https://graph.microsoft.com/v1.0/oauth2PermissionGrants" --headers "Content-Type=application/json" --body "@$tmp" | Out-Null
+  Remove-Item $tmp -Force
+  Write-Host "Created grant with scopes: $($Scope -join ', ')"
+} else {
+  $existing = @($g.scope -split '\s+' | Where-Object { $_ })
+  $missing  = $Scope | Where-Object { $existing -notcontains $_ }
+  if ($missing.Count -eq 0) {
+    Write-Host "All requested scopes already present. Nothing to do."
+  } else {
+    $newScope = (($existing + $missing) -join ' ').Trim()
+    Write-Host "BEFORE: $($g.scope)"
+    Write-Host "ADDING: $($missing -join ', ')"
+    $body = @{ scope = $newScope } | ConvertTo-Json -Compress
+    $tmp = New-TemporaryFile; Set-Content -Path $tmp -Value $body -Encoding utf8
+    az rest --method PATCH --url "https://graph.microsoft.com/v1.0/oauth2PermissionGrants/$($g.id)" --headers "Content-Type=application/json" --body "@$tmp" | Out-Null
+    Remove-Item $tmp -Force
+    Write-Host "AFTER : $newScope"
+  }
+}
+
+# Verify.
+Start-Sleep -Seconds 2
+$after = (az rest --method GET --url "https://graph.microsoft.com/v1.0/servicePrincipals/$bpSpId/oauth2PermissionGrants" | ConvertFrom-Json).value |
+  Where-Object { $_.resourceId -eq $graphSpId } | Select-Object -First 1
+Write-Host "`n=== VERIFY (Graph delegated scopes on agent) ==="
+Write-Host $after.scope
+foreach ($s in $Scope) {
+  $has = ($after.scope -split '\s+') -contains $s
+  Write-Host ("{0,-32} -> {1}" -f $s, ($(if ($has) { 'PRESENT' } else { 'MISSING' })))
+}
+Write-Host "`nRestart the agent so it picks up a fresh token, then test."

--- a/plugins/agent365/skills/purview-dlp-integration/scripts/New-AiAppDlpPolicy.ps1
+++ b/plugins/agent365/skills/purview-dlp-integration/scripts/New-AiAppDlpPolicy.ps1
@@ -1,0 +1,147 @@
+<#
+.SYNOPSIS
+  Creates a Microsoft Purview DLP policy that blocks sensitive content for a specific
+  Agent 365 / custom AI-app, enforced via the Graph `processContent` gate.
+
+.DESCRIPTION
+  A365 agents that call `processContent` are evaluated under the Purview "Applications"
+  workload, scoped to the agent's Entra app id (portal: "Managed cloud apps" location).
+  This script creates a dedicated DLP policy + rule for that app with a RestrictAccess=Block
+  action. It intentionally does NOT mix in Exchange/SharePoint/OneDrive/Teams locations,
+  because Purview rejects that combination (ErrorUnsupportedEnforcementPlanesException).
+
+  Gotchas this script handles for you (all learned the hard way):
+    • location must be Workload=Applications, Location=<AppId>, LocationSource=Entra
+    • policy requires  -EnforcementPlanes @('Application')   (NOT 'CopilotExperiences', which is first-party Copilot)
+    • the block action is  -RestrictAccess @(@{setting='UploadText';value='Block'})  (NOT -BlockAccess)
+    • DownloadText restrict is not supported for this workload → input (prompt) gate only
+
+  Requires: ExchangeOnlineManagement module + Security & Compliance admin. Run:
+    Install-Module ExchangeOnlineManagement -Scope CurrentUser
+
+.PARAMETER AppId
+  The agent's Entra application (client) id — the same id the agent sends as applicationLocation.
+  Auto-discovered from a365.generated.config.json (agentBlueprintId) / a365.config.json if omitted.
+
+.PARAMETER AppName
+  Display name for the policy location (free-form). Auto-discovered from a365.config.json
+  (agentBlueprintDisplayName / agentDescription) if omitted.
+
+.EXAMPLE
+  # From an A365 project folder — app id + name read from a365 config:
+  ./New-AiAppDlpPolicy.ps1 -NotifyUser admin@contoso.com
+
+.EXAMPLE
+  ./New-AiAppDlpPolicy.ps1 -AppId 00000000-1111-2222-3333-444444444444 -AppName "Contoso HR Agent" `
+     -SensitiveInfoType "Credit Card Number","U.S. Social Security Number (SSN)" -NotifyUser admin@contoso.com
+#>
+[CmdletBinding()]
+param(
+  [string]   $AppId,                            # auto-discovered from a365 config if omitted
+  [string]   $AppName,                          # auto-discovered from a365 config if omitted
+  [string]   $PolicyName,
+  [string]   $RuleName,
+  [string[]] $SensitiveInfoType = @('Credit Card Number'),
+  [string]   $NotifyUser        = $null,        # admin UPN to notify on match (recommended by MS: agents are unaware of blocks)
+  [string]   $UserPrincipalName = $null,        # UPN to sign in with (optional; speeds up Connect-IPPSSession)
+  [switch]   $ListExisting,                     # read-only: list existing DLP policies + whether they cover this app, then exit
+  [string]   $ConfigDir         = '.'           # folder containing a365.config.json / a365.generated.config.json
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ── Auto-discover from A365 project config when values aren't passed ──────────
+function Get-A365Value {
+  param([string]$Dir, [string[]]$Files, [string[]]$Keys)
+  foreach ($f in $Files) {
+    $p = Join-Path $Dir $f
+    if (Test-Path $p) {
+      try { $j = Get-Content $p -Raw | ConvertFrom-Json } catch { continue }
+      foreach ($k in $Keys) { if (($j.PSObject.Properties.Name -contains $k) -and $j.$k) { return [string]$j.$k } }
+    }
+  }
+  return $null
+}
+if (-not $AppId)   { $AppId   = Get-A365Value $ConfigDir @('a365.generated.config.json','a365.config.json') @('agentBlueprintId','botMsaAppId','botId') }
+if (-not $AppName) { $AppName = Get-A365Value $ConfigDir @('a365.config.json') @('agentBlueprintDisplayName','agentDescription','agentIdentityDisplayName') }
+if (-not $AppId)      { throw "AppId not provided and not found in a365 config under '$ConfigDir'. Pass -AppId." }
+if (-not $AppName)    { $AppName = 'AI Agent' }
+if (-not $PolicyName) { $PolicyName = "AI Agent DLP - $AppName" }
+if (-not $RuleName)   { $RuleName   = "$PolicyName rule" }
+Write-Host "Target app: $AppId  ('$AppName')"
+
+# 1) Ensure we're connected to Security & Compliance PowerShell.
+if (-not (Get-Module -ListAvailable -Name ExchangeOnlineManagement)) {
+  throw "ExchangeOnlineManagement module not found. Run: Install-Module ExchangeOnlineManagement -Scope CurrentUser"
+}
+Import-Module ExchangeOnlineManagement -ErrorAction Stop
+try {
+  Get-DlpCompliancePolicy -ErrorAction Stop | Out-Null
+} catch {
+  Write-Host "Connecting to Security & Compliance (a sign-in window will open)..."
+  if ($UserPrincipalName) { Connect-IPPSSession -UserPrincipalName $UserPrincipalName -ShowBanner:$false }
+  else                    { Connect-IPPSSession -ShowBanner:$false }
+}
+
+# 1b) -ListExisting: read-only. Show existing DLP policies and whether they already cover THIS app,
+#     so the operator can choose an existing policy instead of creating a new one. Then exit.
+if ($ListExisting) {
+  Write-Host "`n=== Existing DLP policies (coverage for app $AppId) ==="
+  $all = @(Get-DlpCompliancePolicy)
+  if (-not $all) {
+    Write-Host "  (no DLP policies found in this tenant)"
+  } else {
+    foreach ($p in ($all | Sort-Object Name)) {
+      $locStr  = "$($p.Locations)"
+      $covered = $locStr -match [regex]::Escape($AppId)
+      $hasApps = $locStr -match 'Applications'
+      $flag    = if ($covered) { 'COVERS THIS APP' } elseif ($hasApps) { 'Applications loc (other app)' } else { 'no Applications loc' }
+      Write-Host ("  {0,-45} Mode={1,-8} -> {2}" -f $p.Name, $p.Mode, $flag)
+    }
+  }
+  Write-Host "`nUse a policy marked 'COVERS THIS APP' as-is (the guard matches by app id)."
+  Write-Host "If none cover it, add this app id to a policy's Applications location in the Purview"
+  Write-Host "portal, or re-run WITHOUT -ListExisting to create a dedicated policy."
+  return
+}
+
+# 2) Build the AI-app (Managed cloud apps / Applications) location JSON for THIS app.
+$loc = "[{`"Workload`":`"Applications`",`"Location`":`"$AppId`",`"LocationDisplayName`":`"$AppName`",`"LocationSource`":`"Entra`",`"LocationType`":`"Individual`",`"Inclusions`":[{`"Type`":`"Tenant`",`"Identity`":`"All`"}]}]"
+
+# 3) Create the policy (idempotent).
+if (Get-DlpCompliancePolicy -Identity $PolicyName -ErrorAction SilentlyContinue) {
+  Write-Host "Policy already exists: $PolicyName"
+} else {
+  New-DlpCompliancePolicy -Name $PolicyName -Mode Enable -Locations $loc `
+    -EnforcementPlanes @('Application') `
+    -Comment "Blocks sensitive content in the '$AppName' AI app (processContent). Scoped to app $AppId." | Out-Null
+  Write-Host "Created policy: $PolicyName"
+}
+
+Start-Sleep -Seconds 3
+
+# 4) Create the rule (idempotent): SIT condition + RestrictAccess block on the prompt.
+if (Get-DlpComplianceRule -Identity $RuleName -ErrorAction SilentlyContinue) {
+  Write-Host "Rule already exists: $RuleName"
+} else {
+  $sit = @($SensitiveInfoType | ForEach-Object { @{ Name = $_ } })
+  $ruleParams = @{
+    Name                                = $RuleName
+    Policy                              = $PolicyName
+    ContentContainsSensitiveInformation = $sit
+    RestrictAccess                      = @(@{ setting = 'UploadText'; value = 'Block' })
+  }
+  if ($NotifyUser) { $ruleParams.NotifyUser = @($NotifyUser) }
+  New-DlpComplianceRule @ruleParams | Out-Null
+  Write-Host "Created rule: $RuleName  (SITs: $($SensitiveInfoType -join ', '))"
+}
+
+# 5) Verify.
+Write-Host "`n=== VERIFY POLICY ==="
+Get-DlpCompliancePolicy -Identity $PolicyName | Format-List Name, Mode, Enabled, Workload, Locations
+Write-Host "=== VERIFY RULE ==="
+Get-DlpComplianceRule -Identity $RuleName | Format-List Name, ParentPolicyName, Disabled, RestrictAccess
+
+Write-Host "`nDone. Allow up to ~1 hour to propagate, then test."
+Write-Host "NOTE: 'DistributionStatus: Pending' is UNRELIABLE — many tenants show Pending even for live"
+Write-Host "policies. Judge success only by the agent's [purview] log line, not by DistributionStatus."

--- a/tests/validate-purview-dlp-integration.test.js
+++ b/tests/validate-purview-dlp-integration.test.js
@@ -1,0 +1,190 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const { createFixture, runValidator, cleanup } = require('./helpers');
+
+const VALIDATOR = path.join(__dirname, '../plugins/agent365/hooks/stop/validate-purview-dlp-integration.js');
+
+function findingIds(result) {
+  return (result.findings || []).map(f => f.id);
+}
+
+// A minimal stand-in for the Purview guard: it is the only module that calls the
+// Graph processContent API, and it carries the PURVIEW_DLP_ENABLED marker.
+const NODE_GUARD = `
+// Microsoft Purview DLP guard. Reads PURVIEW_DLP_ENABLED.
+export const purviewGuard = {
+  isEnabled: process.env.PURVIEW_DLP_ENABLED === 'true',
+  isCheckOutput: true,
+  async evaluatePrompt() {
+    await fetch('https://graph.microsoft.com/beta/me/processContent', { method: 'POST' });
+    return { blocked: false, decision: 'allowed' };
+  },
+};
+`.trim();
+
+const PY_GUARD = `
+# Microsoft Purview DLP guard. Reads PURVIEW_DLP_ENABLED.
+class _Guard:
+    is_enabled = True
+    async def evaluate_prompt(self, *a):
+        # POST to Graph processContent
+        await _client.post("https://graph.microsoft.com/beta/me/processContent")
+        return type("V", (), {"blocked": False, "decision": "allowed"})()
+
+purview_guard = _Guard()  # PURVIEW_DLP_ENABLED gate
+`.trim();
+
+const CS_GUARD = `
+// Microsoft Purview DLP guard. Reads PURVIEW_DLP_ENABLED.
+namespace Agent365.Purview;
+public sealed class PurviewGuard {
+    public static readonly PurviewGuard Instance = new();
+    public bool IsEnabled => Environment.GetEnvironmentVariable("PURVIEW_DLP_ENABLED") == "true";
+    public async Task EvaluatePromptAsync() {
+        await _http.PostAsync("https://graph.microsoft.com/beta/me/processContent", null);
+    }
+}
+`.trim();
+
+describe('validate-purview-dlp-integration', () => {
+  test('always returns ok:true (report-first)', () => {
+    const dir = createFixture({ 'app.ts': 'export const x = 1;\n' });
+    try {
+      const result = runValidator(VALIDATOR, dir);
+      assert.equal(result.ok, true);
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  test('no Purview artifacts → no findings', () => {
+    const dir = createFixture({
+      'package.json': '{"name":"agent"}',
+      'agent.ts': 'export async function onMessage() { return "hi"; }\n',
+    });
+    try {
+      const result = runValidator(VALIDATOR, dir);
+      assert.equal(result.ok, true);
+      assert.equal(result.findingCount, 0);
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  test('Node.js guard wired + enabled → clean (no high/medium findings)', () => {
+    const dir = createFixture({
+      'package.json': '{"name":"agent","dependencies":{"@microsoft/agents-hosting":"1.0.0"}}',
+      'purview.ts': NODE_GUARD,
+      'agent.ts': `
+import { purviewGuard } from './purview.js';
+export async function onMessage(ctx) {
+  if (purviewGuard.isEnabled) {
+    const gate = await purviewGuard.evaluatePrompt(this.authorization, '', 'hi', ctx);
+    if (gate.blocked) return;
+  }
+  return 'ok';
+}
+      `.trim(),
+      '.env': 'PURVIEW_DLP_ENABLED=true\n',
+    });
+    try {
+      const result = runValidator(VALIDATOR, dir);
+      assert.equal(result.ok, true);
+      assert.ok(!findingIds(result).includes('purview-guard-not-wired'));
+      assert.ok(!findingIds(result).includes('purview-env-flag-missing'));
+      assert.equal(result.findingCount, 0);
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  test('Node.js guard copied but NOT wired → purview-guard-not-wired', () => {
+    const dir = createFixture({
+      'package.json': '{"name":"agent","dependencies":{"@microsoft/agents-hosting":"1.0.0"}}',
+      'purview.ts': NODE_GUARD,
+      '.env': 'PURVIEW_DLP_ENABLED=true\n',
+    });
+    try {
+      const result = runValidator(VALIDATOR, dir);
+      assert.equal(result.ok, true);
+      assert.ok(findingIds(result).includes('purview-guard-not-wired'));
+      assert.equal(
+        result.findings.find(f => f.id === 'purview-guard-not-wired').severity,
+        'high'
+      );
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  test('Python guard wired but env flag missing → purview-env-flag-missing', () => {
+    const dir = createFixture({
+      'requirements.txt': 'microsoft-agents-hosting-core\nhttpx\n',
+      'purview.py': PY_GUARD,
+      'agent.py': `
+from purview import purview_guard
+
+async def process_user_message(self, message, auth, auth_handler_name, context):
+    if purview_guard.is_enabled:
+        gate = await purview_guard.evaluate_prompt(auth, auth_handler_name, "", message, context)
+        if gate.blocked:
+            return "blocked"
+    return "ok"
+      `.trim(),
+    });
+    try {
+      const result = runValidator(VALIDATOR, dir);
+      assert.equal(result.ok, true);
+      assert.ok(findingIds(result).includes('purview-env-flag-missing'));
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  test('.NET guard wired, no .env → best-effort + dotnet env findings', () => {
+    const dir = createFixture({
+      'Agent.csproj': '<Project><ItemGroup><PackageReference Include="Microsoft.Agents.Hosting" /></ItemGroup></Project>',
+      'Purview.cs': CS_GUARD,
+      'Agent.cs': `
+using Agent365.Purview;
+public class MyAgent {
+    public async Task OnMessageAsync(ITurnContext turnContext) {
+        if (PurviewGuard.Instance.IsEnabled) {
+            var gate = await PurviewGuard.Instance.EvaluatePromptAsync();
+        }
+    }
+}
+      `.trim(),
+    });
+    try {
+      const result = runValidator(VALIDATOR, dir);
+      assert.equal(result.ok, true);
+      assert.ok(findingIds(result).includes('purview-env-flag-missing-dotnet'));
+      assert.ok(findingIds(result).includes('purview-dotnet-best-effort'));
+      assert.ok(!findingIds(result).includes('purview-guard-not-wired'));
+    } finally {
+      cleanup(dir);
+    }
+  });
+
+  test('DLP flag explicitly false → purview-dlp-disabled (low, non-blocking)', () => {
+    const dir = createFixture({
+      'package.json': '{"name":"agent"}',
+      'purview.ts': NODE_GUARD,
+      'agent.ts': `import { purviewGuard } from './purview.js';\nconst e = purviewGuard.isEnabled;\n`,
+      '.env': 'PURVIEW_DLP_ENABLED=false\n',
+    });
+    try {
+      const result = runValidator(VALIDATOR, dir);
+      assert.equal(result.ok, true);
+      assert.ok(findingIds(result).includes('purview-dlp-disabled'));
+    } finally {
+      cleanup(dir);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Adds `/agent365:purview-dlp-integration` to protect agent prompts and responses using Microsoft Purview DLP through Microsoft Graph `processContent`.

## Changes
- Add input and optional output guards for Node.js, Python, and .NET, with fail-closed defaults and configurable timeouts.
- Support autonomous S2S agents through a TypeScript guard using the agent identity’s FMI authentication chain.
- Include PowerShell scripts for permission grants and dedicated AI-app DLP policies.
- Provide configuration discovery, policy-selection guidance, verification, and troubleshooting documentation.
- Add an advisory stop-hook validator, eight unit tests, and evaluation scenarios.
- Update plugin metadata and skill discovery documentation.

## Validation
- `npm test`: **132 passed, zero failures**.
- Live-tenant integration was not tested during PR preparation.
- The .NET guard is a best-effort port requiring target-SDK verification.